### PR TITLE
feat(estimation): LMS / NLMS / RLS adaptive filter bindings

### DIFF
--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -47,6 +47,7 @@ try:
         PeakEnvelope, RMSEnvelope, Compressor, AGC,
         # Estimation
         KalmanFilter,
+        LMSFilter, NLMSFilter, RLSFilter,
         # Introspection
         available_dtypes,
     )

--- a/src/estimation_bindings.cpp
+++ b/src/estimation_bindings.cpp
@@ -8,8 +8,11 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
 
 #include <sw/dsp/estimation/kalman.hpp>
+#include <sw/dsp/estimation/lms.hpp>
+#include <sw/dsp/estimation/rls.hpp>
 
 #include "types.hpp"
 
@@ -17,6 +20,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 
 namespace nb = nanobind;
 
@@ -307,6 +311,219 @@ private:
 	std::string dtype_;
 };
 
+// ===========================================================================
+// Adaptive filters (LMS / NLMS / RLS)
+//
+// All three share the same Python-visible shape:
+//   .process(input, desired) -> (output, error) tuple
+//   .process_block(inputs, desireds) -> (outputs, errors) tuple of arrays
+//   .weights -> NumPy float64 array (read-only)
+//   .num_taps, .dtype, .last_error (read-only)
+//   .reset()
+//
+// Constructor parameters differ: LMS(num_taps, step_size),
+// NLMS(num_taps, step_size, epsilon), RLS(num_taps, lambda, delta).
+// ===========================================================================
+
+namespace {
+
+struct IAdaptiveFilter {
+	virtual ~IAdaptiveFilter() = default;
+	virtual std::size_t num_taps() const = 0;
+	virtual double last_error() const = 0;
+	virtual void process(double input, double desired,
+	                     double& out, double& err) = 0;
+	virtual void process_block(const double* xs, const double* ds,
+	                           double* out_y, double* out_e,
+	                           std::size_t n) = 0;
+	virtual np_f64 weights() = 0;
+	virtual void reset() = 0;
+};
+
+template <template <typename> class Filter, typename T>
+struct AdaptiveFilterImpl : IAdaptiveFilter {
+	Filter<T> inner;
+	template <typename... Args>
+	AdaptiveFilterImpl(Args&&... args) : inner(std::forward<Args>(args)...) {}
+
+	std::size_t num_taps() const override { return inner.num_taps(); }
+	double last_error() const override {
+		return static_cast<double>(inner.last_error());
+	}
+
+	void process(double input, double desired,
+	             double& out, double& err) override {
+		T y = inner.process(static_cast<T>(input), static_cast<T>(desired));
+		out = static_cast<double>(y);
+		err = static_cast<double>(inner.last_error());
+	}
+
+	void process_block(const double* xs, const double* ds,
+	                   double* out_y, double* out_e,
+	                   std::size_t n) override {
+		for (std::size_t i = 0; i < n; ++i) {
+			T y = inner.process(static_cast<T>(xs[i]),
+			                    static_cast<T>(ds[i]));
+			out_y[i] = static_cast<double>(y);
+			out_e[i] = static_cast<double>(inner.last_error());
+		}
+	}
+
+	np_f64 weights() override {
+		// Use non-const accessor where available; const otherwise. All three
+		// filters expose at least a const weights() accessor.
+		const auto& w = inner.weights();
+		std::size_t n = w.size();
+		double* out_ptr = nullptr;
+		auto arr = make_f64_array(n, out_ptr);
+		for (std::size_t i = 0; i < n; ++i) {
+			out_ptr[i] = static_cast<double>(w[i]);
+		}
+		return arr;
+	}
+
+	void reset() override { inner.reset(); }
+};
+
+// Construct an adaptive-filter impl of the requested dtype, forwarding
+// constructor arguments (num_taps + filter-specific params) to the T-typed
+// inner. Mirrors make_impl_for_dtype but with the double-valued constructor
+// arguments cast to T at the call site.
+template <template <typename> class Filter, typename... DoubleArgs>
+static std::unique_ptr<IAdaptiveFilter>
+make_adaptive_impl(mpdsp::ArithConfig config, const char* cls,
+                   std::size_t num_taps, DoubleArgs... args) {
+	using mpdsp::ArithConfig;
+	using mpdsp::cf24;
+	using mpdsp::half_;
+	using mpdsp::p32;
+	using tiny_posit_t = sw::universal::posit<8, 2>;
+	switch (config) {
+	case ArithConfig::reference:
+		return std::make_unique<AdaptiveFilterImpl<Filter, double>>(
+			num_taps, static_cast<double>(args)...);
+	case ArithConfig::gpu_baseline:
+		return std::make_unique<AdaptiveFilterImpl<Filter, float>>(
+			num_taps, static_cast<float>(args)...);
+	case ArithConfig::ml_hw:
+		return std::make_unique<AdaptiveFilterImpl<Filter, half_>>(
+			num_taps, static_cast<half_>(args)...);
+	case ArithConfig::cf24_config:
+		return std::make_unique<AdaptiveFilterImpl<Filter, cf24>>(
+			num_taps, static_cast<cf24>(args)...);
+	case ArithConfig::half_config:
+		return std::make_unique<AdaptiveFilterImpl<Filter, half_>>(
+			num_taps, static_cast<half_>(args)...);
+	case ArithConfig::posit_full:
+		return std::make_unique<AdaptiveFilterImpl<Filter, p32>>(
+			num_taps, static_cast<p32>(args)...);
+	case ArithConfig::tiny_posit:
+		return std::make_unique<AdaptiveFilterImpl<Filter, tiny_posit_t>>(
+			num_taps, static_cast<tiny_posit_t>(args)...);
+	}
+	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
+}
+
+} // namespace
+
+// Shared Python wrapper logic for all three adaptive filters. Differs only
+// in how the underlying impl is constructed; delegate via CRTP-free helper.
+class PyAdaptiveFilter {
+public:
+	std::size_t num_taps() const { return impl_->num_taps(); }
+	double last_error() const { return impl_->last_error(); }
+
+	std::tuple<double, double> process(double input, double desired) {
+		double y, e;
+		impl_->process(input, desired, y, e);
+		return {y, e};
+	}
+
+	std::tuple<np_f64, np_f64> process_block(np_f64_ro inputs,
+	                                         np_f64_ro desireds) {
+		std::size_t n = inputs.shape(0);
+		if (desireds.shape(0) != n) {
+			throw std::invalid_argument(
+				"process_block: inputs and desireds must have the same length");
+		}
+		double* out_y = nullptr;
+		double* out_e = nullptr;
+		auto y_arr = make_f64_array(n, out_y);
+		auto e_arr = make_f64_array(n, out_e);
+		const double* xs = inputs.data();
+		const double* ds = desireds.data();
+		{
+			nb::gil_scoped_release release;
+			impl_->process_block(xs, ds, out_y, out_e, n);
+		}
+		return {std::move(y_arr), std::move(e_arr)};
+	}
+
+	np_f64 weights() { return impl_->weights(); }
+	void reset() { impl_->reset(); }
+	const std::string& dtype() const { return dtype_; }
+
+protected:
+	std::unique_ptr<IAdaptiveFilter> impl_;
+	std::string dtype_;
+};
+
+class PyLMSFilter : public PyAdaptiveFilter {
+public:
+	PyLMSFilter(std::size_t num_taps, double step_size,
+	            const std::string& dtype) {
+		if (num_taps == 0) {
+			throw std::invalid_argument(
+				"LMSFilter: num_taps must be > 0");
+		}
+		impl_ = make_adaptive_impl<sw::dsp::LMSFilter>(
+			mpdsp::parse_config(dtype), "LMSFilter", num_taps, step_size);
+		dtype_ = dtype;
+	}
+};
+
+class PyNLMSFilter : public PyAdaptiveFilter {
+public:
+	PyNLMSFilter(std::size_t num_taps, double step_size, double epsilon,
+	             const std::string& dtype) {
+		if (num_taps == 0) {
+			throw std::invalid_argument(
+				"NLMSFilter: num_taps must be > 0");
+		}
+		if (!(epsilon > 0.0)) {
+			throw std::invalid_argument(
+				"NLMSFilter: epsilon must be positive");
+		}
+		impl_ = make_adaptive_impl<sw::dsp::NLMSFilter>(
+			mpdsp::parse_config(dtype), "NLMSFilter",
+			num_taps, step_size, epsilon);
+		dtype_ = dtype;
+	}
+};
+
+class PyRLSFilter : public PyAdaptiveFilter {
+public:
+	PyRLSFilter(std::size_t num_taps, double forgetting_factor, double delta,
+	            const std::string& dtype) {
+		if (num_taps == 0) {
+			throw std::invalid_argument(
+				"RLSFilter: num_taps must be > 0");
+		}
+		if (!(forgetting_factor > 0.0) || forgetting_factor > 1.0) {
+			throw std::invalid_argument(
+				"RLSFilter: forgetting_factor must be in (0, 1]");
+		}
+		if (!(delta > 0.0)) {
+			throw std::invalid_argument(
+				"RLSFilter: delta must be positive");
+		}
+		impl_ = make_adaptive_impl<sw::dsp::RLSFilter>(
+			mpdsp::parse_config(dtype), "RLSFilter",
+			num_taps, forgetting_factor, delta);
+		dtype_ = dtype;
+	}
+};
+
 void bind_estimation(nb::module_& m) {
 	nb::class_<PyKalmanFilter>(m, "KalmanFilter",
 		"Linear Kalman filter for state estimation.\n\n"
@@ -360,4 +577,94 @@ void bind_estimation(nb::module_& m) {
 		     "Update step with a measurement vector of length meas_dim.")
 		.def_prop_ro("dtype", &PyKalmanFilter::dtype,
 		             "Arithmetic configuration selected at construction.");
+
+	// Shared docstring fragment for the three adaptive filters.
+	constexpr const char* ADAPTIVE_PROCESS_DOC =
+		"Process one sample with adaptation. Returns a (output, error) tuple "
+		"where output is y[n] = w^T x[n] and error is d[n] - y[n].";
+	constexpr const char* ADAPTIVE_BLOCK_DOC =
+		"Process two equal-length NumPy float64 signals (input, desired) and "
+		"return a (outputs, errors) tuple of float64 arrays. The per-sample "
+		"loop releases the GIL.";
+	constexpr const char* ADAPTIVE_WEIGHTS_DOC =
+		"Current tap weights as a 1D NumPy float64 array (read-only copy).";
+
+	nb::class_<PyLMSFilter>(m, "LMSFilter",
+		"Least-mean-squares adaptive FIR filter.\n\n"
+		"At each step, runs the FIR cascade w^T x[n], measures error against "
+		"the desired signal, and updates weights by mu * error * x[n].")
+		.def(nb::init<std::size_t, double, const std::string&>(),
+		     nb::arg("num_taps"), nb::arg("step_size"),
+		     nb::arg("dtype") = "reference",
+		     "Construct an LMS adaptive filter.")
+		.def_prop_ro("num_taps", &PyLMSFilter::num_taps)
+		.def_prop_ro("last_error", &PyLMSFilter::last_error,
+		             "Error residual from the most recent process() call.")
+		.def_prop_ro("weights", &PyLMSFilter::weights,
+		             nb::rv_policy::take_ownership,
+		             ADAPTIVE_WEIGHTS_DOC)
+		.def_prop_ro("dtype", &PyLMSFilter::dtype,
+		             "Arithmetic configuration selected at construction.")
+		.def("process", &PyLMSFilter::process,
+		     nb::arg("input"), nb::arg("desired"),
+		     ADAPTIVE_PROCESS_DOC)
+		.def("process_block", &PyLMSFilter::process_block,
+		     nb::arg("inputs"), nb::arg("desireds"),
+		     ADAPTIVE_BLOCK_DOC)
+		.def("reset", &PyLMSFilter::reset,
+		     "Zero the weights and delay line.");
+
+	nb::class_<PyNLMSFilter>(m, "NLMSFilter",
+		"Normalized LMS adaptive filter — scales the step size by input "
+		"power to stay stable across varying signal levels.")
+		.def(nb::init<std::size_t, double, double, const std::string&>(),
+		     nb::arg("num_taps"), nb::arg("step_size"),
+		     nb::arg("epsilon") = 1e-6,
+		     nb::arg("dtype") = "reference",
+		     "Construct an NLMS filter. epsilon regularizes the normalization "
+		     "when input power is near zero.")
+		.def_prop_ro("num_taps", &PyNLMSFilter::num_taps)
+		.def_prop_ro("last_error", &PyNLMSFilter::last_error,
+		             "Error residual from the most recent process() call.")
+		.def_prop_ro("weights", &PyNLMSFilter::weights,
+		             nb::rv_policy::take_ownership,
+		             ADAPTIVE_WEIGHTS_DOC)
+		.def_prop_ro("dtype", &PyNLMSFilter::dtype,
+		             "Arithmetic configuration selected at construction.")
+		.def("process", &PyNLMSFilter::process,
+		     nb::arg("input"), nb::arg("desired"),
+		     ADAPTIVE_PROCESS_DOC)
+		.def("process_block", &PyNLMSFilter::process_block,
+		     nb::arg("inputs"), nb::arg("desireds"),
+		     ADAPTIVE_BLOCK_DOC)
+		.def("reset", &PyNLMSFilter::reset,
+		     "Zero the weights and delay line.");
+
+	nb::class_<PyRLSFilter>(m, "RLSFilter",
+		"Recursive least-squares adaptive filter. Faster convergence than "
+		"LMS at O(N^2) per sample cost. forgetting_factor in (0, 1] "
+		"controls tracking of non-stationary signals (1.0 = no forgetting).")
+		.def(nb::init<std::size_t, double, double, const std::string&>(),
+		     nb::arg("num_taps"),
+		     nb::arg("forgetting_factor") = 0.99,
+		     nb::arg("delta") = 1000.0,
+		     nb::arg("dtype") = "reference",
+		     "Construct an RLS filter. delta is the initial P diagonal "
+		     "(larger = faster initial convergence).")
+		.def_prop_ro("num_taps", &PyRLSFilter::num_taps)
+		.def_prop_ro("last_error", &PyRLSFilter::last_error,
+		             "Error residual from the most recent process() call.")
+		.def_prop_ro("weights", &PyRLSFilter::weights,
+		             nb::rv_policy::take_ownership,
+		             ADAPTIVE_WEIGHTS_DOC)
+		.def_prop_ro("dtype", &PyRLSFilter::dtype,
+		             "Arithmetic configuration selected at construction.")
+		.def("process", &PyRLSFilter::process,
+		     nb::arg("input"), nb::arg("desired"),
+		     ADAPTIVE_PROCESS_DOC)
+		.def("process_block", &PyRLSFilter::process_block,
+		     nb::arg("inputs"), nb::arg("desireds"),
+		     ADAPTIVE_BLOCK_DOC)
+		.def("reset", &PyRLSFilter::reset,
+		     "Zero the weights, delay line, and reset P to delta*I.");
 }

--- a/src/estimation_bindings.cpp
+++ b/src/estimation_bindings.cpp
@@ -476,6 +476,13 @@ public:
 			throw std::invalid_argument(
 				"LMSFilter: num_taps must be > 0");
 		}
+		// !(x > 0.0) catches non-positive values and NaN uniformly. A
+		// non-positive step size either never adapts (0) or silently diverges
+		// (negative); NaN poisons the weights on the first sample.
+		if (!(step_size > 0.0)) {
+			throw std::invalid_argument(
+				"LMSFilter: step_size must be positive");
+		}
 		impl_ = make_adaptive_impl<sw::dsp::LMSFilter>(
 			mpdsp::parse_config(dtype), "LMSFilter", num_taps, step_size);
 		dtype_ = dtype;
@@ -489,6 +496,10 @@ public:
 		if (num_taps == 0) {
 			throw std::invalid_argument(
 				"NLMSFilter: num_taps must be > 0");
+		}
+		if (!(step_size > 0.0)) {
+			throw std::invalid_argument(
+				"NLMSFilter: step_size must be positive");
 		}
 		if (!(epsilon > 0.0)) {
 			throw std::invalid_argument(

--- a/src/estimation_bindings.cpp
+++ b/src/estimation_bindings.cpp
@@ -157,18 +157,13 @@ struct IKalmanImpl {
 	virtual std::size_t meas_dim() const = 0;
 	virtual std::size_t ctrl_dim() const = 0;
 
-	// Getters are intentionally non-const: sw::dsp::KalmanFilter<T>::B() has
-	// only a non-const overload upstream (the other five matrices have
-	// const overloads — this looks like an upstream omission). Reading
-	// Python matrix properties returns a fresh NumPy copy either way, so
-	// non-const virtuals are semantically fine here.
-	virtual np_f64_2d get_F() = 0;
-	virtual np_f64_2d get_H() = 0;
-	virtual np_f64_2d get_Q() = 0;
-	virtual np_f64_2d get_R() = 0;
-	virtual np_f64_2d get_P() = 0;
-	virtual np_f64_2d get_B() = 0;
-	virtual np_f64    get_state() = 0;
+	virtual np_f64_2d get_F() const = 0;
+	virtual np_f64_2d get_H() const = 0;
+	virtual np_f64_2d get_Q() const = 0;
+	virtual np_f64_2d get_R() const = 0;
+	virtual np_f64_2d get_P() const = 0;
+	virtual np_f64_2d get_B() const = 0;
+	virtual np_f64    get_state() const = 0;
 
 	virtual void set_F(np_f64_2d_ro a) = 0;
 	virtual void set_H(np_f64_2d_ro a) = 0;
@@ -193,13 +188,13 @@ struct KalmanImpl : IKalmanImpl {
 	std::size_t meas_dim() const override { return inner.meas_dim(); }
 	std::size_t ctrl_dim() const override { return inner.ctrl_dim(); }
 
-	np_f64_2d get_F() override { return mat_to_numpy(inner.F()); }
-	np_f64_2d get_H() override { return mat_to_numpy(inner.H()); }
-	np_f64_2d get_Q() override { return mat_to_numpy(inner.Q()); }
-	np_f64_2d get_R() override { return mat_to_numpy(inner.R()); }
-	np_f64_2d get_P() override { return mat_to_numpy(inner.P()); }
-	np_f64_2d get_B() override { return mat_to_numpy(inner.B()); }
-	np_f64    get_state() override { return vec_to_numpy(inner.state()); }
+	np_f64_2d get_F() const override { return mat_to_numpy(inner.F()); }
+	np_f64_2d get_H() const override { return mat_to_numpy(inner.H()); }
+	np_f64_2d get_Q() const override { return mat_to_numpy(inner.Q()); }
+	np_f64_2d get_R() const override { return mat_to_numpy(inner.R()); }
+	np_f64_2d get_P() const override { return mat_to_numpy(inner.P()); }
+	np_f64_2d get_B() const override { return mat_to_numpy(inner.B()); }
+	np_f64    get_state() const override { return vec_to_numpy(inner.state()); }
 
 	void set_F(np_f64_2d_ro a) override { numpy_to_mat(a, inner.F(), "F"); }
 	void set_H(np_f64_2d_ro a) override { numpy_to_mat(a, inner.H(), "H"); }
@@ -258,13 +253,13 @@ public:
 	std::size_t meas_dim() const { return impl_->meas_dim(); }
 	std::size_t ctrl_dim() const { return impl_->ctrl_dim(); }
 
-	np_f64_2d get_F() { return impl_->get_F(); }
-	np_f64_2d get_H() { return impl_->get_H(); }
-	np_f64_2d get_Q() { return impl_->get_Q(); }
-	np_f64_2d get_R() { return impl_->get_R(); }
-	np_f64_2d get_P() { return impl_->get_P(); }
-	np_f64_2d get_B() { return impl_->get_B(); }
-	np_f64    get_state() { return impl_->get_state(); }
+	np_f64_2d get_F() const { return impl_->get_F(); }
+	np_f64_2d get_H() const { return impl_->get_H(); }
+	np_f64_2d get_Q() const { return impl_->get_Q(); }
+	np_f64_2d get_R() const { return impl_->get_R(); }
+	np_f64_2d get_P() const { return impl_->get_P(); }
+	np_f64_2d get_B() const { return impl_->get_B(); }
+	np_f64    get_state() const { return impl_->get_state(); }
 
 	void set_F(np_f64_2d_ro a) { impl_->set_F(a); }
 	void set_H(np_f64_2d_ro a) { impl_->set_H(a); }

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -275,6 +275,11 @@ class TestLMSFilter:
         with pytest.raises(ValueError):
             mpdsp.LMSFilter(num_taps=0, step_size=0.01)
 
+    @pytest.mark.parametrize("bad_step", [0.0, -0.01, float("nan")])
+    def test_non_positive_or_nan_step_size_raises(self, bad_step):
+        with pytest.raises(ValueError):
+            mpdsp.LMSFilter(num_taps=4, step_size=bad_step)
+
     def test_unknown_dtype_raises(self):
         with pytest.raises(ValueError):
             mpdsp.LMSFilter(num_taps=4, step_size=0.01, dtype="not_a_dtype")
@@ -336,6 +341,11 @@ class TestNLMSFilter:
     def test_zero_num_taps_raises(self):
         with pytest.raises(ValueError):
             mpdsp.NLMSFilter(num_taps=0, step_size=0.5)
+
+    @pytest.mark.parametrize("bad_step", [0.0, -0.5, float("nan")])
+    def test_non_positive_or_nan_step_size_raises(self, bad_step):
+        with pytest.raises(ValueError):
+            mpdsp.NLMSFilter(num_taps=4, step_size=bad_step)
 
     def test_non_positive_epsilon_raises(self):
         with pytest.raises(ValueError):

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -1,4 +1,4 @@
-"""Tests for state-estimation bindings (scaffold: KalmanFilter)."""
+"""Tests for state-estimation bindings: KalmanFilter, LMSFilter, NLMSFilter, RLSFilter."""
 
 import numpy as np
 import pytest
@@ -243,3 +243,223 @@ class TestKalmanDtypeDispatch:
         # But should still be close — within a few percent of the reference.
         err = np.max(np.abs(ref - posit)) / (np.max(np.abs(ref)) + 1e-12)
         assert err < 0.05
+
+
+# ---------------------------------------------------------------------------
+# Adaptive filters — shared test fixtures.
+# ---------------------------------------------------------------------------
+
+
+def _sysid_signals(true_taps, n=4000, seed=0):
+    """Generate (x, d) signals for a system-identification task where the
+    unknown system is an FIR with `true_taps`. Returns contiguous float64
+    arrays of length n each."""
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal(n)
+    d = np.convolve(x, true_taps, mode="full")[:n]
+    return x, d
+
+
+# ---------------------------------------------------------------------------
+# LMSFilter
+# ---------------------------------------------------------------------------
+
+
+class TestLMSFilter:
+    def test_default_dtype(self):
+        f = mpdsp.LMSFilter(num_taps=4, step_size=0.01)
+        assert f.dtype == "reference"
+        assert f.num_taps == 4
+
+    def test_zero_num_taps_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.LMSFilter(num_taps=0, step_size=0.01)
+
+    def test_unknown_dtype_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.LMSFilter(num_taps=4, step_size=0.01, dtype="not_a_dtype")
+
+    def test_process_returns_tuple(self):
+        f = mpdsp.LMSFilter(num_taps=3, step_size=0.05)
+        y, e = f.process(1.0, 0.5)
+        assert isinstance(y, float)
+        assert isinstance(e, float)
+
+    def test_weights_shape(self):
+        f = mpdsp.LMSFilter(num_taps=5, step_size=0.01)
+        w = f.weights
+        assert w.shape == (5,)
+        assert w.dtype == np.float64
+        # Weights start at zero.
+        assert np.all(w == 0.0)
+
+    def test_process_block_shapes(self):
+        f = mpdsp.LMSFilter(num_taps=3, step_size=0.05)
+        x, d = _sysid_signals([0.3, 0.5, 0.2], n=128)
+        ys, es = f.process_block(x, d)
+        assert ys.shape == (128,)
+        assert es.shape == (128,)
+
+    def test_process_block_length_mismatch_raises(self):
+        f = mpdsp.LMSFilter(num_taps=3, step_size=0.01)
+        with pytest.raises(ValueError):
+            f.process_block(np.zeros(10), np.zeros(11))
+
+    def test_converges_to_known_system(self):
+        """LMS should recover a known unknown-system FIR given enough samples."""
+        true_taps = np.array([0.3, 0.5, 0.2])
+        f = mpdsp.LMSFilter(num_taps=3, step_size=0.05)
+        x, d = _sysid_signals(true_taps, n=2000)
+        f.process_block(x, d)
+        np.testing.assert_allclose(f.weights, true_taps, atol=0.01)
+
+    def test_reset_clears_weights(self):
+        f = mpdsp.LMSFilter(num_taps=3, step_size=0.05)
+        x, d = _sysid_signals([0.3, 0.5, 0.2], n=500)
+        f.process_block(x, d)
+        assert np.max(np.abs(f.weights)) > 0.1
+        f.reset()
+        assert np.all(f.weights == 0.0)
+
+
+# ---------------------------------------------------------------------------
+# NLMSFilter
+# ---------------------------------------------------------------------------
+
+
+class TestNLMSFilter:
+    def test_default_dtype(self):
+        f = mpdsp.NLMSFilter(num_taps=4, step_size=0.5)
+        assert f.dtype == "reference"
+        assert f.num_taps == 4
+
+    def test_zero_num_taps_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.NLMSFilter(num_taps=0, step_size=0.5)
+
+    def test_non_positive_epsilon_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.NLMSFilter(num_taps=4, step_size=0.5, epsilon=0.0)
+
+    def test_converges_to_known_system(self):
+        true_taps = np.array([0.3, 0.5, 0.2])
+        f = mpdsp.NLMSFilter(num_taps=3, step_size=0.5)
+        x, d = _sysid_signals(true_taps, n=2000)
+        f.process_block(x, d)
+        np.testing.assert_allclose(f.weights, true_taps, atol=0.01)
+
+    def test_handles_large_input_stably(self):
+        """NLMS's normalization is its reason to exist: identical step_size
+        that would diverge on LMS at large input amplitudes should track
+        stably with NLMS."""
+        true_taps = np.array([0.4, 0.3])
+        x, d = _sysid_signals(true_taps, n=2000)
+        x_loud = 50.0 * x   # 50x amplitude
+        d_loud = 50.0 * d
+        f = mpdsp.NLMSFilter(num_taps=2, step_size=0.5)
+        f.process_block(x_loud, d_loud)
+        # Even at huge amplitude NLMS converges close to the truth.
+        np.testing.assert_allclose(f.weights, true_taps, atol=0.05)
+
+
+# ---------------------------------------------------------------------------
+# RLSFilter
+# ---------------------------------------------------------------------------
+
+
+class TestRLSFilter:
+    def test_default_dtype(self):
+        f = mpdsp.RLSFilter(num_taps=4)
+        assert f.dtype == "reference"
+        assert f.num_taps == 4
+
+    def test_zero_num_taps_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.RLSFilter(num_taps=0)
+
+    def test_forgetting_factor_out_of_range_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.RLSFilter(num_taps=4, forgetting_factor=0.0)
+        with pytest.raises(ValueError):
+            mpdsp.RLSFilter(num_taps=4, forgetting_factor=1.5)
+
+    def test_non_positive_delta_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.RLSFilter(num_taps=4, delta=0.0)
+
+    def test_converges_to_known_system(self):
+        true_taps = np.array([0.3, 0.5, 0.2])
+        f = mpdsp.RLSFilter(num_taps=3, forgetting_factor=0.99)
+        x, d = _sysid_signals(true_taps, n=500)  # short — RLS is fast
+        f.process_block(x, d)
+        np.testing.assert_allclose(f.weights, true_taps, atol=1e-3)
+
+    def test_reset_clears_state(self):
+        f = mpdsp.RLSFilter(num_taps=3)
+        x, d = _sysid_signals([0.3, 0.5, 0.2], n=200)
+        f.process_block(x, d)
+        assert np.max(np.abs(f.weights)) > 0.1
+        f.reset()
+        assert np.all(f.weights == 0.0)
+
+
+# ---------------------------------------------------------------------------
+# RLS vs LMS — acceptance criterion from issue #6.
+# ---------------------------------------------------------------------------
+
+
+def test_rls_converges_faster_than_lms():
+    """RLS uses a matrix update and should reach low error in far fewer
+    samples than LMS. Count how many samples it takes each to get the
+    weight error below a fixed tolerance."""
+    true_taps = np.array([0.3, 0.5, 0.2])
+
+    def iters_to_converge(filt, x, d, tol=0.02):
+        xs, ds = x.copy(), d.copy()
+        for i in range(len(xs)):
+            filt.process(float(xs[i]), float(ds[i]))
+            if np.max(np.abs(np.asarray(filt.weights) - true_taps)) < tol:
+                return i + 1
+        return len(xs)
+
+    x, d = _sysid_signals(true_taps, n=5000, seed=1)
+    lms_iters = iters_to_converge(mpdsp.LMSFilter(num_taps=3, step_size=0.05),
+                                  x, d)
+    rls_iters = iters_to_converge(mpdsp.RLSFilter(num_taps=3,
+                                                   forgetting_factor=0.99),
+                                  x, d)
+    assert rls_iters < lms_iters, (
+        f"expected RLS to converge faster than LMS "
+        f"(LMS={lms_iters}, RLS={rls_iters})"
+    )
+    # Stronger assertion: RLS should be dramatically faster, not merely 1
+    # iteration fewer. Factor of 3 is a conservative expectation on this
+    # well-conditioned sysid.
+    assert rls_iters * 3 < lms_iters
+
+
+# ---------------------------------------------------------------------------
+# Dtype dispatch (adaptive filters).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [
+    "reference", "gpu_baseline", "ml_hw", "cf24", "half", "posit_full",
+])
+@pytest.mark.parametrize("ctor", [
+    lambda dt: mpdsp.LMSFilter(num_taps=3, step_size=0.05, dtype=dt),
+    lambda dt: mpdsp.NLMSFilter(num_taps=3, step_size=0.5, dtype=dt),
+    lambda dt: mpdsp.RLSFilter(num_taps=3, forgetting_factor=0.99, dtype=dt),
+], ids=["lms", "nlms", "rls"])
+def test_adaptive_filter_runs_under_each_dtype(ctor, dtype):
+    """Every dtype must instantiate, process one sample, and return finite
+    values. tiny_posit is excluded because its precision floor (< 4 bits of
+    fraction at typical weight magnitudes) can't meaningfully represent the
+    update step and the test would be checking noise rather than arithmetic.
+    """
+    f = ctor(dtype)
+    x, d = _sysid_signals([0.3, 0.5, 0.2], n=64)
+    ys, es = f.process_block(x, d)
+    assert ys.shape == x.shape
+    assert np.all(np.isfinite(ys))
+    assert np.all(np.isfinite(es))


### PR DESCRIPTION
## Summary
Fourth slice of Phase 5 (#6). Three adaptive filters sharing the `(input, desired) → (output, error)` tuple shape, built on the stateful-object pattern established in #21 / #22 / #23.

## Design

- **Shared `IAdaptiveFilter` interface** — `num_taps`, `last_error`, `process`, `process_block`, `weights`, `reset`. All three underlying upstream classes have the same API shape aside from constructor arguments, so one interface and one `AdaptiveFilterImpl<Filter, T>` template covers them all.
- **New `make_adaptive_impl<Filter, DoubleArgs...>` helper** — dispatches the requested dtype, casts constructor arguments from double to T at the call site, and forwards to the templated impl. LMS / NLMS / RLS factory call sites are one-liners.
- **`PyAdaptiveFilter` base class** for the three wrappers — only the constructors and per-filter validation differ.
- **`process(input, desired) → (output, error)` tuple** per the issue spec.
- **`process_block(inputs, desireds) → (outputs, errors)` tuples of arrays** for throughput — per-sample loop releases GIL, Python-object construction stays under the GIL.
- **`weights` as read-only NumPy property** with `rv_policy::take_ownership` (see #24).

## API surface

| Class | Constructor | Filter-specific validation |
|-------|-------------|---------------------------|
| `LMSFilter` | `(num_taps, step_size, dtype=\"reference\")` | `num_taps > 0` |
| `NLMSFilter` | `(num_taps, step_size, epsilon=1e-6, dtype=\"reference\")` | `num_taps > 0`, `epsilon > 0` |
| `RLSFilter` | `(num_taps, forgetting_factor=0.99, delta=1000.0, dtype=\"reference\")` | `num_taps > 0`, `forgetting_factor ∈ (0, 1]`, `delta > 0` |

Every instance shares: `.num_taps`, `.last_error`, `.weights`, `.dtype`, `.process(x, d)`, `.process_block(xs, ds)`, `.reset()`.

## Acceptance criteria from issue #6

- [x] **LMS converges to known filter coefficients** — `test_converges_to_known_system` recovers true_taps = [0.3, 0.5, 0.2] within atol=0.01 from 2000 Gaussian-input samples; identical tests for NLMS and RLS (RLS within atol=1e-3 in just 500 samples).
- [x] **RLS converges faster than LMS** — `test_rls_converges_faster_than_lms` times both to a 2% weight-error threshold; asserts RLS needs < LMS/3 iterations. Passes with margin.

## Changes

- `src/estimation_bindings.cpp` — adds shared adaptive-filter infrastructure (`IAdaptiveFilter`, `AdaptiveFilterImpl<Filter, T>`, `make_adaptive_impl<...>`) and the three wrapper classes.
- `python/mpdsp/__init__.py` — re-export `LMSFilter`, `NLMSFilter`, `RLSFilter`.
- `tests/test_estimation.py` — 39 new test cases (up from 33).

## Test Results
| Build | Estimation tests | Full suite |
|-------|------------------|------------|
| gcc | 72/72 pass | 299/299 pass |
| clang | 72/72 pass | 299/299 pass |

(Up from 33 / 260 after #23.)

## Dtype dispatch coverage

6 of 7 dtypes execute and produce finite outputs across all three filters. `tiny_posit` is excluded from the parametrized dispatch test — documented inline: its precision floor can't represent the weight update step at typical magnitudes, so the test would be checking noise rather than arithmetic.

## Follow-up (still open under #6)
- `python/mpdsp/estimation.py` — `plot_kalman_tracking()`, `plot_adaptive_convergence()` helpers
- Notebooks `05_conditioning.ipynb`, `06_estimation.ipynb`

After those two, Phase 5 (#6) closes.

## Test plan
- [x] Fast CI passes (gcc + clang + MSVC + Apple Clang)
- [x] Promote to ready and merge once green

Relates to #6

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new adaptive filters—LMS Filter, NLMS Filter, and RLS Filter—with configurable parameters for different signal processing applications
  * Filters support both single-sample and batch processing modes
  * Access to filter weights, error metrics, and state reset functionality

* **Tests**
  * Added comprehensive test suite validating filter convergence, parameter validation, and multi-dtype compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->