### PR TITLE
feat(filters): Butterworth LP/HP bindings and IIRFilter scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@
 
 # Build
 build/
+build_*/
 
 # Python
 */__pycache__/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ nanobind_add_module(_core
   src/signal_bindings.cpp
   src/quantization_bindings.cpp
   src/spectral_bindings.cpp
+  src/filter_bindings.cpp
 )
 target_link_libraries(_core PRIVATE sw_dsp)
 

--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -23,6 +23,8 @@ try:
         max_absolute_error, max_relative_error,
         # Spectral
         fft, fft_magnitude_db, ifft, periodogram, psd, spectrogram,
+        # Filters
+        IIRFilter, butterworth_lowpass, butterworth_highpass,
         # Introspection
         available_dtypes,
     )

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -11,6 +11,7 @@ namespace nb = nanobind;
 void bind_signals(nb::module_& m);
 void bind_quantization(nb::module_& m);
 void bind_spectral(nb::module_& m);
+void bind_filters(nb::module_& m);
 
 NB_MODULE(_core, m) {
 	m.doc() = "mpdsp C++ core: mixed-precision DSP bindings via nanobind";
@@ -18,4 +19,5 @@ NB_MODULE(_core, m) {
 	bind_signals(m);
 	bind_quantization(m);
 	bind_spectral(m);
+	bind_filters(m);
 }

--- a/src/filter_bindings.cpp
+++ b/src/filter_bindings.cpp
@@ -1,0 +1,232 @@
+// filter_bindings.cpp: IIR filter bindings (Butterworth LP/HP to start)
+//
+// Exposes a PyIIRFilter class wrapping sw::dsp::Cascade<double, MaxStages>
+// and design functions that return instances of it. Processing is
+// type-dispatched: coefficients stay in double; state and sample scalars
+// vary per the dtype key (shared with quantization bindings).
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/complex.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
+
+#include <sw/dsp/filter/biquad/biquad.hpp>
+#include <sw/dsp/filter/biquad/cascade.hpp>
+#include <sw/dsp/filter/biquad/state.hpp>
+#include <sw/dsp/filter/iir/butterworth.hpp>
+
+#include "types.hpp"
+
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace nb = nanobind;
+
+// Upper bound on biquad stages exposed to Python. MaxOrder=16 gives up to
+// 8 LP/HP sections. Bandpass variants (future) double this; we'll revisit
+// when we add them.
+static constexpr int kMaxStages = 8;
+static constexpr int kMaxOrder  = kMaxStages * 2;
+
+using CascadeD = sw::dsp::Cascade<double, kMaxStages>;
+
+namespace {
+
+// Type-dispatched per-sample processing. Coefficients are in double;
+// state and sample arithmetic are parameterized.
+template <typename StateScalar, typename SampleScalar>
+static void process_typed(const CascadeD& cascade,
+                          const double* in, double* out, std::size_t n) {
+	std::array<sw::dsp::DirectFormI<StateScalar>, kMaxStages> state{};
+	for (std::size_t i = 0; i < n; ++i) {
+		SampleScalar x = static_cast<SampleScalar>(in[i]);
+		SampleScalar y = cascade.template process<sw::dsp::DirectFormI<StateScalar>,
+		                                          SampleScalar>(x, state);
+		out[i] = static_cast<double>(y);
+	}
+}
+
+static void process_dispatch(const CascadeD& cascade,
+                             const double* in, double* out, std::size_t n,
+                             mpdsp::ArithConfig config) {
+	using mpdsp::ArithConfig;
+	using mpdsp::cf24;
+	using mpdsp::half_;
+	switch (config) {
+	case ArithConfig::reference:
+		process_typed<double, double>(cascade, in, out, n); break;
+	case ArithConfig::gpu_baseline:
+		process_typed<float, float>(cascade, in, out, n); break;
+	case ArithConfig::ml_hw:
+		process_typed<float, half_>(cascade, in, out, n); break;
+	case ArithConfig::cf24_config:
+		process_typed<cf24, cf24>(cascade, in, out, n); break;
+	case ArithConfig::half_config:
+		process_typed<half_, half_>(cascade, in, out, n); break;
+	// Posit paths deferred until we confirm DspField conformance in a
+	// follow-up PR — reference/float/cfloat paths exercise the pattern.
+	case ArithConfig::posit_full:
+	case ArithConfig::tiny_posit:
+		throw std::invalid_argument(
+			"posit dtypes for filter.process are not yet enabled");
+	}
+}
+
+// NumPy helpers mirroring the pattern in quantization_bindings.cpp.
+using np_f64    = nb::ndarray<nb::numpy, double>;
+using np_f64_ro = nb::ndarray<nb::numpy, const double, nb::ndim<1>>;
+using np_c128   = nb::ndarray<nb::numpy, std::complex<double>>;
+using np_c128_ro = nb::ndarray<nb::numpy, const std::complex<double>, nb::ndim<1>>;
+
+static np_f64 make_f64_array(std::size_t n, double*& out_ptr) {
+	auto* data = new double[n];
+	out_ptr = data;
+	nb::capsule owner(data, [](void* p) noexcept { delete[] static_cast<double*>(p); });
+	std::size_t shape[1] = { n };
+	return np_f64(data, 1, shape, owner);
+}
+
+static np_c128 make_c128_array(std::size_t n, std::complex<double>*& out_ptr) {
+	auto* data = new std::complex<double>[n];
+	out_ptr = data;
+	nb::capsule owner(data, [](void* p) noexcept {
+		delete[] static_cast<std::complex<double>*>(p);
+	});
+	std::size_t shape[1] = { n };
+	return np_c128(data, 1, shape, owner);
+}
+
+} // namespace
+
+// PyIIRFilter: opaque handle wrapping a double-precision biquad cascade.
+// Python sees this as mpdsp.IIRFilter with process/frequency_response/etc.
+class PyIIRFilter {
+public:
+	CascadeD cascade;
+
+	int num_stages() const { return cascade.num_stages(); }
+
+	// Returns list of (b0, b1, b2, a1, a2) tuples — one per active stage.
+	std::vector<std::tuple<double, double, double, double, double>>
+	coefficients() const {
+		std::vector<std::tuple<double, double, double, double, double>> out;
+		out.reserve(static_cast<std::size_t>(cascade.num_stages()));
+		for (int i = 0; i < cascade.num_stages(); ++i) {
+			const auto& s = cascade.stage(i);
+			out.emplace_back(s.b0, s.b1, s.b2, s.a1, s.a2);
+		}
+		return out;
+	}
+
+	// Poles extracted per-stage via BiquadPoleState. Skips the spurious
+	// zero-valued "second" entry on first-order (odd-order trailing) sections.
+	std::vector<std::complex<double>> poles() const {
+		std::vector<std::complex<double>> out;
+		out.reserve(static_cast<std::size_t>(cascade.num_stages()) * 2);
+		for (int i = 0; i < cascade.num_stages(); ++i) {
+			sw::dsp::BiquadPoleState<double> pz(cascade.stage(i));
+			out.push_back(pz.poles.first);
+			const auto& second = pz.poles.second;
+			if (second != std::complex<double>{}) {
+				out.push_back(second);
+			}
+		}
+		return out;
+	}
+
+	np_f64 process(np_f64_ro signal, const std::string& dtype) const {
+		std::size_t n = signal.shape(0);
+		double* out_ptr = nullptr;
+		auto arr = make_f64_array(n, out_ptr);
+		auto config = mpdsp::parse_config(dtype);
+		process_dispatch(cascade, signal.data(), out_ptr, n, config);
+		return arr;
+	}
+
+	np_c128 frequency_response(np_f64_ro normalized_freqs) const {
+		std::size_t n = normalized_freqs.shape(0);
+		std::complex<double>* out_ptr = nullptr;
+		auto arr = make_c128_array(n, out_ptr);
+		const double* f = normalized_freqs.data();
+		for (std::size_t i = 0; i < n; ++i) {
+			out_ptr[i] = cascade.response(f[i]);
+		}
+		return arr;
+	}
+};
+
+void bind_filters(nb::module_& m) {
+	nb::class_<PyIIRFilter>(m, "IIRFilter",
+		"Cascade-of-biquads IIR filter.\n\n"
+		"Construct via one of the design functions "
+		"(e.g. butterworth_lowpass). Coefficients are stored in "
+		"double precision; process() dispatches state/sample arithmetic "
+		"on the dtype argument.")
+		.def("num_stages", &PyIIRFilter::num_stages,
+		     "Number of active biquad sections.")
+		.def("coefficients", &PyIIRFilter::coefficients,
+		     "List of (b0, b1, b2, a1, a2) tuples, one per stage.")
+		.def("poles", &PyIIRFilter::poles,
+		     "List of complex pole locations in the z-plane.")
+		.def("process", &PyIIRFilter::process,
+		     nb::arg("signal"), nb::arg("dtype") = "reference",
+		     "Filter a signal. dtype selects arithmetic for state and samples "
+		     "(see available_dtypes()). Returns NumPy float64.")
+		.def("frequency_response", &PyIIRFilter::frequency_response,
+		     nb::arg("normalized_freqs"),
+		     "Evaluate H(e^{j2*pi*f}) at each normalized frequency (f/fs). "
+		     "Input and output are 1D NumPy arrays; returns complex128.");
+
+	m.def("butterworth_lowpass",
+		[](int order, double sample_rate, double cutoff) {
+			if (order < 1 || order > kMaxOrder) {
+				throw std::invalid_argument(
+					"butterworth_lowpass: order must be in [1, 16]");
+			}
+			if (!(sample_rate > 0.0)) {
+				throw std::invalid_argument(
+					"butterworth_lowpass: sample_rate must be positive");
+			}
+			if (!(cutoff > 0.0) || cutoff >= 0.5 * sample_rate) {
+				throw std::invalid_argument(
+					"butterworth_lowpass: cutoff must be in (0, sample_rate/2)");
+			}
+			sw::dsp::iir::ButterworthLowPass<kMaxOrder> design;
+			design.setup(order, sample_rate, cutoff);
+			PyIIRFilter filt;
+			filt.cascade = design.cascade();
+			return filt;
+		},
+		nb::arg("order"), nb::arg("sample_rate"), nb::arg("cutoff"),
+		"Design a Butterworth lowpass filter. "
+		"order in [1, 16]; cutoff in Hz, must be < sample_rate/2.");
+
+	m.def("butterworth_highpass",
+		[](int order, double sample_rate, double cutoff) {
+			if (order < 1 || order > kMaxOrder) {
+				throw std::invalid_argument(
+					"butterworth_highpass: order must be in [1, 16]");
+			}
+			if (!(sample_rate > 0.0)) {
+				throw std::invalid_argument(
+					"butterworth_highpass: sample_rate must be positive");
+			}
+			if (!(cutoff > 0.0) || cutoff >= 0.5 * sample_rate) {
+				throw std::invalid_argument(
+					"butterworth_highpass: cutoff must be in (0, sample_rate/2)");
+			}
+			sw::dsp::iir::ButterworthHighPass<kMaxOrder> design;
+			design.setup(order, sample_rate, cutoff);
+			PyIIRFilter filt;
+			filt.cascade = design.cascade();
+			return filt;
+		},
+		nb::arg("order"), nb::arg("sample_rate"), nb::arg("cutoff"),
+		"Design a Butterworth highpass filter. "
+		"order in [1, 16]; cutoff in Hz, must be < sample_rate/2.");
+}

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,129 @@
+"""Tests for IIR filter bindings (Butterworth LP/HP)."""
+
+import numpy as np
+import pytest
+
+mpdsp = pytest.importorskip("mpdsp", reason="mpdsp C++ module not built")
+if not mpdsp.HAS_CORE:
+    pytest.skip("mpdsp._core not available", allow_module_level=True)
+
+
+SAMPLE_RATE = 8000.0
+
+
+class TestButterworthDesign:
+    def test_lowpass_returns_filter_with_stages(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        assert isinstance(filt, mpdsp.IIRFilter)
+        assert filt.num_stages() == 2  # order 4 -> 2 biquads
+
+    def test_highpass_returns_filter_with_stages(self):
+        filt = mpdsp.butterworth_highpass(order=6, sample_rate=SAMPLE_RATE, cutoff=500.0)
+        assert filt.num_stages() == 3  # order 6 -> 3 biquads
+
+    def test_odd_order_has_single_first_order_section(self):
+        filt = mpdsp.butterworth_lowpass(order=5, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        assert filt.num_stages() == 3  # ceil(5/2) = 3 sections
+
+    def test_coefficients_shape(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        coeffs = filt.coefficients()
+        assert len(coeffs) == 2
+        for stage in coeffs:
+            assert len(stage) == 5  # (b0, b1, b2, a1, a2)
+
+    def test_poles_count_matches_order(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        poles = filt.poles()
+        assert len(poles) == 4
+        # All poles must be inside the unit circle for a stable filter
+        for p in poles:
+            assert abs(p) < 1.0
+
+    def test_invalid_order_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.butterworth_lowpass(order=0, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        with pytest.raises(ValueError):
+            mpdsp.butterworth_lowpass(order=17, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+
+    def test_cutoff_above_nyquist_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=5000.0)
+
+
+class TestFrequencyResponse:
+    def test_response_shape_and_dtype(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        freqs = np.linspace(0.0, 0.5, 64)
+        h = filt.frequency_response(freqs)
+        assert h.shape == (64,)
+        assert h.dtype == np.complex128
+
+    def test_lowpass_dc_passes_stopband_attenuates(self):
+        filt = mpdsp.butterworth_lowpass(order=6, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        # normalized: DC -> 0.0; nyquist -> 0.5; cutoff at 1000/8000 = 0.125
+        freqs = np.array([0.0, 0.125, 0.4])
+        mag = np.abs(filt.frequency_response(freqs))
+        # DC gain ~ 1.0
+        assert abs(mag[0] - 1.0) < 1e-6
+        # Butterworth is -3 dB at the cutoff (magnitude ~ 1/sqrt(2))
+        assert abs(mag[1] - 1.0 / np.sqrt(2.0)) < 0.05
+        # Deep stopband heavily attenuated
+        assert mag[2] < 0.01
+
+    def test_highpass_dc_rejects(self):
+        filt = mpdsp.butterworth_highpass(order=6, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        freqs = np.array([0.0, 0.125, 0.4])
+        mag = np.abs(filt.frequency_response(freqs))
+        assert mag[0] < 0.01
+        # passband at high freq approaches 1.0
+        assert abs(mag[2] - 1.0) < 0.1
+
+
+class TestProcessing:
+    def _sine(self, freq, n=4096):
+        t = np.arange(n) / SAMPLE_RATE
+        return np.sin(2.0 * np.pi * freq * t)
+
+    def test_process_shape_preserved(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        sig = self._sine(200.0)
+        y = filt.process(sig)
+        assert y.shape == sig.shape
+        assert y.dtype == np.float64
+
+    def test_lowpass_passes_low_rejects_high(self):
+        filt = mpdsp.butterworth_lowpass(order=6, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        low = self._sine(200.0)
+        high = self._sine(3000.0)
+        # Skip transient so steady-state amplitude is meaningful.
+        skip = 512
+        y_low = filt.process(low)[skip:]
+        y_high = filt.process(high)[skip:]
+        # Passband amplitude close to 1; stopband amplitude heavily attenuated.
+        assert np.max(np.abs(y_low)) > 0.9
+        assert np.max(np.abs(y_high)) < 0.1
+
+    def test_dtype_reference_matches_double(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        sig = self._sine(300.0)
+        a = filt.process(sig, dtype="reference")
+        b = filt.process(sig, dtype="double")
+        np.testing.assert_array_equal(a, b)
+
+    def test_dtype_dispatch_differs_from_reference(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        sig = self._sine(300.0)
+        ref = filt.process(sig, dtype="reference")
+        low = filt.process(sig, dtype="half")
+        # Reduced-precision arithmetic should introduce measurable error.
+        assert not np.array_equal(ref, low)
+        # But the output should still be close — within ~1% of reference.
+        err = np.max(np.abs(ref - low)) / (np.max(np.abs(ref)) + 1e-12)
+        assert err < 0.05
+
+    def test_unknown_dtype_raises(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        sig = self._sine(300.0)
+        with pytest.raises(Exception):
+            filt.process(sig, dtype="not_a_real_dtype")


### PR DESCRIPTION
## Summary
- First slice of Phase 4 (issue #5): establishes the `PyIIRFilter` binding pattern with Butterworth lowpass/highpass. Intentionally small so the shape of the Python-facing filter object can be reviewed before replicating it across the other 5 IIR families, the RBJ variants, and FIR.
- Coefficients stay in `double` (per the peer library's design guide); `process(signal, dtype=...)` dispatches state/sample arithmetic on the same dtype keys already used by the quantization bindings (`reference`, `gpu_baseline`, `ml_hw`, `cf24`, `half`).
- Elliptic remains blocked on upstream `stillwater-sc/mixed-precision-dsp#50`; posit paths are deferred pending DspField conformance confirmation.

## Changes
- `src/filter_bindings.cpp` (new) — `PyIIRFilter` class (`process`, `frequency_response`, `poles`, `coefficients`, `num_stages`) and `butterworth_lowpass` / `butterworth_highpass` design functions.
- `src/bindings.cpp` — forward-declare and call `bind_filters`.
- `CMakeLists.txt` — add `src/filter_bindings.cpp` to `_core`.
- `python/mpdsp/__init__.py` — re-export `IIRFilter`, `butterworth_lowpass`, `butterworth_highpass`.
- `tests/test_filters.py` (new) — 15 tests covering design validation, frequency response (DC, -3 dB at cutoff, stopband), processing (shape, passband/stopband amplitude, reference vs. half dispatch).
- `.gitignore` — ignore `build_*/` trees from out-of-source builds.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| `_core` | OK | 15/15 filter, 65/65 suite | OK | 15/15 filter, 65/65 suite |

## Follow-up work (not in this PR)
- Chebyshev I/II, Bessel, Legendre, RBJ design functions using the same `PyIIRFilter` wrapper.
- BandPass / BandStop variants (cascade size doubles — will revisit `kMaxStages`).
- `PyFIRFilter` wrapping `sw::dsp::FIRFilter<double, StateScalar, SampleScalar>` plus window-method design helpers.
- Python helpers (`python/mpdsp/filters.py`: `compare_filters`, `plot_filter_comparison`) and notebooks `02_iir_precision.ipynb`, `03_fir_and_windows.ipynb`.
- Enable posit dtypes for `filter.process` once `DspField` conformance is verified.
- Extended diagnostic methods from the issue (`stability_margin`, `condition_number`, `worst_case_sensitivity`, `pole_displacement`).

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Review the binding pattern before replicating across remaining families

Relates to #5

Generated with [Claude Code](https://claude.com/claude-code)