### PR TITLE
feat(image): scaffold image_bindings with shared binding-helpers header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ nanobind_add_module(_core
   src/filter_bindings.cpp
   src/conditioning_bindings.cpp
   src/estimation_bindings.cpp
+  src/image_bindings.cpp
 )
 target_link_libraries(_core PRIVATE sw_dsp)
 

--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -48,6 +48,9 @@ try:
         # Estimation
         KalmanFilter,
         LMSFilter, NLMSFilter, RLSFilter,
+        # Image (scaffold — full surface rolls out in follow-up PRs)
+        checkerboard, gaussian_blob, gradient_horizontal,
+        convolve2d,
         # Introspection
         available_dtypes,
     )

--- a/src/_binding_helpers.hpp
+++ b/src/_binding_helpers.hpp
@@ -1,0 +1,206 @@
+#pragma once
+// _binding_helpers.hpp: shared nanobind + MTL marshalling utilities.
+//
+// Factored out of conditioning_bindings.cpp and estimation_bindings.cpp
+// (where identical copies had been duplicating by hand) so new binding
+// files can pick up the same idioms without re-deriving them:
+//
+//   np_f64, np_f64_ro            — 1D float64 NumPy views (c_contig for ro)
+//   np_f64_2d, np_f64_2d_ro      — 2D float64 NumPy views (c_contig for ro)
+//   make_f64_array(n)            — owning output buffer of length n
+//   make_f64_2d_array(rows, cols)— owning 2D output buffer
+//   mat_to_numpy<T>              — dense2D<T> -> NumPy float64 (copy, casts)
+//   numpy_to_mat<T>              — NumPy -> existing dense2D<T> (shape-checked)
+//   numpy_to_mat_fresh<T>        — NumPy -> freshly-allocated dense2D<T>
+//   vec_to_numpy<T>              — dense_vector<T> -> NumPy float64 (copy, casts)
+//   numpy_to_vec<T>              — NumPy -> existing dense_vector<T>
+//   make_impl_for_dtype<...>     — construct one Impl<T> per ArithConfig
+//
+// Everything lives in a private `mpdsp::bindings` namespace. Include this
+// header from each binding translation unit that needs it. There is no
+// corresponding .cpp — the helpers are intentionally inline template code
+// so multiple TUs can instantiate them independently.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+#include <mtl/mat/dense2D.hpp>
+#include <mtl/vec/dense_vector.hpp>
+
+#include "types.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace mpdsp::bindings {
+
+namespace nb = ::nanobind;
+
+// ---------------------------------------------------------------------------
+// NumPy typedefs. c_contig on the read-only variants forces nanobind to copy
+// non-contiguous inputs transparently so .data() walks the buffer linearly.
+// ---------------------------------------------------------------------------
+
+using np_f64       = nb::ndarray<nb::numpy, double>;
+using np_f64_ro    = nb::ndarray<nb::numpy, const double, nb::ndim<1>, nb::c_contig>;
+using np_f64_2d    = nb::ndarray<nb::numpy, double, nb::ndim<2>>;
+using np_f64_2d_ro = nb::ndarray<nb::numpy, const double, nb::ndim<2>, nb::c_contig>;
+
+// ---------------------------------------------------------------------------
+// Owning output-buffer builders. Ownership is transferred to the nb::capsule
+// only after the capsule constructor succeeds, so a throw on the capsule
+// path doesn't leak the buffer.
+// ---------------------------------------------------------------------------
+
+inline np_f64 make_f64_array(std::size_t n, double*& out_ptr) {
+	auto buf = std::unique_ptr<double[]>(new double[n]);
+	double* data = buf.get();
+	nb::capsule owner(data, [](void* p) noexcept {
+		delete[] static_cast<double*>(p);
+	});
+	buf.release();
+	out_ptr = data;
+	std::size_t shape[1] = { n };
+	return np_f64(data, 1, shape, owner);
+}
+
+inline np_f64_2d make_f64_2d_array(std::size_t rows, std::size_t cols,
+                                   double*& out_ptr) {
+	std::size_t total = rows * cols;
+	auto buf = std::unique_ptr<double[]>(new double[total]);
+	double* data = buf.get();
+	nb::capsule owner(data, [](void* p) noexcept {
+		delete[] static_cast<double*>(p);
+	});
+	buf.release();
+	out_ptr = data;
+	std::size_t shape[2] = { rows, cols };
+	return np_f64_2d(data, 2, shape, owner);
+}
+
+// ---------------------------------------------------------------------------
+// 1D vector marshalling. T <-> double via static_cast at the boundary.
+// ---------------------------------------------------------------------------
+
+template <typename T>
+inline np_f64 vec_to_numpy(const mtl::vec::dense_vector<T>& v) {
+	std::size_t n = v.size();
+	double* out_ptr = nullptr;
+	auto arr = make_f64_array(n, out_ptr);
+	for (std::size_t i = 0; i < n; ++i) {
+		out_ptr[i] = static_cast<double>(v[i]);
+	}
+	return arr;
+}
+
+template <typename T>
+inline void numpy_to_vec(np_f64_ro src, mtl::vec::dense_vector<T>& dst,
+                         const char* name) {
+	if (src.shape(0) != dst.size()) {
+		throw std::invalid_argument(
+			std::string(name) + ": size mismatch (expected " +
+			std::to_string(dst.size()) + ", got " +
+			std::to_string(src.shape(0)) + ")");
+	}
+	const double* data = src.data();
+	for (std::size_t i = 0; i < dst.size(); ++i) {
+		dst[i] = static_cast<T>(data[i]);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2D matrix marshalling. Walks (row, col) pairs with a shared row-major
+// linear index — MTL's dense2D defaults to row-major orientation, matching
+// NumPy C-order.
+// ---------------------------------------------------------------------------
+
+template <typename T>
+inline np_f64_2d mat_to_numpy(const mtl::mat::dense2D<T>& m) {
+	std::size_t rows = m.num_rows();
+	std::size_t cols = m.num_cols();
+	double* out_ptr = nullptr;
+	auto arr = make_f64_2d_array(rows, cols, out_ptr);
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			out_ptr[r * cols + c] = static_cast<double>(m(r, c));
+		}
+	}
+	return arr;
+}
+
+template <typename T>
+inline void numpy_to_mat(np_f64_2d_ro src, mtl::mat::dense2D<T>& dst,
+                         const char* name) {
+	if (src.shape(0) != dst.num_rows() || src.shape(1) != dst.num_cols()) {
+		throw std::invalid_argument(
+			std::string(name) + ": shape mismatch (expected " +
+			std::to_string(dst.num_rows()) + "x" +
+			std::to_string(dst.num_cols()) + ", got " +
+			std::to_string(src.shape(0)) + "x" +
+			std::to_string(src.shape(1)) + ")");
+	}
+	std::size_t cols = dst.num_cols();
+	const double* data = src.data();
+	for (std::size_t r = 0; r < dst.num_rows(); ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			dst(r, c) = static_cast<T>(data[r * cols + c]);
+		}
+	}
+}
+
+// Convenience: convert a NumPy 2D array to a freshly-allocated dense2D<T>.
+// Use when the caller doesn't have a pre-allocated matrix to copy into.
+template <typename T>
+inline mtl::mat::dense2D<T> numpy_to_mat_fresh(np_f64_2d_ro src) {
+	std::size_t rows = src.shape(0);
+	std::size_t cols = src.shape(1);
+	mtl::mat::dense2D<T> dst(rows, cols);
+	const double* data = src.data();
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			dst(r, c) = static_cast<T>(data[r * cols + c]);
+		}
+	}
+	return dst;
+}
+
+// ---------------------------------------------------------------------------
+// Arithmetic-config dispatcher. Given a class template Impl<T> deriving from
+// Base, construct the right instantiation for the requested ArithConfig and
+// return a unique_ptr<Base>. Variadic Args... forwards constructor arguments
+// to the T-typed Impl — used by e.g. KalmanFilter(state_dim, meas_dim, ...).
+//
+// A future ArithConfig enumerator that's added without extending the switch
+// raises instead of silently dispatching to double.
+// ---------------------------------------------------------------------------
+
+template <template<class> class Impl, class Base, class... Args>
+inline std::unique_ptr<Base>
+make_impl_for_dtype(mpdsp::ArithConfig config, const char* cls, Args&&... args) {
+	using mpdsp::ArithConfig;
+	using mpdsp::cf24;
+	using mpdsp::half_;
+	using mpdsp::p32;
+	using tiny_posit_t = sw::universal::posit<8, 2>;
+	switch (config) {
+	case ArithConfig::reference:
+		return std::make_unique<Impl<double>>(std::forward<Args>(args)...);
+	case ArithConfig::gpu_baseline:
+		return std::make_unique<Impl<float>>(std::forward<Args>(args)...);
+	case ArithConfig::ml_hw:
+		return std::make_unique<Impl<half_>>(std::forward<Args>(args)...);
+	case ArithConfig::cf24_config:
+		return std::make_unique<Impl<cf24>>(std::forward<Args>(args)...);
+	case ArithConfig::half_config:
+		return std::make_unique<Impl<half_>>(std::forward<Args>(args)...);
+	case ArithConfig::posit_full:
+		return std::make_unique<Impl<p32>>(std::forward<Args>(args)...);
+	case ArithConfig::tiny_posit:
+		return std::make_unique<Impl<tiny_posit_t>>(std::forward<Args>(args)...);
+	}
+	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
+}
+
+} // namespace mpdsp::bindings

--- a/src/_binding_helpers.hpp
+++ b/src/_binding_helpers.hpp
@@ -30,9 +30,11 @@
 #include "types.hpp"
 
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>  // for std::forward used in make_impl_for_dtype
 
 namespace mpdsp::bindings {
 
@@ -68,6 +70,14 @@ inline np_f64 make_f64_array(std::size_t n, double*& out_ptr) {
 
 inline np_f64_2d make_f64_2d_array(std::size_t rows, std::size_t cols,
                                    double*& out_ptr) {
+	// Reject oversized dimensions that would wrap rows * cols past SIZE_MAX
+	// and silently produce a too-small allocation. Image generators take
+	// rows/cols from Python, so adversarial or mistyped values can reach
+	// here directly.
+	if (cols != 0 && rows > std::numeric_limits<std::size_t>::max() / cols) {
+		throw std::overflow_error(
+			"make_f64_2d_array: rows * cols overflows size_t");
+	}
 	std::size_t total = rows * cols;
 	auto buf = std::unique_ptr<double[]>(new double[total]);
 	double* data = buf.get();

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -14,6 +14,7 @@ void bind_spectral(nb::module_& m);
 void bind_filters(nb::module_& m);
 void bind_conditioning(nb::module_& m);
 void bind_estimation(nb::module_& m);
+void bind_image(nb::module_& m);
 
 NB_MODULE(_core, m) {
 	m.doc() = "mpdsp C++ core: mixed-precision DSP bindings via nanobind";
@@ -24,4 +25,5 @@ NB_MODULE(_core, m) {
 	bind_filters(m);
 	bind_conditioning(m);
 	bind_estimation(m);
+	bind_image(m);
 }

--- a/src/conditioning_bindings.cpp
+++ b/src/conditioning_bindings.cpp
@@ -17,6 +17,7 @@
 #include <sw/dsp/conditioning/compressor.hpp>
 #include <sw/dsp/conditioning/envelope.hpp>
 
+#include "_binding_helpers.hpp"
 #include "types.hpp"
 
 #include <cstddef>
@@ -26,54 +27,13 @@
 
 namespace nb = nanobind;
 
+// Pull shared NumPy typedefs and helpers into this TU's namespace.
+using mpdsp::bindings::np_f64;
+using mpdsp::bindings::np_f64_ro;
+using mpdsp::bindings::make_f64_array;
+using mpdsp::bindings::make_impl_for_dtype;
+
 namespace {
-
-using np_f64    = nb::ndarray<nb::numpy, double>;
-// c_contig: force nanobind to deliver a C-contiguous buffer (copying if the
-// caller passed a slice or non-contiguous view). Without this, signal.data()
-// would walk the original memory linearly and produce wrong results on any
-// strided input such as sig[::2].
-using np_f64_ro = nb::ndarray<nb::numpy, const double, nb::ndim<1>, nb::c_contig>;
-
-static np_f64 make_f64_array(std::size_t n, double*& out_ptr) {
-	auto buf = std::unique_ptr<double[]>(new double[n]);
-	double* data = buf.get();
-	nb::capsule owner(data, [](void* p) noexcept { delete[] static_cast<double*>(p); });
-	// Ownership transfers to the capsule only after it has been constructed
-	// successfully, so a throw from the capsule ctor won't leak the buffer.
-	buf.release();
-	out_ptr = data;
-	std::size_t shape[1] = { n };
-	return np_f64(data, 1, shape, owner);
-}
-
-// Shared dispatcher: maps ArithConfig → a concrete Impl<T> inheriting from
-// Base, for any class template Impl and interface Base. Every conditioning
-// wrapper in this file shares the same set of supported dtypes, so one
-// switch covers all four. If a future class constraint (e.g. AGC's
-// DspOrderedField) excludes a dtype, that factory can drop back to a
-// hand-written switch without disturbing this helper.
-template <template<class> class Impl, class Base>
-static std::unique_ptr<Base>
-make_impl_for_dtype(mpdsp::ArithConfig config, const char* cls) {
-	using mpdsp::ArithConfig;
-	using mpdsp::cf24;
-	using mpdsp::half_;
-	using mpdsp::p32;
-	using tiny_posit_t = sw::universal::posit<8, 2>;
-	switch (config) {
-	case ArithConfig::reference:    return std::make_unique<Impl<double>>();
-	case ArithConfig::gpu_baseline: return std::make_unique<Impl<float>>();
-	case ArithConfig::ml_hw:        return std::make_unique<Impl<half_>>();
-	case ArithConfig::cf24_config:  return std::make_unique<Impl<cf24>>();
-	case ArithConfig::half_config:  return std::make_unique<Impl<half_>>();
-	case ArithConfig::posit_full:   return std::make_unique<Impl<p32>>();
-	case ArithConfig::tiny_posit:   return std::make_unique<Impl<tiny_posit_t>>();
-	}
-	// Surface additions to the ArithConfig enum instead of silently falling
-	// through to a default impl.
-	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
-}
 
 // Type-erased interface. Python always sees double-precision I/O; the
 // internal arithmetic happens in whatever T the concrete impl chose.

--- a/src/estimation_bindings.cpp
+++ b/src/estimation_bindings.cpp
@@ -14,6 +14,7 @@
 #include <sw/dsp/estimation/lms.hpp>
 #include <sw/dsp/estimation/rls.hpp>
 
+#include "_binding_helpers.hpp"
 #include "types.hpp"
 
 #include <cstddef>
@@ -24,127 +25,20 @@
 
 namespace nb = nanobind;
 
+// Pull shared NumPy typedefs + helpers into this TU's namespace.
+using mpdsp::bindings::np_f64;
+using mpdsp::bindings::np_f64_ro;
+using mpdsp::bindings::np_f64_2d;
+using mpdsp::bindings::np_f64_2d_ro;
+using mpdsp::bindings::make_f64_array;
+using mpdsp::bindings::make_f64_2d_array;
+using mpdsp::bindings::mat_to_numpy;
+using mpdsp::bindings::numpy_to_mat;
+using mpdsp::bindings::vec_to_numpy;
+using mpdsp::bindings::numpy_to_vec;
+using mpdsp::bindings::make_impl_for_dtype;
+
 namespace {
-
-using np_f64       = nb::ndarray<nb::numpy, double>;
-using np_f64_ro    = nb::ndarray<nb::numpy, const double, nb::ndim<1>, nb::c_contig>;
-using np_f64_2d    = nb::ndarray<nb::numpy, double, nb::ndim<2>>;
-// c_contig on 2D inputs matches MTL's default row-major orientation, so
-// numpy_to_mat can walk both buffers with a shared linear index.
-using np_f64_2d_ro = nb::ndarray<nb::numpy, const double, nb::ndim<2>, nb::c_contig>;
-
-// -- Shared array builders ---------------------------------------------------
-
-static np_f64 make_f64_array(std::size_t n, double*& out_ptr) {
-	auto buf = std::unique_ptr<double[]>(new double[n]);
-	double* data = buf.get();
-	nb::capsule owner(data, [](void* p) noexcept { delete[] static_cast<double*>(p); });
-	buf.release();
-	out_ptr = data;
-	std::size_t shape[1] = { n };
-	return np_f64(data, 1, shape, owner);
-}
-
-static np_f64_2d make_f64_2d_array(std::size_t rows, std::size_t cols,
-                                   double*& out_ptr) {
-	std::size_t total = rows * cols;
-	auto buf = std::unique_ptr<double[]>(new double[total]);
-	double* data = buf.get();
-	nb::capsule owner(data, [](void* p) noexcept { delete[] static_cast<double*>(p); });
-	buf.release();
-	out_ptr = data;
-	std::size_t shape[2] = { rows, cols };
-	return np_f64_2d(data, 2, shape, owner);
-}
-
-// -- dense2D <-> NumPy marshalling -------------------------------------------
-//
-// MTL's dense2D defaults to row-major orientation (same as NumPy C-order),
-// but dense2D exposes only operator()(r, c) — not data() with a guaranteed
-// row-major stride — so walk (r, c) element by element. Casts convert
-// T<->double at the boundary.
-
-template <typename T>
-static np_f64_2d mat_to_numpy(const mtl::mat::dense2D<T>& m) {
-	std::size_t rows = m.num_rows();
-	std::size_t cols = m.num_cols();
-	double* out_ptr = nullptr;
-	auto arr = make_f64_2d_array(rows, cols, out_ptr);
-	for (std::size_t r = 0; r < rows; ++r) {
-		for (std::size_t c = 0; c < cols; ++c) {
-			out_ptr[r * cols + c] = static_cast<double>(m(r, c));
-		}
-	}
-	return arr;
-}
-
-template <typename T>
-static void numpy_to_mat(np_f64_2d_ro src, mtl::mat::dense2D<T>& dst,
-                         const char* name) {
-	if (src.shape(0) != dst.num_rows() || src.shape(1) != dst.num_cols()) {
-		throw std::invalid_argument(
-			std::string(name) + ": shape mismatch (expected " +
-			std::to_string(dst.num_rows()) + "x" +
-			std::to_string(dst.num_cols()) + ", got " +
-			std::to_string(src.shape(0)) + "x" +
-			std::to_string(src.shape(1)) + ")");
-	}
-	std::size_t cols = dst.num_cols();
-	const double* data = src.data();
-	for (std::size_t r = 0; r < dst.num_rows(); ++r) {
-		for (std::size_t c = 0; c < cols; ++c) {
-			dst(r, c) = static_cast<T>(data[r * cols + c]);
-		}
-	}
-}
-
-template <typename T>
-static np_f64 vec_to_numpy(const mtl::vec::dense_vector<T>& v) {
-	std::size_t n = v.size();
-	double* out_ptr = nullptr;
-	auto arr = make_f64_array(n, out_ptr);
-	for (std::size_t i = 0; i < n; ++i) {
-		out_ptr[i] = static_cast<double>(v[i]);
-	}
-	return arr;
-}
-
-template <typename T>
-static void numpy_to_vec(np_f64_ro src, mtl::vec::dense_vector<T>& dst,
-                         const char* name) {
-	if (src.shape(0) != dst.size()) {
-		throw std::invalid_argument(
-			std::string(name) + ": size mismatch (expected " +
-			std::to_string(dst.size()) + ", got " +
-			std::to_string(src.shape(0)) + ")");
-	}
-	const double* data = src.data();
-	for (std::size_t i = 0; i < dst.size(); ++i) {
-		dst[i] = static_cast<T>(data[i]);
-	}
-}
-
-// -- Shared dtype dispatcher (mirrors conditioning_bindings.cpp) -------------
-
-template <template<class> class Impl, class Base, class... Args>
-static std::unique_ptr<Base>
-make_impl_for_dtype(mpdsp::ArithConfig config, const char* cls, Args&&... args) {
-	using mpdsp::ArithConfig;
-	using mpdsp::cf24;
-	using mpdsp::half_;
-	using mpdsp::p32;
-	using tiny_posit_t = sw::universal::posit<8, 2>;
-	switch (config) {
-	case ArithConfig::reference:    return std::make_unique<Impl<double>>(std::forward<Args>(args)...);
-	case ArithConfig::gpu_baseline: return std::make_unique<Impl<float>>(std::forward<Args>(args)...);
-	case ArithConfig::ml_hw:        return std::make_unique<Impl<half_>>(std::forward<Args>(args)...);
-	case ArithConfig::cf24_config:  return std::make_unique<Impl<cf24>>(std::forward<Args>(args)...);
-	case ArithConfig::half_config:  return std::make_unique<Impl<half_>>(std::forward<Args>(args)...);
-	case ArithConfig::posit_full:   return std::make_unique<Impl<p32>>(std::forward<Args>(args)...);
-	case ArithConfig::tiny_posit:   return std::make_unique<Impl<tiny_posit_t>>(std::forward<Args>(args)...);
-	}
-	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
-}
 
 // ===========================================================================
 // KalmanFilter

--- a/src/image_bindings.cpp
+++ b/src/image_bindings.cpp
@@ -53,6 +53,16 @@ static sw::dsp::BorderMode parse_border(const std::string& name) {
 		" (expected constant, replicate, reflect, reflect_101, or wrap)");
 }
 
+// Validate that image dimensions from the Python boundary are positive.
+// Zero-sized generators are well-defined but rarely useful; reject early
+// to avoid constructing empty NumPy arrays that surprise callers.
+static void check_dims(std::size_t rows, std::size_t cols, const char* name) {
+	if (rows == 0 || cols == 0) {
+		throw std::invalid_argument(
+			std::string(name) + ": rows and cols must be positive");
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Dtype dispatcher for free-function processors.
 //
@@ -115,6 +125,7 @@ void bind_image(nb::module_& m) {
 	m.def("checkerboard",
 		[](std::size_t rows, std::size_t cols, std::size_t block_size,
 		   double low, double high) {
+			check_dims(rows, cols, "checkerboard");
 			auto img = sw::dsp::checkerboard<double>(rows, cols, block_size,
 			                                         low, high);
 			return mat_to_numpy(img);
@@ -127,6 +138,7 @@ void bind_image(nb::module_& m) {
 	m.def("gaussian_blob",
 		[](std::size_t rows, std::size_t cols, double sigma,
 		   double amplitude) {
+			check_dims(rows, cols, "gaussian_blob");
 			if (!(sigma > 0.0)) {
 				throw std::invalid_argument(
 					"gaussian_blob: sigma must be positive");
@@ -141,6 +153,7 @@ void bind_image(nb::module_& m) {
 
 	m.def("gradient_horizontal",
 		[](std::size_t rows, std::size_t cols, double start, double end) {
+			check_dims(rows, cols, "gradient_horizontal");
 			auto img = sw::dsp::gradient_horizontal<double>(rows, cols,
 			                                                start, end);
 			return mat_to_numpy(img);

--- a/src/image_bindings.cpp
+++ b/src/image_bindings.cpp
@@ -1,0 +1,178 @@
+// image_bindings.cpp: 2D image processing bindings (Phase 6 scaffold).
+//
+// Establishes patterns for Phase 6 before replicating across the full
+// generator/processing/morphology/io surface:
+//
+//   - Free-function bindings returning NumPy float64 2D (for generators).
+//   - Free-function bindings with a dtype dispatcher for mixed-precision
+//     processing (for convolve2d and the other *_typed workers that follow).
+//   - BorderMode string parsing at the Python boundary.
+//
+// Starts with three generators (checkerboard, gaussian_blob,
+// gradient_horizontal) and one dtype-dispatched processor (convolve2d).
+// The rest of the phase will reuse this file's helpers.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
+
+#include <sw/dsp/image/convolve2d.hpp>
+#include <sw/dsp/image/generators.hpp>
+#include <sw/dsp/image/image.hpp>
+
+#include "_binding_helpers.hpp"
+#include "types.hpp"
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+
+namespace nb = nanobind;
+
+using mpdsp::bindings::np_f64_2d;
+using mpdsp::bindings::np_f64_2d_ro;
+using mpdsp::bindings::mat_to_numpy;
+using mpdsp::bindings::numpy_to_mat_fresh;
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// BorderMode string parsing. Matches sw::dsp::BorderMode enumerators; the
+// default "reflect_101" mirrors the upstream default.
+// ---------------------------------------------------------------------------
+
+static sw::dsp::BorderMode parse_border(const std::string& name) {
+	using sw::dsp::BorderMode;
+	if (name == "constant")    return BorderMode::constant;
+	if (name == "replicate")   return BorderMode::replicate;
+	if (name == "reflect")     return BorderMode::reflect;
+	if (name == "reflect_101") return BorderMode::reflect_101;
+	if (name == "wrap")        return BorderMode::wrap;
+	throw std::invalid_argument(
+		"Unknown border mode: " + name +
+		" (expected constant, replicate, reflect, reflect_101, or wrap)");
+}
+
+// ---------------------------------------------------------------------------
+// Dtype dispatcher for free-function processors.
+//
+// Free functions like convolve2d can't use make_impl_for_dtype<Impl, Base>
+// (that one constructs a class Impl<T>). Instead, a per-function dispatcher
+// instantiates the upstream function template at the requested T, ferries
+// NumPy input through dense2D<T>, runs, and ships the result back as
+// NumPy float64. Future processing bindings use the same shape.
+// ---------------------------------------------------------------------------
+
+template <typename T>
+static np_f64_2d convolve2d_typed(np_f64_2d_ro image, np_f64_2d_ro kernel,
+                                   sw::dsp::BorderMode border, double pad) {
+	auto in_mat  = numpy_to_mat_fresh<T>(image);
+	auto kern    = numpy_to_mat_fresh<T>(kernel);
+	auto result  = sw::dsp::convolve2d<T, T>(in_mat, kern, border, static_cast<T>(pad));
+	return mat_to_numpy(result);
+}
+
+static np_f64_2d convolve2d_dispatch(np_f64_2d_ro image, np_f64_2d_ro kernel,
+                                     const std::string& border_name,
+                                     double pad,
+                                     const std::string& dtype) {
+	auto config = mpdsp::parse_config(dtype);
+	auto border = parse_border(border_name);
+	using mpdsp::ArithConfig;
+	using mpdsp::cf24;
+	using mpdsp::half_;
+	using mpdsp::p32;
+	using tiny_posit_t = sw::universal::posit<8, 2>;
+	switch (config) {
+	case ArithConfig::reference:
+		return convolve2d_typed<double>(image, kernel, border, pad);
+	case ArithConfig::gpu_baseline:
+		return convolve2d_typed<float>(image, kernel, border, pad);
+	case ArithConfig::ml_hw:
+		return convolve2d_typed<half_>(image, kernel, border, pad);
+	case ArithConfig::cf24_config:
+		return convolve2d_typed<cf24>(image, kernel, border, pad);
+	case ArithConfig::half_config:
+		return convolve2d_typed<half_>(image, kernel, border, pad);
+	case ArithConfig::posit_full:
+		return convolve2d_typed<p32>(image, kernel, border, pad);
+	case ArithConfig::tiny_posit:
+		return convolve2d_typed<tiny_posit_t>(image, kernel, border, pad);
+	}
+	throw std::invalid_argument("convolve2d: unsupported ArithConfig");
+}
+
+} // namespace
+
+void bind_image(nb::module_& m) {
+	// =======================================================================
+	// Generators — return NumPy float64 2D. No dtype parameter: all
+	// upstream generators are mtl::mat::dense2D<T> for arbitrary T, but
+	// Python-facing generators always produce float64 so they compose with
+	// the dtype-dispatched processors that follow.
+	// =======================================================================
+
+	m.def("checkerboard",
+		[](std::size_t rows, std::size_t cols, std::size_t block_size,
+		   double low, double high) {
+			auto img = sw::dsp::checkerboard<double>(rows, cols, block_size,
+			                                         low, high);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"), nb::arg("block_size"),
+		nb::arg("low") = 0.0, nb::arg("high") = 1.0,
+		"Checkerboard of alternating `low` / `high` blocks, "
+		"`block_size` pixels per square.");
+
+	m.def("gaussian_blob",
+		[](std::size_t rows, std::size_t cols, double sigma,
+		   double amplitude) {
+			if (!(sigma > 0.0)) {
+				throw std::invalid_argument(
+					"gaussian_blob: sigma must be positive");
+			}
+			auto img = sw::dsp::gaussian_blob<double>(rows, cols, sigma,
+			                                           amplitude);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"), nb::arg("sigma"),
+		nb::arg("amplitude") = 1.0,
+		"2D Gaussian centred on the image with standard deviation `sigma`.");
+
+	m.def("gradient_horizontal",
+		[](std::size_t rows, std::size_t cols, double start, double end) {
+			auto img = sw::dsp::gradient_horizontal<double>(rows, cols,
+			                                                start, end);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"),
+		nb::arg("start") = 0.0, nb::arg("end") = 1.0,
+		"Linear horizontal gradient from `start` (left) to `end` (right).");
+
+	// =======================================================================
+	// Processing — dtype-dispatched. Convolve2d is the scaffold; all other
+	// processors in this phase (separable_filter, gaussian_blur, box_blur,
+	// sobel_*, prewitt_*, canny, ...) follow this pattern.
+	// =======================================================================
+
+	m.def("convolve2d",
+		[](np_f64_2d_ro image, np_f64_2d_ro kernel,
+		   const std::string& border, double pad, const std::string& dtype) {
+			if (image.shape(0) == 0 || image.shape(1) == 0) {
+				throw std::invalid_argument(
+					"convolve2d: image must have non-zero dimensions");
+			}
+			if (kernel.shape(0) == 0 || kernel.shape(1) == 0) {
+				throw std::invalid_argument(
+					"convolve2d: kernel must have non-zero dimensions");
+			}
+			return convolve2d_dispatch(image, kernel, border, pad, dtype);
+		},
+		nb::arg("image"), nb::arg("kernel"),
+		nb::arg("border") = "reflect_101", nb::arg("pad") = 0.0,
+		nb::arg("dtype") = "reference",
+		"2D spatial correlation. `border` is one of constant, replicate, "
+		"reflect, reflect_101, or wrap; `pad` is the fill value for "
+		"border='constant'. `dtype` selects the internal arithmetic — see "
+		"available_dtypes().");
+}

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -37,6 +37,11 @@ class TestCheckerboard:
         with pytest.raises(ValueError):
             mpdsp.checkerboard(4, 4, block_size=0)
 
+    @pytest.mark.parametrize("rows,cols", [(0, 4), (4, 0), (0, 0)])
+    def test_zero_dims_rejected(self, rows, cols):
+        with pytest.raises(ValueError):
+            mpdsp.checkerboard(rows, cols, block_size=2)
+
 
 class TestGaussianBlob:
     def test_shape(self):
@@ -63,6 +68,11 @@ class TestGaussianBlob:
         with pytest.raises(ValueError):
             mpdsp.gaussian_blob(8, 8, sigma=-1.0)
 
+    @pytest.mark.parametrize("rows,cols", [(0, 4), (4, 0)])
+    def test_zero_dims_rejected(self, rows, cols):
+        with pytest.raises(ValueError):
+            mpdsp.gaussian_blob(rows, cols, sigma=1.0)
+
 
 class TestGradientHorizontal:
     def test_shape(self):
@@ -80,6 +90,11 @@ class TestGradientHorizontal:
         img = mpdsp.gradient_horizontal(2, 3, start=10.0, end=20.0)
         assert img[0, 0] == 10.0
         assert img[0, -1] == 20.0
+
+    @pytest.mark.parametrize("rows,cols", [(0, 5), (5, 0)])
+    def test_zero_dims_rejected(self, rows, cols):
+        with pytest.raises(ValueError):
+            mpdsp.gradient_horizontal(rows, cols)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,174 @@
+"""Tests for image processing bindings (scaffold: generators + convolve2d)."""
+
+import numpy as np
+import pytest
+
+mpdsp = pytest.importorskip("mpdsp", reason="mpdsp C++ module not built")
+if not mpdsp.HAS_CORE:
+    pytest.skip("mpdsp._core not available", allow_module_level=True)
+
+
+# ---------------------------------------------------------------------------
+# Generators
+# ---------------------------------------------------------------------------
+
+
+class TestCheckerboard:
+    def test_shape_and_dtype(self):
+        img = mpdsp.checkerboard(8, 12, block_size=2)
+        assert img.shape == (8, 12)
+        assert img.dtype == np.float64
+
+    def test_two_values(self):
+        img = mpdsp.checkerboard(4, 4, block_size=1, low=-1.0, high=2.0)
+        unique = np.unique(img)
+        assert set(unique.tolist()) == {-1.0, 2.0}
+
+    def test_block_size_controls_square(self):
+        """With block_size=3, each 3x3 region should be uniform."""
+        img = mpdsp.checkerboard(6, 6, block_size=3)
+        # Top-left 3x3 block is all one value
+        assert len(np.unique(img[:3, :3])) == 1
+        # Top-right 3x3 block is the other value
+        assert len(np.unique(img[:3, 3:])) == 1
+        assert img[0, 0] != img[0, 3]
+
+    def test_zero_block_size_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.checkerboard(4, 4, block_size=0)
+
+
+class TestGaussianBlob:
+    def test_shape(self):
+        img = mpdsp.gaussian_blob(16, 20, sigma=3.0)
+        assert img.shape == (16, 20)
+        assert img.dtype == np.float64
+
+    def test_peak_is_center(self):
+        """The Gaussian blob peaks at the image center."""
+        img = mpdsp.gaussian_blob(17, 17, sigma=3.0)
+        # argmax in flattened space; unravel to (row, col)
+        peak_idx = np.unravel_index(np.argmax(img), img.shape)
+        assert peak_idx == (8, 8)
+
+    def test_amplitude_scales_peak(self):
+        img_low = mpdsp.gaussian_blob(9, 9, sigma=2.0, amplitude=0.5)
+        img_high = mpdsp.gaussian_blob(9, 9, sigma=2.0, amplitude=2.0)
+        # Peak amplitude ratio matches the parameter ratio exactly.
+        assert img_high.max() == pytest.approx(img_low.max() * 4.0)
+
+    def test_non_positive_sigma_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.gaussian_blob(8, 8, sigma=0.0)
+        with pytest.raises(ValueError):
+            mpdsp.gaussian_blob(8, 8, sigma=-1.0)
+
+
+class TestGradientHorizontal:
+    def test_shape(self):
+        img = mpdsp.gradient_horizontal(6, 10)
+        assert img.shape == (6, 10)
+
+    def test_linear_left_to_right(self):
+        img = mpdsp.gradient_horizontal(4, 5, start=0.0, end=1.0)
+        expected_row = np.linspace(0.0, 1.0, 5)
+        # Every row equals the same gradient.
+        for r in range(img.shape[0]):
+            np.testing.assert_allclose(img[r], expected_row)
+
+    def test_start_end_parameters(self):
+        img = mpdsp.gradient_horizontal(2, 3, start=10.0, end=20.0)
+        assert img[0, 0] == 10.0
+        assert img[0, -1] == 20.0
+
+
+# ---------------------------------------------------------------------------
+# convolve2d
+# ---------------------------------------------------------------------------
+
+
+class TestConvolve2d:
+    def test_identity_kernel_round_trips(self):
+        """A 3x3 kernel with 1.0 at the center is the identity operation —
+        output must equal input (at reference dtype, exactly)."""
+        img = mpdsp.checkerboard(8, 8, block_size=2)
+        kernel = np.array([[0.0, 0.0, 0.0],
+                           [0.0, 1.0, 0.0],
+                           [0.0, 0.0, 0.0]])
+        out = mpdsp.convolve2d(img, kernel)
+        np.testing.assert_array_equal(out, img)
+
+    def test_shape_preserved(self):
+        img = mpdsp.gaussian_blob(12, 16, sigma=2.0)
+        kernel = np.ones((5, 5)) / 25.0
+        out = mpdsp.convolve2d(img, kernel)
+        assert out.shape == img.shape
+        assert out.dtype == np.float64
+
+    def test_box_blur_reduces_high_frequency(self):
+        """A box-blur kernel should strictly reduce the peak-to-peak range of
+        a high-frequency signal (like a checkerboard)."""
+        img = mpdsp.checkerboard(16, 16, block_size=1)  # alternating 0/1
+        kernel = np.ones((3, 3)) / 9.0
+        out = mpdsp.convolve2d(img, kernel)
+        # Interior pixels mix so the range tightens around 0.5.
+        interior = out[2:-2, 2:-2]
+        assert interior.max() < 1.0
+        assert interior.min() > 0.0
+
+    def test_unknown_border_raises(self):
+        img = mpdsp.checkerboard(8, 8, block_size=2)
+        kernel = np.ones((3, 3)) / 9.0
+        with pytest.raises(ValueError):
+            mpdsp.convolve2d(img, kernel, border="not_a_border")
+
+    def test_constant_border_with_pad(self):
+        """With border='constant' and pad=0, output border pixels mix
+        in zeros from the virtual padding — so the output is smaller."""
+        img = np.ones((5, 5))
+        kernel = np.ones((3, 3)) / 9.0
+        out_reflect = mpdsp.convolve2d(img, kernel, border="reflect_101")
+        out_constant = mpdsp.convolve2d(img, kernel, border="constant", pad=0.0)
+        # Reflect border replicates the ones, so output stays uniform at 1.
+        np.testing.assert_allclose(out_reflect, 1.0)
+        # Constant-zero border puts zeros at the edges, so corner values drop.
+        assert out_constant[0, 0] < out_constant[2, 2]
+
+    def test_empty_image_raises(self):
+        kernel = np.ones((3, 3))
+        with pytest.raises(ValueError):
+            mpdsp.convolve2d(np.zeros((0, 5)), kernel)
+
+    def test_empty_kernel_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.convolve2d(np.ones((5, 5)), np.zeros((0, 3)))
+
+    def test_unknown_dtype_raises(self):
+        img = np.ones((4, 4))
+        kernel = np.ones((3, 3)) / 9.0
+        with pytest.raises(ValueError):
+            mpdsp.convolve2d(img, kernel, dtype="not_a_dtype")
+
+
+class TestConvolve2dDtypeDispatch:
+    @pytest.mark.parametrize("dtype", [
+        "reference", "gpu_baseline", "ml_hw", "cf24", "half",
+        "posit_full", "tiny_posit",
+    ])
+    def test_runs_under_each_dtype(self, dtype):
+        img = mpdsp.gradient_horizontal(8, 8)
+        kernel = np.ones((3, 3)) / 9.0
+        out = mpdsp.convolve2d(img, kernel, dtype=dtype)
+        assert out.shape == img.shape
+        assert out.dtype == np.float64
+        assert np.all(np.isfinite(out))
+
+    def test_reduced_precision_close_to_reference(self):
+        """For a smooth input and small kernel, `half` output tracks the
+        reference within a few percent."""
+        img = mpdsp.gaussian_blob(16, 16, sigma=3.0)
+        kernel = np.ones((3, 3)) / 9.0
+        ref = mpdsp.convolve2d(img, kernel, dtype="reference")
+        alt = mpdsp.convolve2d(img, kernel, dtype="half")
+        err = np.max(np.abs(ref - alt)) / (np.max(np.abs(ref)) + 1e-12)
+        assert err < 0.02


### PR DESCRIPTION
## Summary

First slice of Phase 6 (#7). Two related pieces land together — a small image-bindings scaffold, and the factoring-out of duplicated helpers that the scaffold motivated.

## 1. `src/_binding_helpers.hpp` — new shared header

The NumPy marshalling and dtype-dispatch utilities had drifted into two hand-copied forms across `conditioning_bindings.cpp` and `estimation_bindings.cpp`. With `image_bindings.cpp` joining as the third consumer, centralizing them paid off now:

- `np_f64` / `np_f64_ro` / `np_f64_2d` / `np_f64_2d_ro` typedefs (c_contig on reads)
- `make_f64_array`, `make_f64_2d_array` owning output builders (with the unique_ptr exception-safe pattern from #21)
- `mat_to_numpy<T>`, `numpy_to_mat<T>`, `numpy_to_mat_fresh<T>`
- `vec_to_numpy<T>`, `numpy_to_vec<T>`
- `make_impl_for_dtype<Impl, Base, Args...>` — variadic dispatcher (the version from #23 / #25)

Everything sits in a `mpdsp::bindings` namespace; each TU pulls what it needs via `using mpdsp::bindings::...;`. Existing call sites unchanged.

Net: **−167 duplicated lines** across conditioning + estimation, **+27 using-directives**, zero behaviour change. 341/341 tests pass.

## 2. `src/image_bindings.cpp` — Phase 6 scaffold

Deliberately small, so the new patterns get vetted before replicating 40+ times:

**Generators** (return NumPy float64 2D directly, no dtype parameter):
- `checkerboard(rows, cols, block_size, low=0, high=1)`
- `gaussian_blob(rows, cols, sigma, amplitude=1)`
- `gradient_horizontal(rows, cols, start=0, end=1)`

**Processing with dtype dispatch** (this is the model for the rest of Phase 6):
- `convolve2d(image, kernel, border=\"reflect_101\", pad=0.0, dtype=\"reference\")`
- Per-function template `convolve2d_typed<T>` + hand-written dispatcher on `ArithConfig`. Unlike the class-based `make_impl_for_dtype` used for stateful objects, free-function processors can't reuse that helper — they instantiate the upstream function template at the chosen T.

**BorderMode string parsing** at the Python boundary — "constant", "replicate", "reflect", "reflect_101", "wrap".

**Boundary validation**: non-zero image/kernel dims, positive `sigma`, positive `block_size`, unknown border/dtype raise `ValueError`.

## 3. `tests/test_image.py` — 27 new cases

- Generator shape/value (checkerboard block size, Gaussian blob peak-at-center, amplitude scaling, gradient linearity)
- convolve2d correctness (identity kernel exact round-trip, box-blur reduces range, `border=\"constant\"` vs `\"reflect_101\"` diverge at edges, input validation)
- dtype-dispatch coverage (all 7 dtypes instantiate and run; `half` tracks `reference` within 2% on a smooth input)

## Test Results
| Build | Image tests | Full suite |
|-------|-------------|------------|
| gcc | 27/27 pass | 341/341 pass |
| clang | 27/27 pass | 341/341 pass |

## Follow-up (open under #7)

| PR | Scope |
|----|-------|
| **#b** | Remaining generators (14 more) + threshold + add_noise |
| **#c** | Separable filter + gaussian_blur / box_blur + edge detection (sobel/prewitt/canny/gradient_magnitude) |
| **#d** | Morphology (7 ops + 3 element constructors) + multi-channel (rgb_to_gray, apply_per_channel) |
| **#e** | I/O (PGM/PPM/BMP) + Python helpers (`image.py`) + two notebooks → closes #7 |

## Test plan
- [x] Fast CI passes (gcc + clang + MSVC + Apple Clang)
- [x] Review the shared-helper header and convolve2d dispatcher pattern before I replicate them

Relates to #7

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added image generation capabilities: checkerboard patterns, Gaussian blobs, and horizontal gradients
  * Added 2D convolution function for image processing with configurable border modes and padding support

* **Tests**
  * Added comprehensive test suite for new image processing functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->