### PR TITLE
feat(conditioning): PeakEnvelope scaffold with stateful dtype dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ nanobind_add_module(_core
   src/quantization_bindings.cpp
   src/spectral_bindings.cpp
   src/filter_bindings.cpp
+  src/conditioning_bindings.cpp
 )
 target_link_libraries(_core PRIVATE sw_dsp)
 

--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -43,6 +43,8 @@ try:
         FIRFilter, fir_filter,
         fir_lowpass, fir_highpass,
         fir_bandpass, fir_bandstop,
+        # Conditioning
+        PeakEnvelope,
         # Introspection
         available_dtypes,
     )

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -12,6 +12,7 @@ void bind_signals(nb::module_& m);
 void bind_quantization(nb::module_& m);
 void bind_spectral(nb::module_& m);
 void bind_filters(nb::module_& m);
+void bind_conditioning(nb::module_& m);
 
 NB_MODULE(_core, m) {
 	m.doc() = "mpdsp C++ core: mixed-precision DSP bindings via nanobind";
@@ -20,4 +21,5 @@ NB_MODULE(_core, m) {
 	bind_quantization(m);
 	bind_spectral(m);
 	bind_filters(m);
+	bind_conditioning(m);
 }

--- a/src/conditioning_bindings.cpp
+++ b/src/conditioning_bindings.cpp
@@ -1,0 +1,152 @@
+// conditioning_bindings.cpp: stateful signal-conditioning bindings.
+//
+// Establishes the stateful-object pattern used by Phase 5:
+//   - dtype is a construction-time parameter (not per-call)
+//   - internal type-erased IEnvelope interface holds a concrete
+//     sw::dsp::PeakEnvelope<T> for the chosen dtype
+//   - Python sees one class (mpdsp.PeakEnvelope); NumPy I/O stays in double
+//
+// Starts with PeakEnvelope. RMSEnvelope, Compressor, AGC follow the same
+// template.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
+
+#include <sw/dsp/conditioning/envelope.hpp>
+
+#include "types.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace nb = nanobind;
+
+namespace {
+
+using np_f64    = nb::ndarray<nb::numpy, double>;
+using np_f64_ro = nb::ndarray<nb::numpy, const double, nb::ndim<1>>;
+
+static np_f64 make_f64_array(std::size_t n, double*& out_ptr) {
+	auto* data = new double[n];
+	out_ptr = data;
+	nb::capsule owner(data, [](void* p) noexcept { delete[] static_cast<double*>(p); });
+	std::size_t shape[1] = { n };
+	return np_f64(data, 1, shape, owner);
+}
+
+// Type-erased interface. Python always sees double-precision I/O; the
+// internal arithmetic happens in whatever T the concrete impl chose.
+struct IPeakEnvelopeImpl {
+	virtual ~IPeakEnvelopeImpl() = default;
+	virtual void setup(double sample_rate, double attack_ms, double release_ms) = 0;
+	virtual double process(double input) = 0;
+	virtual void process_block(const double* in, double* out, std::size_t n) = 0;
+	virtual double value() const = 0;
+	virtual void reset() = 0;
+};
+
+template <typename T>
+struct PeakEnvelopeImpl : IPeakEnvelopeImpl {
+	sw::dsp::PeakEnvelope<T> inner;
+	void setup(double sr, double a, double r) override { inner.setup(sr, a, r); }
+	double process(double input) override {
+		return static_cast<double>(inner.process(static_cast<T>(input)));
+	}
+	void process_block(const double* in, double* out, std::size_t n) override {
+		for (std::size_t i = 0; i < n; ++i) {
+			out[i] = static_cast<double>(inner.process(static_cast<T>(in[i])));
+		}
+	}
+	double value() const override { return static_cast<double>(inner.value()); }
+	void reset() override { inner.reset(); }
+};
+
+static std::unique_ptr<IPeakEnvelopeImpl>
+make_peak_envelope_impl(mpdsp::ArithConfig config) {
+	using mpdsp::ArithConfig;
+	using mpdsp::cf24;
+	using mpdsp::half_;
+	using mpdsp::p16;
+	using mpdsp::p32;
+	using tiny_posit_t = sw::universal::posit<8, 2>;
+	switch (config) {
+	case ArithConfig::reference:    return std::make_unique<PeakEnvelopeImpl<double>>();
+	case ArithConfig::gpu_baseline: return std::make_unique<PeakEnvelopeImpl<float>>();
+	case ArithConfig::ml_hw:        return std::make_unique<PeakEnvelopeImpl<half_>>();
+	case ArithConfig::cf24_config:  return std::make_unique<PeakEnvelopeImpl<cf24>>();
+	case ArithConfig::half_config:  return std::make_unique<PeakEnvelopeImpl<half_>>();
+	case ArithConfig::posit_full:   return std::make_unique<PeakEnvelopeImpl<p32>>();
+	case ArithConfig::tiny_posit:   return std::make_unique<PeakEnvelopeImpl<tiny_posit_t>>();
+	}
+	return std::make_unique<PeakEnvelopeImpl<double>>();
+}
+
+} // namespace
+
+// PyPeakEnvelope: stateful envelope follower with construction-time dtype.
+class PyPeakEnvelope {
+public:
+	PyPeakEnvelope(double sample_rate, double attack_ms, double release_ms,
+	               const std::string& dtype) {
+		if (!(sample_rate > 0.0)) {
+			throw std::invalid_argument(
+				"PeakEnvelope: sample_rate must be positive");
+		}
+		if (!(attack_ms > 0.0) || !(release_ms > 0.0)) {
+			throw std::invalid_argument(
+				"PeakEnvelope: attack_ms and release_ms must be positive");
+		}
+		impl_ = make_peak_envelope_impl(mpdsp::parse_config(dtype));
+		impl_->setup(sample_rate, attack_ms, release_ms);
+		dtype_ = dtype;
+	}
+
+	double process(double input) { return impl_->process(input); }
+
+	np_f64 process_block(np_f64_ro signal) {
+		std::size_t n = signal.shape(0);
+		double* out_ptr = nullptr;
+		auto arr = make_f64_array(n, out_ptr);
+		impl_->process_block(signal.data(), out_ptr, n);
+		return arr;
+	}
+
+	double value() const { return impl_->value(); }
+
+	void reset() { impl_->reset(); }
+
+	const std::string& dtype() const { return dtype_; }
+
+private:
+	std::unique_ptr<IPeakEnvelopeImpl> impl_;
+	std::string dtype_;
+};
+
+void bind_conditioning(nb::module_& m) {
+	nb::class_<PyPeakEnvelope>(m, "PeakEnvelope",
+		"Peak envelope follower with exponential attack and release.\n\n"
+		"Tracks |x[n]| through a one-pole filter whose time constant switches "
+		"between attack_ms (when rising) and release_ms (when falling). State "
+		"is kept across process() calls; use reset() to clear.")
+		.def(nb::init<double, double, double, const std::string&>(),
+		     nb::arg("sample_rate"), nb::arg("attack_ms"), nb::arg("release_ms"),
+		     nb::arg("dtype") = "reference",
+		     "Construct an envelope follower. dtype selects the arithmetic "
+		     "used internally (see available_dtypes).")
+		.def("process", &PyPeakEnvelope::process,
+		     nb::arg("input"),
+		     "Process a single sample. Returns the updated envelope value.")
+		.def("process_block", &PyPeakEnvelope::process_block,
+		     nb::arg("signal"),
+		     "Process a 1D NumPy float64 signal. Returns the envelope trace "
+		     "(same length as the input).")
+		.def("value", &PyPeakEnvelope::value,
+		     "Current envelope value without consuming a sample.")
+		.def("reset", &PyPeakEnvelope::reset,
+		     "Clear the internal envelope state to zero.")
+		.def_prop_ro("dtype", &PyPeakEnvelope::dtype,
+		     "The arithmetic configuration selected at construction.");
+}

--- a/src/conditioning_bindings.cpp
+++ b/src/conditioning_bindings.cpp
@@ -27,12 +27,20 @@ namespace nb = nanobind;
 namespace {
 
 using np_f64    = nb::ndarray<nb::numpy, double>;
-using np_f64_ro = nb::ndarray<nb::numpy, const double, nb::ndim<1>>;
+// c_contig: force nanobind to deliver a C-contiguous buffer (copying if the
+// caller passed a slice or non-contiguous view). Without this, signal.data()
+// would walk the original memory linearly and produce wrong results on any
+// strided input such as sig[::2].
+using np_f64_ro = nb::ndarray<nb::numpy, const double, nb::ndim<1>, nb::c_contig>;
 
 static np_f64 make_f64_array(std::size_t n, double*& out_ptr) {
-	auto* data = new double[n];
-	out_ptr = data;
+	auto buf = std::unique_ptr<double[]>(new double[n]);
+	double* data = buf.get();
 	nb::capsule owner(data, [](void* p) noexcept { delete[] static_cast<double*>(p); });
+	// Ownership transfers to the capsule only after it has been constructed
+	// successfully, so a throw from the capsule ctor won't leak the buffer.
+	buf.release();
+	out_ptr = data;
 	std::size_t shape[1] = { n };
 	return np_f64(data, 1, shape, owner);
 }
@@ -81,7 +89,9 @@ make_peak_envelope_impl(mpdsp::ArithConfig config) {
 	case ArithConfig::posit_full:   return std::make_unique<PeakEnvelopeImpl<p32>>();
 	case ArithConfig::tiny_posit:   return std::make_unique<PeakEnvelopeImpl<tiny_posit_t>>();
 	}
-	return std::make_unique<PeakEnvelopeImpl<double>>();
+	// If a new ArithConfig enumerator is added without extending the switch,
+	// surface it instead of silently dispatching to double.
+	throw std::invalid_argument("PeakEnvelope: unsupported ArithConfig");
 }
 
 } // namespace
@@ -110,7 +120,15 @@ public:
 		std::size_t n = signal.shape(0);
 		double* out_ptr = nullptr;
 		auto arr = make_f64_array(n, out_ptr);
-		impl_->process_block(signal.data(), out_ptr, n);
+		const double* in_ptr = signal.data();
+		// The processing loop touches no Python state, so drop the GIL
+		// across the hot path. We can't use nb::call_guard at the .def()
+		// site because make_f64_array creates Python objects (capsule +
+		// ndarray) — those require the GIL held.
+		{
+			nb::gil_scoped_release release;
+			impl_->process_block(in_ptr, out_ptr, n);
+		}
 		return arr;
 	}
 
@@ -142,7 +160,8 @@ void bind_conditioning(nb::module_& m) {
 		.def("process_block", &PyPeakEnvelope::process_block,
 		     nb::arg("signal"),
 		     "Process a 1D NumPy float64 signal. Returns the envelope trace "
-		     "(same length as the input).")
+		     "(same length as the input). The per-sample loop releases the "
+		     "GIL internally so other Python threads can run.")
 		.def("value", &PyPeakEnvelope::value,
 		     "Current envelope value without consuming a sample.")
 		.def("reset", &PyPeakEnvelope::reset,

--- a/tests/test_conditioning.py
+++ b/tests/test_conditioning.py
@@ -1,0 +1,164 @@
+"""Tests for signal-conditioning bindings (scaffold: PeakEnvelope)."""
+
+import numpy as np
+import pytest
+
+mpdsp = pytest.importorskip("mpdsp", reason="mpdsp C++ module not built")
+if not mpdsp.HAS_CORE:
+    pytest.skip("mpdsp._core not available", allow_module_level=True)
+
+
+SAMPLE_RATE = 8000.0
+
+
+def _step_signal(n=1024, onset=128, amplitude=1.0):
+    """Unit-step-like signal: zeros, then a constant-amplitude tone."""
+    t = np.arange(n) / SAMPLE_RATE
+    env = np.where(np.arange(n) < onset, 0.0, amplitude)
+    return env * np.sin(2 * np.pi * 200 * t)
+
+
+class TestPeakEnvelopeConstruction:
+    def test_default_dtype_is_reference(self):
+        env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=5.0, release_ms=50.0)
+        assert env.dtype == "reference"
+
+    def test_dtype_is_stored(self):
+        env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=5.0, release_ms=50.0,
+                                  dtype="half")
+        assert env.dtype == "half"
+
+    def test_invalid_sample_rate_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.PeakEnvelope(sample_rate=-1.0,
+                                attack_ms=5.0, release_ms=50.0)
+
+    def test_non_positive_attack_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                attack_ms=0.0, release_ms=50.0)
+
+    def test_unknown_dtype_raises(self):
+        with pytest.raises(Exception):
+            mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                attack_ms=5.0, release_ms=50.0,
+                                dtype="not_a_dtype")
+
+
+class TestPeakEnvelopeBehavior:
+    def test_process_single_sample_returns_float(self):
+        env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=5.0, release_ms=50.0)
+        y = env.process(1.0)
+        assert isinstance(y, float)
+
+    def test_initial_value_is_zero(self):
+        env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=5.0, release_ms=50.0)
+        assert env.value() == 0.0
+
+    def test_state_persists_across_calls(self):
+        env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=5.0, release_ms=50.0)
+        for _ in range(100):
+            env.process(1.0)
+        # After a burst of ones, envelope should have risen above zero
+        assert env.value() > 0.1
+
+    def test_reset_clears_state(self):
+        env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=5.0, release_ms=50.0)
+        for _ in range(200):
+            env.process(1.0)
+        assert env.value() > 0.1
+        env.reset()
+        assert env.value() == 0.0
+
+    def test_process_block_returns_correct_shape(self):
+        env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=5.0, release_ms=50.0)
+        sig = _step_signal()
+        out = env.process_block(sig)
+        assert out.shape == sig.shape
+        assert out.dtype == np.float64
+
+    def test_envelope_tracks_step_onset(self):
+        env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=1.0, release_ms=100.0)
+        sig = _step_signal(n=2048, onset=256, amplitude=1.0)
+        out = env.process_block(sig)
+        # Before onset: envelope stays near zero
+        assert np.max(np.abs(out[:200])) < 0.05
+        # After onset with a few attack time-constants: envelope rises
+        # toward the peak amplitude (1.0).
+        assert out[1000] > 0.5
+
+    def test_attack_faster_than_release(self):
+        # With short attack and long release, envelope should rise quickly
+        # and decay slowly. Compare attack-time-constant region to release.
+        env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=1.0, release_ms=100.0)
+        # 512 samples @ 8 kHz = 64 ms. Burst of amplitude 1 for 256 samples,
+        # then zero for the rest. By sample 256 we should be near 1.0; by
+        # sample 400 we should still be well above 0.1 (slow release).
+        n = 768
+        sig = np.zeros(n)
+        sig[:256] = 1.0
+        out = env.process_block(sig)
+        assert out[200] > 0.8      # attack has converged
+        assert out[400] > 0.1      # release still holding (long decay)
+
+
+class TestPeakEnvelopeDtypeDispatch:
+    @pytest.mark.parametrize("dtype", [
+        "reference", "gpu_baseline", "ml_hw", "cf24", "half",
+        "posit_full", "tiny_posit",
+    ])
+    def test_process_runs_under_each_dtype(self, dtype):
+        """Every dtype must at least instantiate, process, and return
+        correctly-shaped output — even if arithmetic is lossy enough that
+        tracking itself isn't meaningful at that precision."""
+        env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=5.0, release_ms=50.0,
+                                  dtype=dtype)
+        sig = _step_signal(n=512)
+        out = env.process_block(sig)
+        assert out.shape == sig.shape
+        assert out.dtype == np.float64
+
+    @pytest.mark.parametrize("dtype", [
+        "reference", "gpu_baseline", "ml_hw", "cf24", "half", "posit_full",
+    ])
+    def test_envelope_tracks_step_under_dtype(self, dtype):
+        """All dtypes with enough precision to represent the smoothing
+        coefficient (1 - exp(-1/(release_ms*fs))) should track the step.
+
+        tiny_posit (posit<8,2>) is deliberately excluded: with 5 ms attack /
+        50 ms release at 8 kHz the release coefficient is ~0.9975 and
+        (1 - 0.9975) = 0.0025 rounds to 0 in posit<8,2>, pinning the
+        envelope to zero. That's a precision characteristic, not a bug;
+        it's the kind of thing mixed-precision research is supposed to
+        surface.
+        """
+        env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=5.0, release_ms=50.0,
+                                  dtype=dtype)
+        sig = _step_signal(n=512)
+        out = env.process_block(sig)
+        assert np.max(out[256:]) > 0.1
+
+    def test_reduced_precision_tracks_reference_approximately(self):
+        ref = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=5.0, release_ms=50.0,
+                                  dtype="reference")
+        alt = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                  attack_ms=5.0, release_ms=50.0,
+                                  dtype="half")
+        sig = _step_signal(n=1024)
+        r = ref.process_block(sig)
+        a = alt.process_block(sig)
+        # Envelope shapes agree to within a reasonable low-precision bound.
+        err = np.max(np.abs(r - a)) / (np.max(np.abs(r)) + 1e-12)
+        assert err < 0.1

--- a/tests/test_conditioning.py
+++ b/tests/test_conditioning.py
@@ -30,9 +30,10 @@ class TestPeakEnvelopeConstruction:
                                   dtype="half")
         assert env.dtype == "half"
 
-    def test_invalid_sample_rate_raises(self):
+    @pytest.mark.parametrize("bad_sr", [-1.0, 0.0])
+    def test_invalid_sample_rate_raises(self, bad_sr):
         with pytest.raises(ValueError):
-            mpdsp.PeakEnvelope(sample_rate=-1.0,
+            mpdsp.PeakEnvelope(sample_rate=bad_sr,
                                 attack_ms=5.0, release_ms=50.0)
 
     def test_non_positive_attack_raises(self):
@@ -40,8 +41,15 @@ class TestPeakEnvelopeConstruction:
             mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
                                 attack_ms=0.0, release_ms=50.0)
 
+    @pytest.mark.parametrize("bad_release", [0.0, -1.0])
+    def test_non_positive_release_raises(self, bad_release):
+        with pytest.raises(ValueError):
+            mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                attack_ms=5.0, release_ms=bad_release)
+
     def test_unknown_dtype_raises(self):
-        with pytest.raises(Exception):
+        # parse_config throws std::invalid_argument -> ValueError in Python.
+        with pytest.raises(ValueError):
             mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
                                 attack_ms=5.0, release_ms=50.0,
                                 dtype="not_a_dtype")
@@ -83,6 +91,24 @@ class TestPeakEnvelopeBehavior:
         out = env.process_block(sig)
         assert out.shape == sig.shape
         assert out.dtype == np.float64
+
+    def test_process_block_accepts_strided_input(self):
+        """A non-contiguous view (e.g. sig[::2]) must produce the same output
+        as feeding a contiguous copy. The c_contig constraint on the binding
+        asks nanobind to copy strided inputs transparently — this test pins
+        that behavior so a future relaxation of the constraint would fail
+        loudly rather than silently walk the underlying buffer linearly."""
+        sig = _step_signal(n=2048, onset=256)
+        view = sig[::2]
+        copy = view.copy()
+
+        env_view = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                       attack_ms=5.0, release_ms=50.0)
+        env_copy = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,
+                                       attack_ms=5.0, release_ms=50.0)
+        out_view = env_view.process_block(view)
+        out_copy = env_copy.process_block(copy)
+        np.testing.assert_array_equal(out_view, out_copy)
 
     def test_envelope_tracks_step_onset(self):
         env = mpdsp.PeakEnvelope(sample_rate=SAMPLE_RATE,


### PR DESCRIPTION
## Summary
- First slice of Phase 5 (issue #6). Intentionally small: only `PeakEnvelope`, so the stateful-object binding pattern can be reviewed before replicating it to `RMSEnvelope` / `Compressor` / `AGC` and then the larger estimation classes.
- Stateful objects have different binding requirements than the stateless IIR/FIR filters from Phase 4: dtype choice is semantically different when state persists across calls. This PR pins down the decisions once; the remaining conditioning classes reuse the pattern.

## Pattern codified by this PR

1. **dtype is construction-time, not per-call.** `PeakEnvelope(sr, attack_ms, release_ms, dtype="...")` carries one concrete `sw::dsp::PeakEnvelope<T>` for its lifetime. Matches the Kalman spec in the issue; gives unambiguous semantics for state that persists across `process()` calls.
2. **Type-erased `IPeakEnvelopeImpl` interface.** Abstract base + one `PeakEnvelopeImpl<T>` per dtype. Keeps `mpdsp.PeakEnvelope` a single concrete Python class and moves dispatch out of the per-sample hot loop.
3. **NumPy I/O stays in float64 at the Python boundary.** Internal arithmetic happens in `T`. Same convention Phase 4 settled on.
4. **API mirrors the issue spec**: `process(x) → float`, `process_block(signal) → NumPy float64`, `reset()`, `value()`, plus a read-only `dtype` property.

## Changes
- `src/conditioning_bindings.cpp` (new) — `PyPeakEnvelope` class + `bind_conditioning` registration (~135 lines).
- `src/bindings.cpp` — forward-declare and call `bind_conditioning`.
- `CMakeLists.txt` — add `src/conditioning_bindings.cpp` to `_core`.
- `python/mpdsp/__init__.py` — re-export `PeakEnvelope`.
- `tests/test_conditioning.py` (new) — 26 tests covering construction validation, state persistence, `reset`, step-onset tracking, attack-faster-than-release behavior, and dtype dispatch.

## Test Results
| Build | Conditioning tests | Full suite |
|-------|--------------------|------------|
| gcc | 26/26 pass | 176/176 pass |
| clang | 26/26 pass | 176/176 pass |

### Noteworthy test observation (documented inline)

`tiny_posit` (posit<8,2>) instantiates and executes but **can't meaningfully track** at 5 ms / 50 ms time constants — the release coefficient `(1 - exp(-1 / (50 ms · 8 kHz))) ≈ 0.0025` rounds to 0 in posit<8,2>, pinning the envelope at zero. Split the dtype tests:

- `test_process_runs_under_each_dtype` — all 7 dtypes, asserts shape/dtype only
- `test_envelope_tracks_step_under_dtype` — 6 dtypes (excludes tiny_posit), asserts real tracking

The *why* is in the docstring. This is the kind of precision-floor finding mixed-precision research is meant to surface.

## Follow-up (still open under issue #6)
- `RMSEnvelope` — same interface shape as `PeakEnvelope`, one fewer parameter
- `Compressor` — 7 parameters, same pattern, wraps an internal envelope
- `AGC` — uses `DspOrderedField` concept; need to verify tiny_posit conformance
- `KalmanFilter` — new territory: NumPy 2D matrix I/O for F/H/Q/R/P/B
- `LMSFilter`, `NLMSFilter`, `RLSFilter` — adaptive filters, `(output, error)` tuple return
- `python/mpdsp/estimation.py` helpers (`plot_kalman_tracking`, `plot_adaptive_convergence`)
- `notebooks/05_conditioning.ipynb`, `notebooks/06_estimation.ipynb`

## Test plan
- [x] Fast CI passes (gcc + clang + MSVC + Apple Clang)
- [x] Review the stateful-binding pattern before I replicate it

Relates to #6

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Introduced PeakEnvelope signal conditioning to the mpdsp package
  - Supports single-sample and block-based audio processing
  - Configurable attack and release time parameters
  - Multiple precision type support for flexible use cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->