### PR TITLE
feat(filters): FIR bindings, posit dtypes, diagnostics, and Python helpers

### DIFF
--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -40,6 +40,9 @@ try:
         rbj_lowpass, rbj_highpass,
         rbj_bandpass, rbj_bandstop,
         rbj_allpass, rbj_lowshelf, rbj_highshelf,
+        FIRFilter, fir_filter,
+        fir_lowpass, fir_highpass,
+        fir_bandpass, fir_bandstop,
         # Introspection
         available_dtypes,
     )
@@ -57,3 +60,7 @@ try:
     HAS_PLOT = True
 except ImportError:
     HAS_PLOT = False
+
+# Filter helpers (pure Python; requires mpdsp._core; plotting needs matplotlib)
+if HAS_CORE:
+    from mpdsp.filters import compare_filters, plot_filter_comparison

--- a/python/mpdsp/filters.py
+++ b/python/mpdsp/filters.py
@@ -1,0 +1,186 @@
+"""Mixed-precision filter comparison helpers.
+
+Built on top of the C++ bindings in `mpdsp._core` (IIRFilter and FIRFilter).
+Use `compare_filters` to quantify precision loss across dtypes and
+`plot_filter_comparison` to visualize magnitude, phase, and pole locations
+side by side.
+"""
+
+import numpy as np
+
+import mpdsp
+
+try:
+    import pandas as pd
+    HAS_PANDAS = True
+except ImportError:
+    HAS_PANDAS = False
+
+try:
+    import matplotlib.pyplot as plt
+    HAS_MPL = True
+except ImportError:
+    HAS_MPL = False
+
+
+# Configurations to compare by default — the pre-instantiated ones.
+DEFAULT_DTYPES = [
+    "reference",
+    "gpu_baseline",
+    "ml_hw",
+    "cf24",
+    "half",
+    "posit_full",
+    "tiny_posit",
+]
+
+
+def compare_filters(filt, signal, dtypes=None):
+    """Process `signal` through `filt` at multiple dtypes and report error metrics.
+
+    For each dtype the filter is re-run; SQNR and max absolute error are
+    measured against the "reference" (double-precision) output.
+
+    Parameters
+    ----------
+    filt : mpdsp.IIRFilter or mpdsp.FIRFilter
+        A filter object with a `process(signal, dtype)` method.
+    signal : numpy.ndarray
+        1D input signal (float64).
+    dtypes : list of str, optional
+        Dtype keys to compare. Defaults to all pre-instantiated configurations.
+        The first entry is treated as the reference if "reference" isn't listed.
+
+    Returns
+    -------
+    pandas.DataFrame (if pandas is available), else list of dict
+        Columns: dtype, sqnr_db, max_abs_error, max_rel_error.
+        Failed dtypes (e.g. posit when disabled) record the exception message
+        and NaN error values.
+    """
+    if dtypes is None:
+        dtypes = list(DEFAULT_DTYPES)
+
+    reference_key = "reference" if "reference" in dtypes else dtypes[0]
+    ref = filt.process(signal, dtype=reference_key)
+
+    rows = []
+    for dt in dtypes:
+        try:
+            out = filt.process(signal, dtype=dt)
+            row = {
+                "dtype": dt,
+                "sqnr_db": mpdsp.sqnr_db(ref, out),
+                "max_abs_error": mpdsp.max_absolute_error(ref, out),
+                "max_rel_error": mpdsp.max_relative_error(ref, out),
+                "error": None,
+            }
+        except Exception as e:
+            row = {
+                "dtype": dt,
+                "sqnr_db": float("nan"),
+                "max_abs_error": float("nan"),
+                "max_rel_error": float("nan"),
+                "error": str(e),
+            }
+        rows.append(row)
+
+    if HAS_PANDAS:
+        return pd.DataFrame(rows)
+    return rows
+
+
+def plot_filter_comparison(filt, dtypes=None, num_freqs=512, signal=None,
+                           sample_rate=1.0, title=None, figsize=(12, 4)):
+    """Plot magnitude, phase, and pole locations for a filter.
+
+    Parameters
+    ----------
+    filt : mpdsp.IIRFilter or mpdsp.FIRFilter
+        A filter object. Pole-zero subplot is only populated for IIRFilter.
+    dtypes : list of str, optional
+        If provided AND a `signal` is given, overlays SQNR-annotated
+        magnitude curves from each dtype onto the main magnitude subplot.
+        For design-only visualization, leave this as None.
+    num_freqs : int
+        Number of frequency points on [0, 0.5] (normalized).
+    signal : numpy.ndarray, optional
+        If provided with `dtypes`, each dtype's processed output is evaluated
+        for SQNR annotation (purely informational).
+    sample_rate : float
+        For axis labels only. Default 1.0 labels x-axis in normalized units.
+    title : str, optional
+        Overall figure title.
+    figsize : tuple
+        Figure size.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    if not HAS_MPL:
+        raise ImportError("matplotlib is required for plot_filter_comparison. "
+                          "Install with: pip install matplotlib")
+
+    freqs = np.linspace(0.0, 0.5, num_freqs)
+    H = filt.frequency_response(freqs)
+    mag_db = 20.0 * np.log10(np.maximum(np.abs(H), 1e-12))
+    phase = np.unwrap(np.angle(H))
+
+    # Plot in Hz if sample_rate was provided, otherwise normalized.
+    x_freqs = freqs * sample_rate
+    x_label = "Frequency (Hz)" if sample_rate != 1.0 else "Normalized frequency"
+
+    is_iir = isinstance(filt, mpdsp.IIRFilter)
+    n_cols = 3 if is_iir else 2
+    fig, axes = plt.subplots(1, n_cols, figsize=figsize)
+    ax_mag = axes[0]
+    ax_phase = axes[1]
+
+    ax_mag.plot(x_freqs, mag_db, label="reference")
+    ax_mag.set_xlabel(x_label)
+    ax_mag.set_ylabel("Magnitude (dB)")
+    ax_mag.set_title("Magnitude response")
+    ax_mag.grid(True)
+
+    ax_phase.plot(x_freqs, phase)
+    ax_phase.set_xlabel(x_label)
+    ax_phase.set_ylabel("Phase (rad, unwrapped)")
+    ax_phase.set_title("Phase response")
+    ax_phase.grid(True)
+
+    # If the caller asks for per-dtype SQNR annotation, run the signal through
+    # each dtype once and tag the legend with the result.
+    if dtypes is not None and signal is not None:
+        ref_out = filt.process(signal, dtype="reference")
+        for dt in dtypes:
+            if dt == "reference":
+                continue
+            try:
+                out = filt.process(signal, dtype=dt)
+                sqnr = mpdsp.sqnr_db(ref_out, out)
+                ax_mag.plot([], [], " ", label=f"{dt}: SQNR={sqnr:.1f} dB")
+            except Exception as e:
+                ax_mag.plot([], [], " ", label=f"{dt}: {e}")
+        ax_mag.legend(loc="best", fontsize="small")
+
+    if is_iir:
+        ax_pz = axes[2]
+        poles = np.asarray(filt.poles())
+        # Unit circle for reference
+        theta = np.linspace(0, 2 * np.pi, 256)
+        ax_pz.plot(np.cos(theta), np.sin(theta), color="0.7", linewidth=0.8)
+        ax_pz.scatter(poles.real, poles.imag, marker="x", color="C3",
+                      s=60, label="poles")
+        ax_pz.set_aspect("equal")
+        ax_pz.set_xlabel("Re(z)")
+        ax_pz.set_ylabel("Im(z)")
+        ax_pz.set_title(f"Pole locations (margin = "
+                        f"{filt.stability_margin():.3f})")
+        ax_pz.grid(True)
+        ax_pz.legend(loc="best", fontsize="small")
+
+    if title:
+        fig.suptitle(title)
+    fig.tight_layout()
+    return fig

--- a/src/filter_bindings.cpp
+++ b/src/filter_bindings.cpp
@@ -16,9 +16,14 @@
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
 
+#include <sw/dsp/analysis/condition.hpp>
+#include <sw/dsp/analysis/sensitivity.hpp>
+#include <sw/dsp/analysis/stability.hpp>
 #include <sw/dsp/filter/biquad/biquad.hpp>
 #include <sw/dsp/filter/biquad/cascade.hpp>
 #include <sw/dsp/filter/biquad/state.hpp>
+#include <sw/dsp/filter/fir/fir_design.hpp>
+#include <sw/dsp/filter/fir/fir_filter.hpp>
 #include <sw/dsp/filter/iir/bessel.hpp>
 #include <sw/dsp/filter/iir/butterworth.hpp>
 #include <sw/dsp/filter/iir/chebyshev1.hpp>
@@ -26,6 +31,7 @@
 #include <sw/dsp/filter/iir/elliptic.hpp>
 #include <sw/dsp/filter/iir/legendre.hpp>
 #include <sw/dsp/filter/iir/rbj.hpp>
+#include <sw/dsp/windows/windows.hpp>
 
 #include "types.hpp"
 
@@ -72,6 +78,9 @@ static void process_dispatch(const CascadeD& cascade,
 	using mpdsp::ArithConfig;
 	using mpdsp::cf24;
 	using mpdsp::half_;
+	using mpdsp::p16;
+	using mpdsp::p32;
+	using tiny_posit_t = sw::universal::posit<8, 2>;
 	switch (config) {
 	case ArithConfig::reference:
 		process_typed<double, double>(cascade, in, out, n); break;
@@ -84,9 +93,9 @@ static void process_dispatch(const CascadeD& cascade,
 	case ArithConfig::half_config:
 		process_typed<half_, half_>(cascade, in, out, n); break;
 	case ArithConfig::posit_full:
+		process_typed<p32, p16>(cascade, in, out, n); break;
 	case ArithConfig::tiny_posit:
-		throw std::invalid_argument(
-			"posit dtypes for filter.process are not yet enabled");
+		process_typed<tiny_posit_t, tiny_posit_t>(cascade, in, out, n); break;
 	}
 }
 
@@ -218,9 +227,214 @@ public:
 		}
 		return arr;
 	}
+
+	// --- Extended diagnostics --------------------------------------------
+
+	double stability_margin() const {
+		return sw::dsp::stability_margin(cascade);
+	}
+
+	double condition_number(int num_freqs) const {
+		return sw::dsp::cascade_condition_number(cascade, num_freqs);
+	}
+
+	double worst_case_sensitivity(double epsilon) const {
+		return sw::dsp::worst_case_sensitivity(cascade, epsilon);
+	}
+
+	// Pole displacement: quantize each coefficient through the target dtype
+	// (double -> T -> double) and measure how far the resulting poles move.
+	// This captures the dominant quantization effect (coefficient precision);
+	// pole extraction is done in double on both cascades.
+	double pole_displacement(const std::string& dtype) const;
+};
+
+// ---------------------------------------------------------------------------
+// PyFIRFilter: opaque handle wrapping a double-precision tap vector.
+// ---------------------------------------------------------------------------
+
+class PyFIRFilter {
+public:
+	mtl::vec::dense_vector<double> taps;
+
+	int num_taps() const { return static_cast<int>(taps.size()); }
+
+	// Taps as a NumPy float64 array (copied).
+	np_f64 coefficients() const {
+		std::size_t n = taps.size();
+		double* out_ptr = nullptr;
+		auto arr = make_f64_array(n, out_ptr);
+		for (std::size_t i = 0; i < n; ++i) out_ptr[i] = taps[i];
+		return arr;
+	}
+
+	// Impulse response of length `length` — the taps padded (or truncated).
+	np_f64 impulse_response(int length) const {
+		if (length <= 0) {
+			throw std::invalid_argument(
+				"impulse_response: length must be positive");
+		}
+		std::size_t n = static_cast<std::size_t>(length);
+		double* out_ptr = nullptr;
+		auto arr = make_f64_array(n, out_ptr);
+		std::size_t copy_n = std::min(n, taps.size());
+		for (std::size_t i = 0; i < copy_n; ++i) out_ptr[i] = taps[i];
+		for (std::size_t i = copy_n; i < n; ++i) out_ptr[i] = 0.0;
+		return arr;
+	}
+
+	// H(e^{j2*pi*f}) = sum_n taps[n] * exp(-j * 2*pi*f * n).
+	np_c128 frequency_response(np_f64_ro normalized_freqs) const {
+		std::size_t n = normalized_freqs.shape(0);
+		std::complex<double>* out_ptr = nullptr;
+		auto arr = make_c128_array(n, out_ptr);
+		const double* f = normalized_freqs.data();
+		std::size_t N = taps.size();
+		for (std::size_t k = 0; k < n; ++k) {
+			std::complex<double> acc{};
+			double w = 2.0 * 3.14159265358979323846 * f[k];
+			for (std::size_t i = 0; i < N; ++i) {
+				acc += taps[i] * std::exp(std::complex<double>(0.0, -w * static_cast<double>(i)));
+			}
+			out_ptr[k] = acc;
+		}
+		return arr;
+	}
+
+	np_f64 process(np_f64_ro signal, const std::string& dtype) const;
 };
 
 namespace {
+
+// ---------------------------------------------------------------------------
+// FIR type-dispatched processing. Each call spins up a fresh FIRFilter with
+// taps cast to StateScalar (== CoeffScalar here). This matches the IIR
+// pattern: the Python-facing filter object is stateless across process() calls.
+// ---------------------------------------------------------------------------
+
+template <typename StateScalar, typename SampleScalar>
+static void fir_process_typed(const mtl::vec::dense_vector<double>& taps_d,
+                              const double* in, double* out, std::size_t n) {
+	mtl::vec::dense_vector<StateScalar> taps(taps_d.size());
+	for (std::size_t i = 0; i < taps_d.size(); ++i) {
+		taps[i] = static_cast<StateScalar>(taps_d[i]);
+	}
+	sw::dsp::FIRFilter<StateScalar, StateScalar, SampleScalar> filt(taps);
+	for (std::size_t i = 0; i < n; ++i) {
+		SampleScalar x = static_cast<SampleScalar>(in[i]);
+		out[i] = static_cast<double>(filt.process(x));
+	}
+}
+
+static void fir_process_dispatch(const mtl::vec::dense_vector<double>& taps_d,
+                                 const double* in, double* out, std::size_t n,
+                                 mpdsp::ArithConfig config) {
+	using mpdsp::ArithConfig;
+	using mpdsp::cf24;
+	using mpdsp::half_;
+	using mpdsp::p16;
+	using mpdsp::p32;
+	using tiny_posit_t = sw::universal::posit<8, 2>;
+	switch (config) {
+	case ArithConfig::reference:
+		fir_process_typed<double, double>(taps_d, in, out, n); break;
+	case ArithConfig::gpu_baseline:
+		fir_process_typed<float, float>(taps_d, in, out, n); break;
+	case ArithConfig::ml_hw:
+		fir_process_typed<float, half_>(taps_d, in, out, n); break;
+	case ArithConfig::cf24_config:
+		fir_process_typed<cf24, cf24>(taps_d, in, out, n); break;
+	case ArithConfig::half_config:
+		fir_process_typed<half_, half_>(taps_d, in, out, n); break;
+	case ArithConfig::posit_full:
+		fir_process_typed<p32, p16>(taps_d, in, out, n); break;
+	case ArithConfig::tiny_posit:
+		fir_process_typed<tiny_posit_t, tiny_posit_t>(taps_d, in, out, n); break;
+	}
+}
+
+// Build a window of the requested kind (name matches signal_bindings.cpp).
+static mtl::vec::dense_vector<double>
+make_window(const std::string& name, std::size_t N, double kaiser_beta) {
+	using namespace sw::dsp;
+	if (name == "hamming")     return hamming_window<double>(N);
+	if (name == "hanning")     return hanning_window<double>(N);
+	if (name == "blackman")    return blackman_window<double>(N);
+	if (name == "rectangular") return rectangular_window<double>(N);
+	if (name == "flat_top")    return flat_top_window<double>(N);
+	if (name == "kaiser")      return kaiser_window<double>(N, kaiser_beta);
+	throw std::invalid_argument("Unknown window: " + name +
+		" (expected hamming, hanning, blackman, rectangular, flat_top, kaiser)");
+}
+
+// Common FIR parameter validation shared by the design functions below.
+static void check_num_taps(int n, const char* name) {
+	if (n < 1) {
+		throw std::invalid_argument(std::string(name) +
+			": num_taps must be positive");
+	}
+}
+
+} // namespace
+
+np_f64 PyFIRFilter::process(np_f64_ro signal, const std::string& dtype) const {
+	std::size_t n = signal.shape(0);
+	double* out_ptr = nullptr;
+	auto arr = make_f64_array(n, out_ptr);
+	auto config = mpdsp::parse_config(dtype);
+	fir_process_dispatch(taps, signal.data(), out_ptr, n, config);
+	return arr;
+}
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Coefficient quantization for pole-displacement analysis.
+// Round-trips each coefficient through target type T (double -> T -> double)
+// so pole extraction can use the existing double-precision cascade machinery.
+// ---------------------------------------------------------------------------
+
+template <typename T>
+static double round_trip(double v) {
+	return static_cast<double>(static_cast<T>(v));
+}
+
+template <typename T>
+static CascadeD quantize_cascade(const CascadeD& src) {
+	CascadeD dst;
+	dst.set_num_stages(src.num_stages());
+	for (int i = 0; i < src.num_stages(); ++i) {
+		const auto& s = src.stage(i);
+		auto& d = dst.stage(i);
+		d.b0 = round_trip<T>(s.b0);
+		d.b1 = round_trip<T>(s.b1);
+		d.b2 = round_trip<T>(s.b2);
+		d.a1 = round_trip<T>(s.a1);
+		d.a2 = round_trip<T>(s.a2);
+	}
+	return dst;
+}
+
+static double pole_displacement_dispatch(const CascadeD& src,
+                                         mpdsp::ArithConfig config) {
+	using mpdsp::ArithConfig;
+	using mpdsp::cf24;
+	using mpdsp::half_;
+	using mpdsp::p16;
+	using mpdsp::p32;
+	using tiny_posit_t = sw::universal::posit<8, 2>;
+	CascadeD quantized;
+	switch (config) {
+	case ArithConfig::reference:    return 0.0;  // no quantization
+	case ArithConfig::gpu_baseline: quantized = quantize_cascade<float>(src); break;
+	case ArithConfig::ml_hw:        quantized = quantize_cascade<half_>(src); break;
+	case ArithConfig::cf24_config:  quantized = quantize_cascade<cf24>(src); break;
+	case ArithConfig::half_config:  quantized = quantize_cascade<half_>(src); break;
+	case ArithConfig::posit_full:   quantized = quantize_cascade<p32>(src); break;
+	case ArithConfig::tiny_posit:   quantized = quantize_cascade<tiny_posit_t>(src); break;
+	}
+	return sw::dsp::pole_displacement(src, quantized);
+}
 
 // ---------------------------------------------------------------------------
 // Design factories. DesignT is a class with .setup(...) and .cascade().
@@ -252,6 +466,11 @@ static PyIIRFilter make_from_rbj(SetupArgs... args) {
 
 } // namespace
 
+double PyIIRFilter::pole_displacement(const std::string& dtype) const {
+	auto config = mpdsp::parse_config(dtype);
+	return pole_displacement_dispatch(cascade, config);
+}
+
 // ---------------------------------------------------------------------------
 // Module registration.
 // ---------------------------------------------------------------------------
@@ -275,7 +494,21 @@ void bind_filters(nb::module_& m) {
 		.def("frequency_response", &PyIIRFilter::frequency_response,
 		     nb::arg("normalized_freqs"),
 		     "Evaluate H(e^{j2*pi*f}) at each normalized frequency (f/fs). "
-		     "Returns complex128.");
+		     "Returns complex128.")
+		.def("stability_margin", &PyIIRFilter::stability_margin,
+		     "1 - max(|pole|). Positive = stable, 0 = marginal, < 0 = unstable.")
+		.def("condition_number", &PyIIRFilter::condition_number,
+		     nb::arg("num_freqs") = 256,
+		     "Worst-case relative change in |H| per coefficient perturbation "
+		     "across stages. Higher = more sensitive to coefficient quantization.")
+		.def("worst_case_sensitivity", &PyIIRFilter::worst_case_sensitivity,
+		     nb::arg("epsilon") = 1e-8,
+		     "Worst-case |d(max_pole_radius)/d(coeff)| across stages, "
+		     "computed by finite differences.")
+		.def("pole_displacement", &PyIIRFilter::pole_displacement,
+		     nb::arg("dtype"),
+		     "Max pole displacement when coefficients are quantized through "
+		     "the target dtype (see available_dtypes). Returns 0 for 'reference'.");
 
 	namespace iir = sw::dsp::iir;
 	namespace rbj = sw::dsp::iir::rbj;
@@ -677,4 +910,120 @@ void bind_filters(nb::module_& m) {
 		}, nb::arg(A_SR), nb::arg(A_CUT), nb::arg("gain_db"),
 		   nb::arg("slope") = 1.0,
 		"RBJ biquad high shelf. gain_db is the high-frequency shelf gain.");
+
+	// =======================================================================
+	// FIR filters.
+	// =======================================================================
+
+	nb::class_<PyFIRFilter>(m, "FIRFilter",
+		"Finite-impulse-response filter with a double-precision tap vector.\n\n"
+		"Construct via fir_lowpass / fir_highpass / fir_bandpass / fir_bandstop, "
+		"or from explicit coefficients via fir_filter(taps). "
+		"process() dispatches state/sample arithmetic on the dtype argument.")
+		.def("num_taps", &PyFIRFilter::num_taps,
+		     "Number of tap coefficients.")
+		.def("coefficients", &PyFIRFilter::coefficients,
+		     "Taps as a NumPy float64 array.")
+		.def("impulse_response", &PyFIRFilter::impulse_response,
+		     nb::arg("length"),
+		     "Impulse response — the taps, padded or truncated to `length`.")
+		.def("frequency_response", &PyFIRFilter::frequency_response,
+		     nb::arg("normalized_freqs"),
+		     "Evaluate H(e^{j2*pi*f}) at each normalized frequency (f/fs). "
+		     "Returns complex128.")
+		.def("process", &PyFIRFilter::process,
+		     nb::arg("signal"), nb::arg("dtype") = "reference",
+		     "Filter a signal. dtype selects arithmetic for taps, state, and "
+		     "samples (see available_dtypes()). Returns NumPy float64.");
+
+	m.def("fir_filter",
+		[](np_f64_ro coeffs) {
+			std::size_t n = coeffs.shape(0);
+			check_num_taps(static_cast<int>(n), "fir_filter");
+			PyFIRFilter f;
+			f.taps = mtl::vec::dense_vector<double>(n);
+			const double* src = coeffs.data();
+			for (std::size_t i = 0; i < n; ++i) f.taps[i] = src[i];
+			return f;
+		}, nb::arg("coefficients"),
+		"Construct an FIR filter from explicit tap coefficients.");
+
+	m.def("fir_lowpass",
+		[](int num_taps, double sr, double cutoff,
+		   const std::string& window, double kaiser_beta) {
+			const char* n = "fir_lowpass";
+			check_num_taps(num_taps, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			auto w = make_window(window, static_cast<std::size_t>(num_taps), kaiser_beta);
+			PyFIRFilter f;
+			f.taps = sw::dsp::design_fir_lowpass<double>(
+				static_cast<std::size_t>(num_taps), cutoff / sr, w);
+			return f;
+		}, nb::arg("num_taps"), nb::arg(A_SR), nb::arg(A_CUT),
+		   nb::arg("window") = "hamming", nb::arg("kaiser_beta") = 8.6,
+		"Design an FIR lowpass filter via the window method.");
+
+	m.def("fir_highpass",
+		[](int num_taps, double sr, double cutoff,
+		   const std::string& window, double kaiser_beta) {
+			const char* n = "fir_highpass";
+			check_num_taps(num_taps, n);
+			check_sample_rate(sr, n);
+			check_frequency(cutoff, sr, n, "cutoff");
+			auto w = make_window(window, static_cast<std::size_t>(num_taps), kaiser_beta);
+			PyFIRFilter f;
+			f.taps = sw::dsp::design_fir_highpass<double>(
+				static_cast<std::size_t>(num_taps), cutoff / sr, w);
+			return f;
+		}, nb::arg("num_taps"), nb::arg(A_SR), nb::arg(A_CUT),
+		   nb::arg("window") = "hamming", nb::arg("kaiser_beta") = 8.6,
+		"Design an FIR highpass filter via spectral inversion of a lowpass.");
+
+	m.def("fir_bandpass",
+		[](int num_taps, double sr, double f_low, double f_high,
+		   const std::string& window, double kaiser_beta) {
+			const char* n = "fir_bandpass";
+			check_num_taps(num_taps, n);
+			check_sample_rate(sr, n);
+			check_frequency(f_low, sr, n, "f_low");
+			check_frequency(f_high, sr, n, "f_high");
+			if (!(f_high > f_low)) {
+				throw std::invalid_argument(
+					"fir_bandpass: f_high must be greater than f_low");
+			}
+			auto w = make_window(window, static_cast<std::size_t>(num_taps), kaiser_beta);
+			PyFIRFilter f;
+			f.taps = sw::dsp::design_fir_bandpass<double>(
+				static_cast<std::size_t>(num_taps), f_low / sr, f_high / sr, w);
+			return f;
+		}, nb::arg("num_taps"), nb::arg(A_SR), nb::arg("f_low"), nb::arg("f_high"),
+		   nb::arg("window") = "hamming", nb::arg("kaiser_beta") = 8.6,
+		"Design an FIR bandpass filter.");
+
+	m.def("fir_bandstop",
+		[](int num_taps, double sr, double f_low, double f_high,
+		   const std::string& window, double kaiser_beta) {
+			const char* n = "fir_bandstop";
+			check_num_taps(num_taps, n);
+			check_sample_rate(sr, n);
+			check_frequency(f_low, sr, n, "f_low");
+			check_frequency(f_high, sr, n, "f_high");
+			if (!(f_high > f_low)) {
+				throw std::invalid_argument(
+					"fir_bandstop: f_high must be greater than f_low");
+			}
+			auto w = make_window(window, static_cast<std::size_t>(num_taps), kaiser_beta);
+			// Bandstop via spectral inversion of a bandpass:
+			// bs[n] = delta[n - M/2] - bp[n]
+			auto bp = sw::dsp::design_fir_bandpass<double>(
+				static_cast<std::size_t>(num_taps), f_low / sr, f_high / sr, w);
+			PyFIRFilter f;
+			f.taps = mtl::vec::dense_vector<double>(bp.size());
+			for (std::size_t i = 0; i < bp.size(); ++i) f.taps[i] = -bp[i];
+			f.taps[(bp.size() - 1) / 2] += 1.0;
+			return f;
+		}, nb::arg("num_taps"), nb::arg(A_SR), nb::arg("f_low"), nb::arg("f_high"),
+		   nb::arg("window") = "hamming", nb::arg("kaiser_beta") = 8.6,
+		"Design an FIR bandstop (notch) filter via spectral inversion.");
 }

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -422,3 +422,239 @@ def test_filter_common_api(make):
     y = filt.process(sig)
     assert y.shape == sig.shape
     assert y.dtype == np.float64
+
+
+# ---------------------------------------------------------------------------
+# Posit dtypes — now enabled for process().
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", ["posit_full", "tiny_posit"])
+def test_iir_posit_process(dtype):
+    filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+    sig = _sine(300.0)
+    ref = filt.process(sig, dtype="reference")
+    out = filt.process(sig, dtype=dtype)
+    assert out.shape == ref.shape
+    # Posit arithmetic should produce a recognizably similar result to reference.
+    # posit<8,2> (tiny_posit) is quite lossy — allow a generous bound.
+    err = np.max(np.abs(ref - out)) / (np.max(np.abs(ref)) + 1e-12)
+    assert err < 0.5, f"{dtype} relative error too large: {err}"
+
+
+# ---------------------------------------------------------------------------
+# Extended diagnostics on IIRFilter.
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnostics:
+    def test_stability_margin_stable_filter(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        # Butterworth is always stable; margin = 1 - max|pole| > 0
+        assert filt.stability_margin() > 0.0
+
+    def test_condition_number_finite(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        cn = filt.condition_number(num_freqs=64)
+        assert np.isfinite(cn)
+        assert cn > 0.0
+
+    def test_worst_case_sensitivity_finite(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        s = filt.worst_case_sensitivity()
+        assert np.isfinite(s)
+        assert s >= 0.0
+
+    def test_pole_displacement_reference_is_zero(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        assert filt.pole_displacement("reference") == 0.0
+
+    def test_pole_displacement_half_positive(self):
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        # Half precision stores fewer coefficient bits, so poles must move.
+        d = filt.pole_displacement("half")
+        assert d > 0.0
+        # But should still be small (filter is not marginally stable).
+        assert d < 0.01
+
+    def test_higher_order_filter_has_larger_condition(self):
+        # Higher-order cascades are more sensitive to coefficient perturbation.
+        low = mpdsp.butterworth_lowpass(order=2, sample_rate=SAMPLE_RATE, cutoff=500.0)
+        high = mpdsp.butterworth_lowpass(order=10, sample_rate=SAMPLE_RATE, cutoff=500.0)
+        assert high.condition_number(num_freqs=64) > low.condition_number(num_freqs=64)
+
+
+# ---------------------------------------------------------------------------
+# FIR filters.
+# ---------------------------------------------------------------------------
+
+
+class TestFIRDesign:
+    def test_lowpass_design_shape(self):
+        f = mpdsp.fir_lowpass(num_taps=51, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        assert isinstance(f, mpdsp.FIRFilter)
+        assert f.num_taps() == 51
+        c = f.coefficients()
+        assert c.shape == (51,)
+        assert c.dtype == np.float64
+
+    def test_highpass_dc_rejects(self):
+        f = mpdsp.fir_highpass(num_taps=51, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        h = f.frequency_response(np.array([0.0, 0.45]))
+        assert np.abs(h[0]) < 0.05
+        assert np.abs(h[1]) > 0.5
+
+    def test_lowpass_passes_dc_rejects_high(self):
+        f = mpdsp.fir_lowpass(num_taps=51, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        h = f.frequency_response(np.array([0.0, 0.45]))
+        assert abs(np.abs(h[0]) - 1.0) < 0.05
+        assert np.abs(h[1]) < 0.05
+
+    def test_bandpass_peaks_between_bounds(self):
+        f = mpdsp.fir_bandpass(num_taps=101, sample_rate=SAMPLE_RATE,
+                                f_low=800.0, f_high=1600.0)
+        freqs = np.array([100.0, 1200.0, 3500.0]) / SAMPLE_RATE
+        mag = np.abs(f.frequency_response(freqs))
+        assert mag[1] > mag[0]
+        assert mag[1] > mag[2]
+
+    def test_bandstop_notches_center(self):
+        f = mpdsp.fir_bandstop(num_taps=101, sample_rate=SAMPLE_RATE,
+                                f_low=800.0, f_high=1600.0)
+        freqs = np.array([100.0, 1200.0, 3500.0]) / SAMPLE_RATE
+        mag = np.abs(f.frequency_response(freqs))
+        assert mag[1] < mag[0]
+        assert mag[1] < mag[2]
+
+    def test_fir_filter_from_explicit_coefficients(self):
+        # Unity-impulse taps => identity filter.
+        taps = np.zeros(11, dtype=np.float64)
+        taps[0] = 1.0
+        f = mpdsp.fir_filter(taps)
+        assert f.num_taps() == 11
+        sig = _sine(300.0)
+        y = f.process(sig)
+        # First sample in == first sample out (no delay for zero-position tap).
+        assert abs(y[0] - sig[0]) < 1e-12
+
+    def test_impulse_response_matches_taps(self):
+        f = mpdsp.fir_lowpass(num_taps=21, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        ir = f.impulse_response(21)
+        np.testing.assert_allclose(ir, f.coefficients())
+
+    def test_impulse_response_padded_with_zeros(self):
+        f = mpdsp.fir_lowpass(num_taps=21, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        ir = f.impulse_response(30)
+        assert ir.shape == (30,)
+        np.testing.assert_allclose(ir[:21], f.coefficients())
+        np.testing.assert_array_equal(ir[21:], 0.0)
+
+    def test_windows_accepts_kaiser(self):
+        # Kaiser requires a beta parameter; the binding accepts it as
+        # kaiser_beta and passes it through to the window.
+        f = mpdsp.fir_lowpass(num_taps=51, sample_rate=SAMPLE_RATE,
+                              cutoff=1000.0, window="kaiser", kaiser_beta=6.0)
+        h = f.frequency_response(np.array([0.0]))
+        assert abs(np.abs(h[0]) - 1.0) < 0.05
+
+    def test_windows_rejects_unknown(self):
+        with pytest.raises(ValueError):
+            mpdsp.fir_lowpass(num_taps=51, sample_rate=SAMPLE_RATE,
+                              cutoff=1000.0, window="not_a_window")
+
+    def test_invalid_num_taps_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.fir_lowpass(num_taps=0, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+
+    def test_bandpass_requires_ordered_frequencies(self):
+        with pytest.raises(ValueError):
+            mpdsp.fir_bandpass(num_taps=51, sample_rate=SAMPLE_RATE,
+                                f_low=1600.0, f_high=800.0)
+
+
+class TestFIRProcessing:
+    def test_process_signal_shape(self):
+        f = mpdsp.fir_lowpass(num_taps=51, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        sig = _sine(200.0)
+        y = f.process(sig)
+        assert y.shape == sig.shape
+        assert y.dtype == np.float64
+
+    def test_lowpass_rejects_high_freq(self):
+        f = mpdsp.fir_lowpass(num_taps=101, sample_rate=SAMPLE_RATE, cutoff=500.0)
+        low = _sine(100.0)
+        high = _sine(3000.0)
+        # Skip group-delay transient
+        skip = 200
+        y_low = f.process(low)[skip:]
+        y_high = f.process(high)[skip:]
+        assert np.max(np.abs(y_low)) > 0.8
+        assert np.max(np.abs(y_high)) < 0.1
+
+    @pytest.mark.parametrize("dtype", ["gpu_baseline", "half", "cf24", "posit_full"])
+    def test_process_dispatch_works(self, dtype):
+        f = mpdsp.fir_lowpass(num_taps=51, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        sig = _sine(300.0)
+        ref = f.process(sig, dtype="reference")
+        out = f.process(sig, dtype=dtype)
+        assert out.shape == ref.shape
+        # Reduced precision should differ from reference but still be close.
+        err = np.max(np.abs(ref - out)) / (np.max(np.abs(ref)) + 1e-12)
+        assert err < 0.5
+
+
+# ---------------------------------------------------------------------------
+# Python helpers in mpdsp.filters.
+# ---------------------------------------------------------------------------
+
+
+class TestFilterHelpers:
+    def test_compare_filters_runs_across_dtypes(self):
+        from mpdsp.filters import compare_filters
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        sig = _sine(300.0)
+        df = compare_filters(filt, sig, dtypes=["reference", "gpu_baseline", "half"])
+        # Accept either pandas.DataFrame or list-of-dicts depending on pandas
+        # availability.
+        rows = df.to_dict("records") if hasattr(df, "to_dict") else df
+        by_dtype = {r["dtype"]: r for r in rows}
+        assert set(by_dtype.keys()) == {"reference", "gpu_baseline", "half"}
+        # Reference compared to itself: SQNR is capped high, error is 0.
+        ref_row = by_dtype["reference"]
+        assert ref_row["max_abs_error"] == 0.0
+        # Reduced dtypes should have finite SQNR and positive error.
+        assert np.isfinite(by_dtype["half"]["sqnr_db"])
+        assert by_dtype["half"]["max_abs_error"] > 0.0
+
+    def test_compare_filters_on_fir(self):
+        from mpdsp.filters import compare_filters
+        f = mpdsp.fir_lowpass(num_taps=51, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        sig = _sine(300.0)
+        df = compare_filters(f, sig, dtypes=["reference", "gpu_baseline"])
+        rows = df.to_dict("records") if hasattr(df, "to_dict") else df
+        assert {r["dtype"] for r in rows} == {"reference", "gpu_baseline"}
+
+    def test_plot_filter_comparison_returns_figure(self):
+        pytest.importorskip("matplotlib")
+        from mpdsp.filters import plot_filter_comparison
+        import matplotlib
+        matplotlib.use("Agg")  # headless
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        fig = plot_filter_comparison(filt, num_freqs=64,
+                                     sample_rate=SAMPLE_RATE)
+        # Three subplots for IIR (magnitude, phase, pole-zero)
+        assert len(fig.axes) == 3
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+
+    def test_plot_filter_comparison_fir_has_two_axes(self):
+        pytest.importorskip("matplotlib")
+        from mpdsp.filters import plot_filter_comparison
+        import matplotlib
+        matplotlib.use("Agg")
+        f = mpdsp.fir_lowpass(num_taps=31, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        fig = plot_filter_comparison(f, num_freqs=64, sample_rate=SAMPLE_RATE)
+        # FIR: magnitude + phase (no pole-zero)
+        assert len(fig.axes) == 2
+        import matplotlib.pyplot as plt
+        plt.close(fig)


### PR DESCRIPTION
## Summary
Closes most of the remaining Phase 4 scope under issue #5. Four related pieces of work, all sharing the existing `PyIIRFilter` / `IIRFilter` API and pattern:

1. **FIR filter bindings** — a new `PyFIRFilter` / `mpdsp.FIRFilter` class + five design functions.
2. **Posit dtypes enabled for `process()`** — the earlier deferral is lifted; `posit_full` and `tiny_posit` now dispatch to real processing paths.
3. **Extended diagnostics on `IIRFilter`** — `stability_margin`, `condition_number`, `worst_case_sensitivity`, `pole_displacement(dtype)`.
4. **Python helpers in `mpdsp/filters.py`** — `compare_filters` (DataFrame of SQNR/error per dtype) and `plot_filter_comparison` (magnitude + phase + pole-zero).

Only remaining item from issue #5 after this lands: the two notebooks (`02_iir_precision.ipynb`, `03_fir_and_windows.ipynb`).

## FIR bindings

### Design functions
| Function | Signature |
|----------|-----------|
| `fir_filter` | `(coefficients: ndarray) → FIRFilter` |
| `fir_lowpass` | `(num_taps, sample_rate, cutoff, window="hamming", kaiser_beta=8.6)` |
| `fir_highpass` | `(num_taps, sample_rate, cutoff, window="hamming", ...)` |
| `fir_bandpass` | `(num_taps, sample_rate, f_low, f_high, window="hamming", ...)` |
| `fir_bandstop` | `(num_taps, sample_rate, f_low, f_high, window="hamming", ...)` |

Windows supported: hamming, hanning, blackman, kaiser, rectangular, flat_top.
Bandstop is implemented via spectral inversion of a bandpass (upstream `sw::dsp::design_fir_bandstop` doesn't exist).

### FIRFilter methods
`num_taps`, `coefficients`, `impulse_response(length)`, `frequency_response(freqs)`, `process(signal, dtype)`.
Same dtype dispatch table as IIR; a fresh `FIRFilter<T,T,S>` is instantiated per `process()` call so the Python object stays stateless across calls.

## Posit dtypes

- `posit_full` → state=`posit<32,2>`, sample=`posit<16,1>`
- `tiny_posit` → state=sample=`posit<8,2>`

The previous `throw std::invalid_argument(\"posit dtypes for filter.process are not yet enabled\")` guard is removed. Posit types satisfy `DspField`, so the existing `process_typed<State, Sample>` template instantiates cleanly.

## Diagnostics

All four analyses come from `sw::dsp::analysis::` in the peer library:

| Method | Returns | Source |
|--------|---------|--------|
| `stability_margin()` | `1 - max(|pole|)` | `analysis/stability.hpp` |
| `condition_number(num_freqs=256)` | worst-case `|dH|/|H|` per coef perturbation | `analysis/condition.hpp` |
| `worst_case_sensitivity(eps=1e-8)` | max `|d(pole_radius)/d(coeff)|` | `analysis/sensitivity.hpp` |
| `pole_displacement(dtype)` | max pole shift when coefs are quantized through dtype | `analysis/sensitivity.hpp` |

`pole_displacement` works by round-tripping each coefficient through the target type (`double → T → double`) to produce a quantized `Cascade<double>`, then delegating to `sw::dsp::pole_displacement`. This captures the dominant quantization effect (coefficient precision); pole extraction itself stays in double precision on both cascades.

## Python helpers

`mpdsp.compare_filters(filt, signal, dtypes=None)`:
- Processes signal at each dtype, measures SQNR + max abs/rel error vs reference.
- Returns `pandas.DataFrame` if pandas is installed, else list-of-dicts.
- Failed dtypes record the exception message and NaN metrics.

`mpdsp.plot_filter_comparison(filt, ...)`:
- Magnitude + phase subplots always; adds a pole-zero subplot for `IIRFilter`.
- Optional per-dtype SQNR annotation if `signal` and `dtypes` are provided.

## Test Results
| Build | Filter tests | Full suite |
|-------|--------------|------------|
| gcc | 100/100 pass | 150/150 pass |
| clang | 100/100 pass | 150/150 pass |

(Up from 67/67 and 117/117 after #18 merged.)

New coverage: posit dispatch paths, all 4 diagnostics (including higher-order condition growth), FIR design + processing with all 4 response types + explicit-coefficient construction + kaiser window + unknown-window rejection, and the Python helpers (`compare_filters` on both IIR and FIR; `plot_filter_comparison` with matplotlib Agg backend).

## Follow-up (final Phase 4 item still open under #5)
- `02_iir_precision.ipynb` and `03_fir_and_windows.ipynb` — notebook walkthroughs exercising `compare_filters` / `plot_filter_comparison` across the mixed-precision dtype sweep.

## Test plan
- [x] Fast CI passes (gcc + clang + MSVC + Apple Clang)
- [x] Promote to ready and merge once green

Relates to #5

Generated with [Claude Code](https://claude.com/claude-code)