### PR TITLE
feat(filters): Chebyshev I/II, Bessel, Legendre, Elliptic, RBJ + BP/BS for all families

### DIFF
--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -24,7 +24,20 @@ try:
         # Spectral
         fft, fft_magnitude_db, ifft, periodogram, psd, spectrogram,
         # Filters
-        IIRFilter, butterworth_lowpass, butterworth_highpass,
+        IIRFilter,
+        butterworth_lowpass, butterworth_highpass,
+        butterworth_bandpass, butterworth_bandstop,
+        chebyshev1_lowpass, chebyshev1_highpass,
+        chebyshev1_bandpass, chebyshev1_bandstop,
+        chebyshev2_lowpass, chebyshev2_highpass,
+        chebyshev2_bandpass, chebyshev2_bandstop,
+        bessel_lowpass, bessel_highpass,
+        bessel_bandpass, bessel_bandstop,
+        legendre_lowpass, legendre_highpass,
+        legendre_bandpass, legendre_bandstop,
+        rbj_lowpass, rbj_highpass,
+        rbj_bandpass, rbj_bandstop,
+        rbj_allpass, rbj_lowshelf, rbj_highshelf,
         # Introspection
         available_dtypes,
     )

--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -35,6 +35,8 @@ try:
         bessel_bandpass, bessel_bandstop,
         legendre_lowpass, legendre_highpass,
         legendre_bandpass, legendre_bandstop,
+        elliptic_lowpass, elliptic_highpass,
+        elliptic_bandpass, elliptic_bandstop,
         rbj_lowpass, rbj_highpass,
         rbj_bandpass, rbj_bandstop,
         rbj_allpass, rbj_lowshelf, rbj_highshelf,

--- a/src/filter_bindings.cpp
+++ b/src/filter_bindings.cpp
@@ -1,9 +1,14 @@
-// filter_bindings.cpp: IIR filter bindings (Butterworth LP/HP to start)
+// filter_bindings.cpp: IIR filter bindings
 //
 // Exposes a PyIIRFilter class wrapping sw::dsp::Cascade<double, MaxStages>
 // and design functions that return instances of it. Processing is
 // type-dispatched: coefficients stay in double; state and sample scalars
 // vary per the dtype key (shared with quantization bindings).
+//
+// Families covered:
+//   - Butterworth, Chebyshev I/II, Bessel, Legendre: LP/HP/BP/BS
+//   - RBJ: LP/HP/BP/BS/allpass/lowshelf/highshelf (single biquad each)
+// Elliptic is deferred — upstream dsp#50 (NaN bug).
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -15,7 +20,12 @@
 #include <sw/dsp/filter/biquad/biquad.hpp>
 #include <sw/dsp/filter/biquad/cascade.hpp>
 #include <sw/dsp/filter/biquad/state.hpp>
+#include <sw/dsp/filter/iir/bessel.hpp>
 #include <sw/dsp/filter/iir/butterworth.hpp>
+#include <sw/dsp/filter/iir/chebyshev1.hpp>
+#include <sw/dsp/filter/iir/chebyshev2.hpp>
+#include <sw/dsp/filter/iir/legendre.hpp>
+#include <sw/dsp/filter/iir/rbj.hpp>
 
 #include "types.hpp"
 
@@ -23,22 +33,27 @@
 #include <complex>
 #include <cstddef>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace nb = nanobind;
 
-// Upper bound on biquad stages exposed to Python. MaxOrder=16 gives up to
-// 8 LP/HP sections. Bandpass variants (future) double this; we'll revisit
-// when we add them.
-static constexpr int kMaxStages = 8;
-static constexpr int kMaxOrder  = kMaxStages * 2;
+// Max biquad stages exposed to Python. For Butterworth/Cheby/Bessel/Legendre:
+//  - LP/HP templates instantiated with MaxOrder=16 → max_stages = 8
+//  - BP/BS templates instantiated with MaxOrder=8  → max_stages = 8 (order doubles)
+// All design cascades therefore share type Cascade<double, 8>.
+static constexpr int kMaxStages    = 8;
+static constexpr int kMaxOrderLPHP = 16;
+static constexpr int kMaxOrderBPBS = 8;
 
 using CascadeD = sw::dsp::Cascade<double, kMaxStages>;
 
 namespace {
 
-// Type-dispatched per-sample processing. Coefficients are in double;
-// state and sample arithmetic are parameterized.
+// ---------------------------------------------------------------------------
+// Type-dispatched per-sample processing.
+// ---------------------------------------------------------------------------
+
 template <typename StateScalar, typename SampleScalar>
 static void process_typed(const CascadeD& cascade,
                           const double* in, double* out, std::size_t n) {
@@ -68,8 +83,6 @@ static void process_dispatch(const CascadeD& cascade,
 		process_typed<cf24, cf24>(cascade, in, out, n); break;
 	case ArithConfig::half_config:
 		process_typed<half_, half_>(cascade, in, out, n); break;
-	// Posit paths deferred until we confirm DspField conformance in a
-	// follow-up PR — reference/float/cfloat paths exercise the pattern.
 	case ArithConfig::posit_full:
 	case ArithConfig::tiny_posit:
 		throw std::invalid_argument(
@@ -77,11 +90,13 @@ static void process_dispatch(const CascadeD& cascade,
 	}
 }
 
-// NumPy helpers mirroring the pattern in quantization_bindings.cpp.
-using np_f64    = nb::ndarray<nb::numpy, double>;
-using np_f64_ro = nb::ndarray<nb::numpy, const double, nb::ndim<1>>;
-using np_c128   = nb::ndarray<nb::numpy, std::complex<double>>;
-using np_c128_ro = nb::ndarray<nb::numpy, const std::complex<double>, nb::ndim<1>>;
+// ---------------------------------------------------------------------------
+// NumPy helpers.
+// ---------------------------------------------------------------------------
+
+using np_f64     = nb::ndarray<nb::numpy, double>;
+using np_f64_ro  = nb::ndarray<nb::numpy, const double, nb::ndim<1>>;
+using np_c128    = nb::ndarray<nb::numpy, std::complex<double>>;
 
 static np_f64 make_f64_array(std::size_t n, double*& out_ptr) {
 	auto* data = new double[n];
@@ -101,17 +116,64 @@ static np_c128 make_c128_array(std::size_t n, std::complex<double>*& out_ptr) {
 	return np_c128(data, 1, shape, owner);
 }
 
+// ---------------------------------------------------------------------------
+// Shared parameter validation.
+// ---------------------------------------------------------------------------
+
+static void check_sample_rate(double sr, const char* name) {
+	if (!(sr > 0.0)) {
+		throw std::invalid_argument(std::string(name) +
+			": sample_rate must be positive");
+	}
+}
+
+static void check_frequency(double f, double sr, const char* name,
+                            const char* freq_name) {
+	if (!(f > 0.0) || f >= 0.5 * sr) {
+		throw std::invalid_argument(std::string(name) + ": " + freq_name +
+			" must be in (0, sample_rate/2)");
+	}
+}
+
+static void check_order(int order, int max_order, const char* name) {
+	if (order < 1 || order > max_order) {
+		throw std::invalid_argument(std::string(name) +
+			": order must be in [1, " + std::to_string(max_order) + "]");
+	}
+}
+
+static void check_positive(double v, const char* name, const char* field) {
+	if (!(v > 0.0)) {
+		throw std::invalid_argument(std::string(name) + ": " + field +
+			" must be positive");
+	}
+}
+
+static void check_bp_band(double center, double width, double sr,
+                          const char* name) {
+	if (!(center > 0.0) || !(width > 0.0)) {
+		throw std::invalid_argument(std::string(name) +
+			": center_freq and width_freq must be positive");
+	}
+	double half = 0.5 * width;
+	if (center - half <= 0.0 || center + half >= 0.5 * sr) {
+		throw std::invalid_argument(std::string(name) +
+			": passband [center - width/2, center + width/2] must fit within (0, sample_rate/2)");
+	}
+}
+
 } // namespace
 
+// ---------------------------------------------------------------------------
 // PyIIRFilter: opaque handle wrapping a double-precision biquad cascade.
-// Python sees this as mpdsp.IIRFilter with process/frequency_response/etc.
+// ---------------------------------------------------------------------------
+
 class PyIIRFilter {
 public:
 	CascadeD cascade;
 
 	int num_stages() const { return cascade.num_stages(); }
 
-	// Returns list of (b0, b1, b2, a1, a2) tuples — one per active stage.
 	std::vector<std::tuple<double, double, double, double, double>>
 	coefficients() const {
 		std::vector<std::tuple<double, double, double, double, double>> out;
@@ -123,8 +185,6 @@ public:
 		return out;
 	}
 
-	// Poles extracted per-stage via BiquadPoleState. Skips the spurious
-	// zero-valued "second" entry on first-order (odd-order trailing) sections.
 	std::vector<std::complex<double>> poles() const {
 		std::vector<std::complex<double>> out;
 		out.reserve(static_cast<std::size_t>(cascade.num_stages()) * 2);
@@ -160,12 +220,47 @@ public:
 	}
 };
 
+namespace {
+
+// ---------------------------------------------------------------------------
+// Design factories. DesignT is a class with .setup(...) and .cascade().
+// For LP/HP: DesignT instantiated with MaxOrder = kMaxOrderLPHP (16).
+// For BP/BS: DesignT instantiated with MaxOrder = kMaxOrderBPBS (8).
+// Both produce Cascade<double, kMaxStages = 8>.
+// ---------------------------------------------------------------------------
+
+template <typename DesignT, typename... SetupArgs>
+static PyIIRFilter make_from_design(int order, SetupArgs... args) {
+	DesignT design;
+	design.setup(order, args...);
+	PyIIRFilter filt;
+	filt.cascade = design.cascade();
+	return filt;
+}
+
+// RBJ designs have no 'order' and their cascade is size-1. Copy the single
+// biquad into stage 0 of our size-kMaxStages cascade.
+template <typename DesignT, typename... SetupArgs>
+static PyIIRFilter make_from_rbj(SetupArgs... args) {
+	DesignT design;
+	design.setup(args...);
+	PyIIRFilter filt;
+	filt.cascade.set_num_stages(1);
+	filt.cascade.stage(0) = design.cascade().stage(0);
+	return filt;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Module registration.
+// ---------------------------------------------------------------------------
+
 void bind_filters(nb::module_& m) {
 	nb::class_<PyIIRFilter>(m, "IIRFilter",
 		"Cascade-of-biquads IIR filter.\n\n"
-		"Construct via one of the design functions "
-		"(e.g. butterworth_lowpass). Coefficients are stored in "
-		"double precision; process() dispatches state/sample arithmetic "
+		"Construct via one of the design functions. Coefficients are stored "
+		"in double precision; process() dispatches state/sample arithmetic "
 		"on the dtype argument.")
 		.def("num_stages", &PyIIRFilter::num_stages,
 		     "Number of active biquad sections.")
@@ -180,53 +275,318 @@ void bind_filters(nb::module_& m) {
 		.def("frequency_response", &PyIIRFilter::frequency_response,
 		     nb::arg("normalized_freqs"),
 		     "Evaluate H(e^{j2*pi*f}) at each normalized frequency (f/fs). "
-		     "Input and output are 1D NumPy arrays; returns complex128.");
+		     "Returns complex128.");
+
+	namespace iir = sw::dsp::iir;
+	namespace rbj = sw::dsp::iir::rbj;
+
+	// Common argument names for the LP/HP/BP/BS registration blocks below.
+	constexpr const char* A_ORDER = "order";
+	constexpr const char* A_SR    = "sample_rate";
+	constexpr const char* A_CUT   = "cutoff";
+	constexpr const char* A_CTR   = "center_freq";
+	constexpr const char* A_WID   = "width_freq";
+
+	// =======================================================================
+	// Butterworth — no extra parameters.
+	// =======================================================================
 
 	m.def("butterworth_lowpass",
-		[](int order, double sample_rate, double cutoff) {
-			if (order < 1 || order > kMaxOrder) {
-				throw std::invalid_argument(
-					"butterworth_lowpass: order must be in [1, 16]");
-			}
-			if (!(sample_rate > 0.0)) {
-				throw std::invalid_argument(
-					"butterworth_lowpass: sample_rate must be positive");
-			}
-			if (!(cutoff > 0.0) || cutoff >= 0.5 * sample_rate) {
-				throw std::invalid_argument(
-					"butterworth_lowpass: cutoff must be in (0, sample_rate/2)");
-			}
-			sw::dsp::iir::ButterworthLowPass<kMaxOrder> design;
-			design.setup(order, sample_rate, cutoff);
-			PyIIRFilter filt;
-			filt.cascade = design.cascade();
-			return filt;
-		},
-		nb::arg("order"), nb::arg("sample_rate"), nb::arg("cutoff"),
-		"Design a Butterworth lowpass filter. "
-		"order in [1, 16]; cutoff in Hz, must be < sample_rate/2.");
+		[](int order, double sr, double cutoff) {
+			const char* n = "butterworth_lowpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			return make_from_design<iir::ButterworthLowPass<kMaxOrderLPHP>>(
+				order, sr, cutoff);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT),
+		"Design a Butterworth lowpass filter. order in [1, 16].");
 
 	m.def("butterworth_highpass",
-		[](int order, double sample_rate, double cutoff) {
-			if (order < 1 || order > kMaxOrder) {
-				throw std::invalid_argument(
-					"butterworth_highpass: order must be in [1, 16]");
-			}
-			if (!(sample_rate > 0.0)) {
-				throw std::invalid_argument(
-					"butterworth_highpass: sample_rate must be positive");
-			}
-			if (!(cutoff > 0.0) || cutoff >= 0.5 * sample_rate) {
-				throw std::invalid_argument(
-					"butterworth_highpass: cutoff must be in (0, sample_rate/2)");
-			}
-			sw::dsp::iir::ButterworthHighPass<kMaxOrder> design;
-			design.setup(order, sample_rate, cutoff);
-			PyIIRFilter filt;
-			filt.cascade = design.cascade();
-			return filt;
-		},
-		nb::arg("order"), nb::arg("sample_rate"), nb::arg("cutoff"),
-		"Design a Butterworth highpass filter. "
-		"order in [1, 16]; cutoff in Hz, must be < sample_rate/2.");
+		[](int order, double sr, double cutoff) {
+			const char* n = "butterworth_highpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			return make_from_design<iir::ButterworthHighPass<kMaxOrderLPHP>>(
+				order, sr, cutoff);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT),
+		"Design a Butterworth highpass filter. order in [1, 16].");
+
+	m.def("butterworth_bandpass",
+		[](int order, double sr, double center_freq, double width_freq) {
+			const char* n = "butterworth_bandpass";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			return make_from_design<iir::ButterworthBandPass<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		"Design a Butterworth bandpass filter. order in [1, 8] "
+		"(the bandpass transform doubles the internal order).");
+
+	m.def("butterworth_bandstop",
+		[](int order, double sr, double center_freq, double width_freq) {
+			const char* n = "butterworth_bandstop";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			return make_from_design<iir::ButterworthBandStop<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		"Design a Butterworth bandstop filter. order in [1, 8].");
+
+	// =======================================================================
+	// Chebyshev I — equiripple passband, extra ripple_db parameter.
+	// =======================================================================
+
+	m.def("chebyshev1_lowpass",
+		[](int order, double sr, double cutoff, double ripple_db) {
+			const char* n = "chebyshev1_lowpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			check_positive(ripple_db, n, "ripple_db");
+			return make_from_design<iir::ChebyshevILowPass<kMaxOrderLPHP>>(
+				order, sr, cutoff, ripple_db);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT), nb::arg("ripple_db"),
+		"Design a Chebyshev Type I lowpass filter with equiripple passband.");
+
+	m.def("chebyshev1_highpass",
+		[](int order, double sr, double cutoff, double ripple_db) {
+			const char* n = "chebyshev1_highpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			check_positive(ripple_db, n, "ripple_db");
+			return make_from_design<iir::ChebyshevIHighPass<kMaxOrderLPHP>>(
+				order, sr, cutoff, ripple_db);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT), nb::arg("ripple_db"),
+		"Design a Chebyshev Type I highpass filter with equiripple passband.");
+
+	m.def("chebyshev1_bandpass",
+		[](int order, double sr, double center_freq, double width_freq, double ripple_db) {
+			const char* n = "chebyshev1_bandpass";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			check_positive(ripple_db, n, "ripple_db");
+			return make_from_design<iir::ChebyshevIBandPass<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq, ripple_db);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		   nb::arg("ripple_db"),
+		"Design a Chebyshev Type I bandpass filter.");
+
+	m.def("chebyshev1_bandstop",
+		[](int order, double sr, double center_freq, double width_freq, double ripple_db) {
+			const char* n = "chebyshev1_bandstop";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			check_positive(ripple_db, n, "ripple_db");
+			return make_from_design<iir::ChebyshevIBandStop<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq, ripple_db);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		   nb::arg("ripple_db"),
+		"Design a Chebyshev Type I bandstop filter.");
+
+	// =======================================================================
+	// Chebyshev II — monotonic passband, equiripple stopband, stopband_db param.
+	// =======================================================================
+
+	m.def("chebyshev2_lowpass",
+		[](int order, double sr, double cutoff, double stopband_db) {
+			const char* n = "chebyshev2_lowpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			check_positive(stopband_db, n, "stopband_db");
+			return make_from_design<iir::ChebyshevIILowPass<kMaxOrderLPHP>>(
+				order, sr, cutoff, stopband_db);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT), nb::arg("stopband_db"),
+		"Design an inverse Chebyshev (Type II) lowpass filter with "
+		"equiripple stopband.");
+
+	m.def("chebyshev2_highpass",
+		[](int order, double sr, double cutoff, double stopband_db) {
+			const char* n = "chebyshev2_highpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			check_positive(stopband_db, n, "stopband_db");
+			return make_from_design<iir::ChebyshevIIHighPass<kMaxOrderLPHP>>(
+				order, sr, cutoff, stopband_db);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT), nb::arg("stopband_db"),
+		"Design an inverse Chebyshev (Type II) highpass filter.");
+
+	m.def("chebyshev2_bandpass",
+		[](int order, double sr, double center_freq, double width_freq, double stopband_db) {
+			const char* n = "chebyshev2_bandpass";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			check_positive(stopband_db, n, "stopband_db");
+			return make_from_design<iir::ChebyshevIIBandPass<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq, stopband_db);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		   nb::arg("stopband_db"),
+		"Design an inverse Chebyshev (Type II) bandpass filter.");
+
+	m.def("chebyshev2_bandstop",
+		[](int order, double sr, double center_freq, double width_freq, double stopband_db) {
+			const char* n = "chebyshev2_bandstop";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			check_positive(stopband_db, n, "stopband_db");
+			return make_from_design<iir::ChebyshevIIBandStop<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq, stopband_db);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		   nb::arg("stopband_db"),
+		"Design an inverse Chebyshev (Type II) bandstop filter.");
+
+	// =======================================================================
+	// Bessel — maximally flat group delay. Same signatures as Butterworth.
+	// =======================================================================
+
+	m.def("bessel_lowpass",
+		[](int order, double sr, double cutoff) {
+			const char* n = "bessel_lowpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			return make_from_design<iir::BesselLowPass<kMaxOrderLPHP>>(
+				order, sr, cutoff);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT),
+		"Design a Bessel (Thomson) lowpass filter — maximally flat group delay.");
+
+	m.def("bessel_highpass",
+		[](int order, double sr, double cutoff) {
+			const char* n = "bessel_highpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			return make_from_design<iir::BesselHighPass<kMaxOrderLPHP>>(
+				order, sr, cutoff);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT),
+		"Design a Bessel highpass filter.");
+
+	m.def("bessel_bandpass",
+		[](int order, double sr, double center_freq, double width_freq) {
+			const char* n = "bessel_bandpass";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			return make_from_design<iir::BesselBandPass<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		"Design a Bessel bandpass filter.");
+
+	m.def("bessel_bandstop",
+		[](int order, double sr, double center_freq, double width_freq) {
+			const char* n = "bessel_bandstop";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			return make_from_design<iir::BesselBandStop<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		"Design a Bessel bandstop filter.");
+
+	// =======================================================================
+	// Legendre — steepest monotonic transition. Same signatures as Butterworth.
+	// =======================================================================
+
+	m.def("legendre_lowpass",
+		[](int order, double sr, double cutoff) {
+			const char* n = "legendre_lowpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			return make_from_design<iir::LegendreLowPass<kMaxOrderLPHP>>(
+				order, sr, cutoff);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT),
+		"Design a Legendre (Papoulis) lowpass filter — steepest monotonic "
+		"passband response.");
+
+	m.def("legendre_highpass",
+		[](int order, double sr, double cutoff) {
+			const char* n = "legendre_highpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			return make_from_design<iir::LegendreHighPass<kMaxOrderLPHP>>(
+				order, sr, cutoff);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT),
+		"Design a Legendre highpass filter.");
+
+	m.def("legendre_bandpass",
+		[](int order, double sr, double center_freq, double width_freq) {
+			const char* n = "legendre_bandpass";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			return make_from_design<iir::LegendreBandPass<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		"Design a Legendre bandpass filter.");
+
+	m.def("legendre_bandstop",
+		[](int order, double sr, double center_freq, double width_freq) {
+			const char* n = "legendre_bandstop";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			return make_from_design<iir::LegendreBandStop<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		"Design a Legendre bandstop filter.");
+
+	// =======================================================================
+	// RBJ Audio EQ Cookbook — single biquad per variant, no 'order' parameter.
+	// =======================================================================
+
+	m.def("rbj_lowpass",
+		[](double sr, double cutoff, double q) {
+			return make_from_rbj<rbj::LowPass<>>(sr, cutoff, q);
+		}, nb::arg(A_SR), nb::arg(A_CUT), nb::arg("q") = 0.7071,
+		"RBJ biquad lowpass. q ~ 0.7071 gives a Butterworth-like response.");
+
+	m.def("rbj_highpass",
+		[](double sr, double cutoff, double q) {
+			return make_from_rbj<rbj::HighPass<>>(sr, cutoff, q);
+		}, nb::arg(A_SR), nb::arg(A_CUT), nb::arg("q") = 0.7071,
+		"RBJ biquad highpass.");
+
+	m.def("rbj_bandpass",
+		[](double sr, double center_freq, double bandwidth) {
+			return make_from_rbj<rbj::BandPass<>>(sr, center_freq, bandwidth);
+		}, nb::arg(A_SR), nb::arg(A_CTR), nb::arg("bandwidth") = 1.0,
+		"RBJ biquad bandpass. bandwidth is in octaves.");
+
+	m.def("rbj_bandstop",
+		[](double sr, double center_freq, double bandwidth) {
+			return make_from_rbj<rbj::BandStop<>>(sr, center_freq, bandwidth);
+		}, nb::arg(A_SR), nb::arg(A_CTR), nb::arg("bandwidth") = 1.0,
+		"RBJ biquad bandstop (notch). bandwidth is in octaves.");
+
+	m.def("rbj_allpass",
+		[](double sr, double center_freq, double q) {
+			return make_from_rbj<rbj::AllPass<>>(sr, center_freq, q);
+		}, nb::arg(A_SR), nb::arg(A_CTR), nb::arg("q") = 0.7071,
+		"RBJ biquad allpass — unit magnitude, phase shift only.");
+
+	m.def("rbj_lowshelf",
+		[](double sr, double cutoff, double gain_db, double slope) {
+			return make_from_rbj<rbj::LowShelf<>>(sr, cutoff, gain_db, slope);
+		}, nb::arg(A_SR), nb::arg(A_CUT), nb::arg("gain_db"),
+		   nb::arg("slope") = 1.0,
+		"RBJ biquad low shelf. gain_db is the low-frequency shelf gain.");
+
+	m.def("rbj_highshelf",
+		[](double sr, double cutoff, double gain_db, double slope) {
+			return make_from_rbj<rbj::HighShelf<>>(sr, cutoff, gain_db, slope);
+		}, nb::arg(A_SR), nb::arg(A_CUT), nb::arg("gain_db"),
+		   nb::arg("slope") = 1.0,
+		"RBJ biquad high shelf. gain_db is the high-frequency shelf gain.");
 }

--- a/src/filter_bindings.cpp
+++ b/src/filter_bindings.cpp
@@ -606,36 +606,62 @@ void bind_filters(nb::module_& m) {
 
 	m.def("rbj_lowpass",
 		[](double sr, double cutoff, double q) {
+			const char* n = "rbj_lowpass";
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			check_positive(q, n, "q");
 			return make_from_rbj<rbj::LowPass<>>(sr, cutoff, q);
 		}, nb::arg(A_SR), nb::arg(A_CUT), nb::arg("q") = 0.7071,
 		"RBJ biquad lowpass. q ~ 0.7071 gives a Butterworth-like response.");
 
 	m.def("rbj_highpass",
 		[](double sr, double cutoff, double q) {
+			const char* n = "rbj_highpass";
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			check_positive(q, n, "q");
 			return make_from_rbj<rbj::HighPass<>>(sr, cutoff, q);
 		}, nb::arg(A_SR), nb::arg(A_CUT), nb::arg("q") = 0.7071,
 		"RBJ biquad highpass.");
 
 	m.def("rbj_bandpass",
 		[](double sr, double center_freq, double bandwidth) {
+			const char* n = "rbj_bandpass";
+			check_sample_rate(sr, n);
+			check_frequency(center_freq, sr, n, "center_freq");
+			check_positive(bandwidth, n, "bandwidth");
 			return make_from_rbj<rbj::BandPass<>>(sr, center_freq, bandwidth);
 		}, nb::arg(A_SR), nb::arg(A_CTR), nb::arg("bandwidth") = 1.0,
 		"RBJ biquad bandpass. bandwidth is in octaves.");
 
 	m.def("rbj_bandstop",
 		[](double sr, double center_freq, double bandwidth) {
+			const char* n = "rbj_bandstop";
+			check_sample_rate(sr, n);
+			check_frequency(center_freq, sr, n, "center_freq");
+			check_positive(bandwidth, n, "bandwidth");
 			return make_from_rbj<rbj::BandStop<>>(sr, center_freq, bandwidth);
 		}, nb::arg(A_SR), nb::arg(A_CTR), nb::arg("bandwidth") = 1.0,
 		"RBJ biquad bandstop (notch). bandwidth is in octaves.");
 
 	m.def("rbj_allpass",
 		[](double sr, double center_freq, double q) {
+			const char* n = "rbj_allpass";
+			check_sample_rate(sr, n);
+			check_frequency(center_freq, sr, n, "center_freq");
+			check_positive(q, n, "q");
 			return make_from_rbj<rbj::AllPass<>>(sr, center_freq, q);
 		}, nb::arg(A_SR), nb::arg(A_CTR), nb::arg("q") = 0.7071,
 		"RBJ biquad allpass — unit magnitude, phase shift only.");
 
+	// Shelf filters: gain_db is intentionally not validated — any real value
+	// is meaningful (0 dB is a legal unity shelf, negative values cut).
 	m.def("rbj_lowshelf",
 		[](double sr, double cutoff, double gain_db, double slope) {
+			const char* n = "rbj_lowshelf";
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			check_positive(slope, n, "slope");
 			return make_from_rbj<rbj::LowShelf<>>(sr, cutoff, gain_db, slope);
 		}, nb::arg(A_SR), nb::arg(A_CUT), nb::arg("gain_db"),
 		   nb::arg("slope") = 1.0,
@@ -643,6 +669,10 @@ void bind_filters(nb::module_& m) {
 
 	m.def("rbj_highshelf",
 		[](double sr, double cutoff, double gain_db, double slope) {
+			const char* n = "rbj_highshelf";
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			check_positive(slope, n, "slope");
 			return make_from_rbj<rbj::HighShelf<>>(sr, cutoff, gain_db, slope);
 		}, nb::arg(A_SR), nb::arg(A_CUT), nb::arg("gain_db"),
 		   nb::arg("slope") = 1.0,

--- a/src/filter_bindings.cpp
+++ b/src/filter_bindings.cpp
@@ -6,9 +6,8 @@
 // vary per the dtype key (shared with quantization bindings).
 //
 // Families covered:
-//   - Butterworth, Chebyshev I/II, Bessel, Legendre: LP/HP/BP/BS
+//   - Butterworth, Chebyshev I/II, Bessel, Legendre, Elliptic: LP/HP/BP/BS
 //   - RBJ: LP/HP/BP/BS/allpass/lowshelf/highshelf (single biquad each)
-// Elliptic is deferred — upstream dsp#50 (NaN bug).
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -24,6 +23,7 @@
 #include <sw/dsp/filter/iir/butterworth.hpp>
 #include <sw/dsp/filter/iir/chebyshev1.hpp>
 #include <sw/dsp/filter/iir/chebyshev2.hpp>
+#include <sw/dsp/filter/iir/elliptic.hpp>
 #include <sw/dsp/filter/iir/legendre.hpp>
 #include <sw/dsp/filter/iir/rbj.hpp>
 
@@ -541,6 +541,64 @@ void bind_filters(nb::module_& m) {
 				order, sr, center_freq, width_freq);
 		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
 		"Design a Legendre bandstop filter.");
+
+	// =======================================================================
+	// Elliptic (Cauer) — equiripple passband and stopband. Takes ripple_db
+	// and a selectivity parameter 'rolloff' in [0.1, 5.0]. Upstream validates
+	// both; higher rolloff gives a steeper transition with more stopband ripple.
+	// =======================================================================
+
+	m.def("elliptic_lowpass",
+		[](int order, double sr, double cutoff, double ripple_db, double rolloff) {
+			const char* n = "elliptic_lowpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			return make_from_design<iir::EllipticLowPass<kMaxOrderLPHP>>(
+				order, sr, cutoff, ripple_db, rolloff);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT),
+		   nb::arg("ripple_db"), nb::arg("rolloff") = 1.0,
+		"Design an Elliptic (Cauer) lowpass filter — equiripple in both "
+		"passband and stopband. rolloff in [0.1, 5.0] controls transition "
+		"selectivity (higher = steeper).");
+
+	m.def("elliptic_highpass",
+		[](int order, double sr, double cutoff, double ripple_db, double rolloff) {
+			const char* n = "elliptic_highpass";
+			check_order(order, kMaxOrderLPHP, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			return make_from_design<iir::EllipticHighPass<kMaxOrderLPHP>>(
+				order, sr, cutoff, ripple_db, rolloff);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CUT),
+		   nb::arg("ripple_db"), nb::arg("rolloff") = 1.0,
+		"Design an Elliptic highpass filter. rolloff in [0.1, 5.0].");
+
+	m.def("elliptic_bandpass",
+		[](int order, double sr, double center_freq, double width_freq,
+		   double ripple_db, double rolloff) {
+			const char* n = "elliptic_bandpass";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			return make_from_design<iir::EllipticBandPass<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq, ripple_db, rolloff);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		   nb::arg("ripple_db"), nb::arg("rolloff") = 1.0,
+		"Design an Elliptic bandpass filter.");
+
+	m.def("elliptic_bandstop",
+		[](int order, double sr, double center_freq, double width_freq,
+		   double ripple_db, double rolloff) {
+			const char* n = "elliptic_bandstop";
+			check_order(order, kMaxOrderBPBS, n);
+			check_sample_rate(sr, n);
+			check_bp_band(center_freq, width_freq, sr, n);
+			return make_from_design<iir::EllipticBandStop<kMaxOrderBPBS>>(
+				order, sr, center_freq, width_freq, ripple_db, rolloff);
+		}, nb::arg(A_ORDER), nb::arg(A_SR), nb::arg(A_CTR), nb::arg(A_WID),
+		   nb::arg("ripple_db"), nb::arg("rolloff") = 1.0,
+		"Design an Elliptic bandstop filter.");
 
 	// =======================================================================
 	// RBJ Audio EQ Cookbook — single biquad per variant, no 'order' parameter.

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -200,6 +200,9 @@ LP_HP_FAMILIES = [
     ("legendre", {},
         lambda kind, **kw: getattr(mpdsp, f"legendre_{kind}")(
             order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0, **kw)),
+    ("elliptic", {"ripple_db": 1.0, "rolloff": 1.0},
+        lambda kind, **kw: getattr(mpdsp, f"elliptic_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0, **kw)),
 ]
 
 
@@ -242,6 +245,9 @@ BP_BS_FAMILIES = [
             order=4, sample_rate=SAMPLE_RATE, center_freq=1500.0, width_freq=800.0, **kw)),
     ("legendre", {},
         lambda kind, **kw: getattr(mpdsp, f"legendre_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, center_freq=1500.0, width_freq=800.0, **kw)),
+    ("elliptic", {"ripple_db": 1.0, "rolloff": 1.0},
+        lambda kind, **kw: getattr(mpdsp, f"elliptic_{kind}")(
             order=4, sample_rate=SAMPLE_RATE, center_freq=1500.0, width_freq=800.0, **kw)),
 ]
 
@@ -290,6 +296,22 @@ class TestParameterValidation:
         with pytest.raises(ValueError):
             mpdsp.butterworth_bandpass(order=9, sample_rate=SAMPLE_RATE,
                                        center_freq=1500.0, width_freq=800.0)
+
+    def test_elliptic_rolloff_out_of_range_raises(self):
+        # Upstream validates rolloff is in [0.1, 5.0] — it's a selectivity
+        # parameter, not a stopband dB. Values outside the range used to
+        # produce NaN coefficients; they now raise.
+        with pytest.raises(ValueError):
+            mpdsp.elliptic_lowpass(order=4, sample_rate=SAMPLE_RATE,
+                                   cutoff=1000.0, ripple_db=1.0, rolloff=0.0)
+        with pytest.raises(ValueError):
+            mpdsp.elliptic_lowpass(order=4, sample_rate=SAMPLE_RATE,
+                                   cutoff=1000.0, ripple_db=1.0, rolloff=10.0)
+
+    def test_elliptic_requires_positive_ripple(self):
+        with pytest.raises(ValueError):
+            mpdsp.elliptic_lowpass(order=4, sample_rate=SAMPLE_RATE,
+                                   cutoff=1000.0, ripple_db=0.0, rolloff=1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -367,6 +389,8 @@ ALL_FILTERS = [
     lambda: mpdsp.bessel_bandstop(order=4, sample_rate=SAMPLE_RATE,
                                    center_freq=1500.0, width_freq=800.0),
     lambda: mpdsp.legendre_lowpass(order=3, sample_rate=SAMPLE_RATE, cutoff=1500.0),
+    lambda: mpdsp.elliptic_highpass(order=4, sample_rate=SAMPLE_RATE,
+                                     cutoff=1000.0, ripple_db=1.0, rolloff=1.0),
     lambda: mpdsp.rbj_allpass(sample_rate=SAMPLE_RATE, center_freq=1000.0),
 ]
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -81,21 +81,17 @@ class TestFrequencyResponse:
 
 
 class TestProcessing:
-    def _sine(self, freq, n=4096):
-        t = np.arange(n) / SAMPLE_RATE
-        return np.sin(2.0 * np.pi * freq * t)
-
     def test_process_shape_preserved(self):
         filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
-        sig = self._sine(200.0)
+        sig = _sine(200.0)
         y = filt.process(sig)
         assert y.shape == sig.shape
         assert y.dtype == np.float64
 
     def test_lowpass_passes_low_rejects_high(self):
         filt = mpdsp.butterworth_lowpass(order=6, sample_rate=SAMPLE_RATE, cutoff=1000.0)
-        low = self._sine(200.0)
-        high = self._sine(3000.0)
+        low = _sine(200.0)
+        high = _sine(3000.0)
         # Skip transient so steady-state amplitude is meaningful.
         skip = 512
         y_low = filt.process(low)[skip:]
@@ -106,14 +102,14 @@ class TestProcessing:
 
     def test_dtype_reference_matches_double(self):
         filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
-        sig = self._sine(300.0)
+        sig = _sine(300.0)
         a = filt.process(sig, dtype="reference")
         b = filt.process(sig, dtype="double")
         np.testing.assert_array_equal(a, b)
 
     def test_dtype_dispatch_differs_from_reference(self):
         filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
-        sig = self._sine(300.0)
+        sig = _sine(300.0)
         ref = filt.process(sig, dtype="reference")
         low = filt.process(sig, dtype="half")
         # Reduced-precision arithmetic should introduce measurable error.
@@ -124,7 +120,7 @@ class TestProcessing:
 
     def test_unknown_dtype_raises(self):
         filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
-        sig = self._sine(300.0)
+        sig = _sine(300.0)
         with pytest.raises(Exception):
             filt.process(sig, dtype="not_a_real_dtype")
 
@@ -373,6 +369,20 @@ class TestRBJ:
     def test_invalid_sample_rate_raises(self):
         with pytest.raises(ValueError):
             mpdsp.rbj_lowpass(sample_rate=-1.0, cutoff=1000.0)
+
+    def test_non_positive_q_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.rbj_lowpass(sample_rate=SAMPLE_RATE, cutoff=1000.0, q=0.0)
+
+    def test_non_positive_bandwidth_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.rbj_bandpass(sample_rate=SAMPLE_RATE, center_freq=1000.0,
+                               bandwidth=-1.0)
+
+    def test_non_positive_slope_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.rbj_lowshelf(sample_rate=SAMPLE_RATE, cutoff=1000.0,
+                               gain_db=6.0, slope=0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,4 @@
-"""Tests for IIR filter bindings (Butterworth LP/HP)."""
+"""Tests for IIR filter bindings across all analog-prototype families and RBJ."""
 
 import numpy as np
 import pytest
@@ -127,3 +127,264 @@ class TestProcessing:
         sig = self._sine(300.0)
         with pytest.raises(Exception):
             filt.process(sig, dtype="not_a_real_dtype")
+
+
+# ---------------------------------------------------------------------------
+# Helpers reused across families.
+# ---------------------------------------------------------------------------
+
+
+def _sine(freq, n=4096):
+    t = np.arange(n) / SAMPLE_RATE
+    return np.sin(2.0 * np.pi * freq * t)
+
+
+def _assert_stable(filt):
+    for p in filt.poles():
+        assert abs(p) < 1.0, f"unstable pole {p}"
+
+
+def _assert_lp_behavior(filt, cutoff_hz):
+    freqs = np.array([0.0, cutoff_hz / SAMPLE_RATE, 0.4])
+    mag = np.abs(filt.frequency_response(freqs))
+    assert abs(mag[0] - 1.0) < 0.2  # DC passes (shelf/ripple may slightly offset)
+    assert mag[2] < 0.2              # stopband attenuated
+
+
+def _assert_hp_behavior(filt, cutoff_hz):
+    freqs = np.array([0.0, cutoff_hz / SAMPLE_RATE, 0.4])
+    mag = np.abs(filt.frequency_response(freqs))
+    assert mag[0] < 0.2              # DC blocked
+    assert abs(mag[2] - 1.0) < 0.2   # passband passes
+
+
+def _assert_bp_behavior(filt, center_hz):
+    f_center = center_hz / SAMPLE_RATE
+    freqs = np.array([0.01, f_center, 0.48])
+    mag = np.abs(filt.frequency_response(freqs))
+    # center passes more strongly than far edges (DC / Nyquist)
+    assert mag[1] > mag[0]
+    assert mag[1] > mag[2]
+
+
+def _assert_bs_behavior(filt, center_hz):
+    f_center = center_hz / SAMPLE_RATE
+    # use a small offset to avoid landing exactly on Nyquist when center is high
+    freqs = np.array([0.01, f_center, 0.48])
+    mag = np.abs(filt.frequency_response(freqs))
+    # center attenuates more than the passband shoulders
+    assert mag[1] < mag[0]
+    assert mag[1] < mag[2]
+
+
+# ---------------------------------------------------------------------------
+# Analog-prototype families — Chebyshev I/II, Bessel, Legendre LP/HP/BP/BS.
+# Covered parametrically to keep the test file tight; each case exercises
+# design validation, stability, and expected frequency-domain behavior.
+# ---------------------------------------------------------------------------
+
+
+LP_HP_FAMILIES = [
+    ("butterworth", {},
+        lambda kind, **kw: getattr(mpdsp, f"butterworth_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0, **kw)),
+    ("chebyshev1", {"ripple_db": 1.0},
+        lambda kind, **kw: getattr(mpdsp, f"chebyshev1_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0, **kw)),
+    ("chebyshev2", {"stopband_db": 40.0},
+        lambda kind, **kw: getattr(mpdsp, f"chebyshev2_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0, **kw)),
+    ("bessel", {},
+        lambda kind, **kw: getattr(mpdsp, f"bessel_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0, **kw)),
+    ("legendre", {},
+        lambda kind, **kw: getattr(mpdsp, f"legendre_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0, **kw)),
+]
+
+
+@pytest.mark.parametrize("family,extra_kwargs,designer", LP_HP_FAMILIES,
+                         ids=[f[0] for f in LP_HP_FAMILIES])
+class TestLpHpFamilies:
+    def test_lowpass_design(self, family, extra_kwargs, designer):
+        filt = designer("lowpass", **extra_kwargs)
+        assert filt.num_stages() == 2
+        _assert_stable(filt)
+        _assert_lp_behavior(filt, 1000.0)
+
+    def test_highpass_design(self, family, extra_kwargs, designer):
+        filt = designer("highpass", **extra_kwargs)
+        assert filt.num_stages() == 2
+        _assert_stable(filt)
+        _assert_hp_behavior(filt, 1000.0)
+
+    def test_lowpass_processes_signal(self, family, extra_kwargs, designer):
+        filt = designer("lowpass", **extra_kwargs)
+        low, high = _sine(200.0), _sine(3000.0)
+        y_low = filt.process(low)[512:]
+        y_high = filt.process(high)[512:]
+        assert np.max(np.abs(y_low)) > 0.5
+        assert np.max(np.abs(y_high)) < np.max(np.abs(y_low))
+
+
+BP_BS_FAMILIES = [
+    ("butterworth", {},
+        lambda kind, **kw: getattr(mpdsp, f"butterworth_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, center_freq=1500.0, width_freq=800.0, **kw)),
+    ("chebyshev1", {"ripple_db": 1.0},
+        lambda kind, **kw: getattr(mpdsp, f"chebyshev1_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, center_freq=1500.0, width_freq=800.0, **kw)),
+    ("chebyshev2", {"stopband_db": 40.0},
+        lambda kind, **kw: getattr(mpdsp, f"chebyshev2_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, center_freq=1500.0, width_freq=800.0, **kw)),
+    ("bessel", {},
+        lambda kind, **kw: getattr(mpdsp, f"bessel_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, center_freq=1500.0, width_freq=800.0, **kw)),
+    ("legendre", {},
+        lambda kind, **kw: getattr(mpdsp, f"legendre_{kind}")(
+            order=4, sample_rate=SAMPLE_RATE, center_freq=1500.0, width_freq=800.0, **kw)),
+]
+
+
+@pytest.mark.parametrize("family,extra_kwargs,designer", BP_BS_FAMILIES,
+                         ids=[f[0] for f in BP_BS_FAMILIES])
+class TestBpBsFamilies:
+    def test_bandpass_design(self, family, extra_kwargs, designer):
+        filt = designer("bandpass", **extra_kwargs)
+        # Bandpass transform doubles the internal order: user order 4 -> 4 biquads
+        assert filt.num_stages() == 4
+        _assert_stable(filt)
+        _assert_bp_behavior(filt, 1500.0)
+
+    def test_bandstop_design(self, family, extra_kwargs, designer):
+        filt = designer("bandstop", **extra_kwargs)
+        assert filt.num_stages() == 4
+        _assert_stable(filt)
+        _assert_bs_behavior(filt, 1500.0)
+
+
+# ---------------------------------------------------------------------------
+# Parameter validation — per-family invariants that aren't covered above.
+# ---------------------------------------------------------------------------
+
+
+class TestParameterValidation:
+    def test_chebyshev1_requires_positive_ripple(self):
+        with pytest.raises(ValueError):
+            mpdsp.chebyshev1_lowpass(order=4, sample_rate=SAMPLE_RATE,
+                                     cutoff=1000.0, ripple_db=0.0)
+
+    def test_chebyshev2_requires_positive_stopband(self):
+        with pytest.raises(ValueError):
+            mpdsp.chebyshev2_lowpass(order=4, sample_rate=SAMPLE_RATE,
+                                     cutoff=1000.0, stopband_db=0.0)
+
+    def test_bandpass_width_outside_range_raises(self):
+        # width too large -> passband exceeds Nyquist
+        with pytest.raises(ValueError):
+            mpdsp.butterworth_bandpass(order=4, sample_rate=SAMPLE_RATE,
+                                       center_freq=1000.0, width_freq=5000.0)
+
+    def test_bandpass_order_above_bpbs_limit_raises(self):
+        # BP/BS caps at 8 (kMaxOrderBPBS), lower than LP/HP's 16.
+        with pytest.raises(ValueError):
+            mpdsp.butterworth_bandpass(order=9, sample_rate=SAMPLE_RATE,
+                                       center_freq=1500.0, width_freq=800.0)
+
+
+# ---------------------------------------------------------------------------
+# RBJ — single-biquad cookbook designs, different signature (no 'order').
+# ---------------------------------------------------------------------------
+
+
+class TestRBJ:
+    def test_lowpass_is_single_biquad(self):
+        filt = mpdsp.rbj_lowpass(sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        assert filt.num_stages() == 1
+        _assert_stable(filt)
+        _assert_lp_behavior(filt, 1000.0)
+
+    def test_highpass(self):
+        filt = mpdsp.rbj_highpass(sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        assert filt.num_stages() == 1
+        _assert_stable(filt)
+        _assert_hp_behavior(filt, 1000.0)
+
+    def test_bandpass_peaks_at_center(self):
+        filt = mpdsp.rbj_bandpass(sample_rate=SAMPLE_RATE, center_freq=1000.0)
+        assert filt.num_stages() == 1
+        _assert_bp_behavior(filt, 1000.0)
+
+    def test_bandstop_notches_at_center(self):
+        filt = mpdsp.rbj_bandstop(sample_rate=SAMPLE_RATE, center_freq=1000.0)
+        _assert_bs_behavior(filt, 1000.0)
+
+    def test_allpass_magnitude_is_unity(self):
+        filt = mpdsp.rbj_allpass(sample_rate=SAMPLE_RATE, center_freq=1000.0)
+        freqs = np.linspace(0.001, 0.499, 32)
+        mag = np.abs(filt.frequency_response(freqs))
+        # All-pass: unit magnitude everywhere.
+        assert np.allclose(mag, 1.0, atol=1e-6)
+
+    def test_lowshelf_gain_matches_request(self):
+        filt = mpdsp.rbj_lowshelf(sample_rate=SAMPLE_RATE, cutoff=500.0,
+                                  gain_db=6.0)
+        mag = np.abs(filt.frequency_response(np.array([0.0, 0.49])))
+        # DC should be boosted by ~6 dB = factor 2.0; Nyquist ~ 0 dB (unity).
+        assert mag[0] > 1.5
+        assert abs(mag[1] - 1.0) < 0.2
+
+    def test_highshelf_gain_matches_request(self):
+        filt = mpdsp.rbj_highshelf(sample_rate=SAMPLE_RATE, cutoff=2000.0,
+                                   gain_db=6.0)
+        mag = np.abs(filt.frequency_response(np.array([0.0, 0.49])))
+        assert abs(mag[0] - 1.0) < 0.2
+        assert mag[1] > 1.5
+
+    def test_processes_signal(self):
+        filt = mpdsp.rbj_lowpass(sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        sig = _sine(200.0)
+        y = filt.process(sig)
+        assert y.shape == sig.shape
+        assert np.max(np.abs(y[512:])) > 0.5  # passband preserved
+
+    def test_invalid_sample_rate_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.rbj_lowpass(sample_rate=-1.0, cutoff=1000.0)
+
+
+# ---------------------------------------------------------------------------
+# Cross-family smoke tests — frequency_response and process work the same
+# way on every kind of filter exposed by this module.
+# ---------------------------------------------------------------------------
+
+
+ALL_FILTERS = [
+    lambda: mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0),
+    lambda: mpdsp.chebyshev1_highpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0, ripple_db=0.5),
+    lambda: mpdsp.chebyshev2_bandpass(order=4, sample_rate=SAMPLE_RATE,
+                                       center_freq=1500.0, width_freq=800.0, stopband_db=40.0),
+    lambda: mpdsp.bessel_bandstop(order=4, sample_rate=SAMPLE_RATE,
+                                   center_freq=1500.0, width_freq=800.0),
+    lambda: mpdsp.legendre_lowpass(order=3, sample_rate=SAMPLE_RATE, cutoff=1500.0),
+    lambda: mpdsp.rbj_allpass(sample_rate=SAMPLE_RATE, center_freq=1000.0),
+]
+
+
+@pytest.mark.parametrize("make", ALL_FILTERS)
+def test_filter_common_api(make):
+    filt = make()
+    assert isinstance(filt, mpdsp.IIRFilter)
+    assert filt.num_stages() >= 1
+
+    # frequency_response returns complex128 with correct shape
+    freqs = np.linspace(0.0, 0.5, 16)
+    h = filt.frequency_response(freqs)
+    assert h.shape == freqs.shape
+    assert h.dtype == np.complex128
+
+    # process returns float64 with same shape as input
+    sig = _sine(300.0, n=1024)
+    y = filt.process(sig)
+    assert y.shape == sig.shape
+    assert y.dtype == np.float64


### PR DESCRIPTION
## Summary
- Expands the `PyIIRFilter` pattern established in #17 to cover the remaining IIR analog-prototype families (including Elliptic, now safe after the upstream NaN-bug fix) and the RBJ audio EQ cookbook biquads.
- No changes to the filter-object API — everything new is just more design functions returning `mpdsp.IIRFilter`.

## What's new

**Analog-prototype families** (6 × 4 = 24 designs; 20 new in this PR)

| Family       | LP / HP | BP / BS | Extra parameters                        |
|--------------|:-------:|:-------:|-----------------------------------------|
| Butterworth  | ✓ (from #17) | **new** | —                                       |
| Chebyshev I  | **new** | **new** | `ripple_db`                             |
| Chebyshev II | **new** | **new** | `stopband_db`                           |
| Bessel       | **new** | **new** | —                                       |
| Legendre     | **new** | **new** | —                                       |
| Elliptic     | **new** | **new** | `ripple_db`, `rolloff` (in [0.1, 5.0]) |

Elliptic is included after upstream `mixed-precision-dsp` fixes landed (`4b7ac94` and `0d43a52`). The `rolloff` parameter is a selectivity control — higher values give a steeper transition with more stopband ripple. (The issue description's "stopband_db" isn't how the Cauer design is parameterized, so the binding exposes the real parameter.)

**RBJ biquads** (7 single-biquad designs, all new)
- `rbj_lowpass`, `rbj_highpass`, `rbj_bandpass`, `rbj_bandstop` (notch)
- `rbj_allpass` — unit magnitude everywhere; verified by test
- `rbj_lowshelf`, `rbj_highshelf` — gain_db + slope; verified by test

## How it fits one cascade type

All designs produce a `Cascade<double, 8>`:
- LP/HP templates with `MaxOrder = 16` → `max_stages = (MaxOrder+1)/2 = 8`
- BP/BS templates with `MaxOrder = 8` → `max_stages = MaxOrder = 8` (bandpass transform doubles order internally)
- RBJ copies its single biquad into stage 0, `num_stages = 1`

## Test Results
| Build  | Filter tests | Full suite  |
|--------|--------------|-------------|
| gcc    | 67/67 pass   | 117/117 pass |
| clang  | 67/67 pass   | 117/117 pass |

(Up from 15 / 65 in #17.)

## Follow-up (still open under issue #5)
- FIR design + `PyFIRFilter` class
- Python helpers (`python/mpdsp/filters.py`) — `compare_filters`, `plot_filter_comparison`
- Notebooks `02_iir_precision.ipynb`, `03_fir_and_windows.ipynb`
- Enable posit dtypes for `process()` once `DspField` conformance is verified
- Extended diagnostics: `stability_margin`, `condition_number`, `worst_case_sensitivity`, `pole_displacement`

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC + Apple Clang)
- [ ] Promote to ready and merge once green

Relates to #5

Generated with [Claude Code](https://claude.com/claude-code)