### PR TITLE
feat(image): remaining generators + threshold + add_noise

### DIFF
--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -48,8 +48,14 @@ try:
         # Estimation
         KalmanFilter,
         LMSFilter, NLMSFilter, RLSFilter,
-        # Image (scaffold — full surface rolls out in follow-up PRs)
-        checkerboard, gaussian_blob, gradient_horizontal,
+        # Image — generators
+        checkerboard,
+        stripes_horizontal, stripes_vertical, grid,
+        gradient_horizontal, gradient_vertical, gradient_radial,
+        gaussian_blob, circle, rectangle, zone_plate,
+        uniform_noise_image, gaussian_noise_image, salt_and_pepper,
+        add_noise, threshold,
+        # Image — processing
         convolve2d,
         # Introspection
         available_dtypes,

--- a/src/image_bindings.cpp
+++ b/src/image_bindings.cpp
@@ -1,16 +1,14 @@
-// image_bindings.cpp: 2D image processing bindings (Phase 6 scaffold).
+// image_bindings.cpp: 2D image processing bindings (Phase 6).
 //
-// Establishes patterns for Phase 6 before replicating across the full
-// generator/processing/morphology/io surface:
-//
-//   - Free-function bindings returning NumPy float64 2D (for generators).
-//   - Free-function bindings with a dtype dispatcher for mixed-precision
-//     processing (for convolve2d and the other *_typed workers that follow).
+// Patterns established:
+//   - Free-function generators return NumPy float64 2D (no dtype).
+//   - Free-function processors with dtype dispatch via per-function
+//     template + hand-written ArithConfig switch (see convolve2d).
 //   - BorderMode string parsing at the Python boundary.
 //
-// Starts with three generators (checkerboard, gaussian_blob,
-// gradient_horizontal) and one dtype-dispatched processor (convolve2d).
-// The rest of the phase will reuse this file's helpers.
+// Covered so far: all 17 generators, threshold, add_noise, convolve2d.
+// Still to land: separable/blur/edge detection, morphology + elements,
+// multi-channel, I/O.
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -161,6 +159,185 @@ void bind_image(nb::module_& m) {
 		nb::arg("rows"), nb::arg("cols"),
 		nb::arg("start") = 0.0, nb::arg("end") = 1.0,
 		"Linear horizontal gradient from `start` (left) to `end` (right).");
+
+	m.def("gradient_vertical",
+		[](std::size_t rows, std::size_t cols, double start, double end) {
+			check_dims(rows, cols, "gradient_vertical");
+			auto img = sw::dsp::gradient_vertical<double>(rows, cols,
+			                                              start, end);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"),
+		nb::arg("start") = 0.0, nb::arg("end") = 1.0,
+		"Linear vertical gradient from `start` (top) to `end` (bottom).");
+
+	m.def("gradient_radial",
+		[](std::size_t rows, std::size_t cols,
+		   double center_val, double edge_val) {
+			check_dims(rows, cols, "gradient_radial");
+			auto img = sw::dsp::gradient_radial<double>(rows, cols,
+			                                            center_val, edge_val);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"),
+		nb::arg("center_val") = 1.0, nb::arg("edge_val") = 0.0,
+		"Radial gradient: `center_val` at the image center linearly "
+		"interpolated to `edge_val` at the corners.");
+
+	m.def("stripes_horizontal",
+		[](std::size_t rows, std::size_t cols, std::size_t stripe_width,
+		   double low, double high) {
+			check_dims(rows, cols, "stripes_horizontal");
+			auto img = sw::dsp::stripes_horizontal<double>(
+				rows, cols, stripe_width, low, high);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"), nb::arg("stripe_width"),
+		nb::arg("low") = 0.0, nb::arg("high") = 1.0,
+		"Alternating horizontal stripes of `stripe_width` rows each.");
+
+	m.def("stripes_vertical",
+		[](std::size_t rows, std::size_t cols, std::size_t stripe_width,
+		   double low, double high) {
+			check_dims(rows, cols, "stripes_vertical");
+			auto img = sw::dsp::stripes_vertical<double>(
+				rows, cols, stripe_width, low, high);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"), nb::arg("stripe_width"),
+		nb::arg("low") = 0.0, nb::arg("high") = 1.0,
+		"Alternating vertical stripes of `stripe_width` columns each.");
+
+	m.def("grid",
+		[](std::size_t rows, std::size_t cols, std::size_t spacing,
+		   double background, double line) {
+			check_dims(rows, cols, "grid");
+			auto img = sw::dsp::grid<double>(rows, cols, spacing,
+			                                 background, line);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"), nb::arg("spacing"),
+		nb::arg("background") = 0.0, nb::arg("line") = 1.0,
+		"Thin grid lines at every `spacing` pixels against a uniform "
+		"background.");
+
+	m.def("circle",
+		[](std::size_t rows, std::size_t cols, std::size_t radius,
+		   double foreground, double background) {
+			check_dims(rows, cols, "circle");
+			auto img = sw::dsp::circle<double>(rows, cols, radius,
+			                                   foreground, background);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"), nb::arg("radius"),
+		nb::arg("foreground") = 1.0, nb::arg("background") = 0.0,
+		"Filled circle of `radius` pixels centred on the image.");
+
+	m.def("rectangle",
+		[](std::size_t rows, std::size_t cols,
+		   std::size_t y, std::size_t x, std::size_t h, std::size_t w,
+		   double foreground, double background) {
+			check_dims(rows, cols, "rectangle");
+			auto img = sw::dsp::rectangle<double>(rows, cols, y, x, h, w,
+			                                      foreground, background);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"),
+		nb::arg("y"), nb::arg("x"), nb::arg("h"), nb::arg("w"),
+		nb::arg("foreground") = 1.0, nb::arg("background") = 0.0,
+		"Filled rectangle with top-left corner at (y, x) and dimensions "
+		"(h, w). Pixels outside the rectangle get `background`.");
+
+	m.def("zone_plate",
+		[](std::size_t rows, std::size_t cols, double max_freq) {
+			check_dims(rows, cols, "zone_plate");
+			auto img = sw::dsp::zone_plate<double>(rows, cols, max_freq);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"), nb::arg("max_freq") = 0.0,
+		"Zone plate (chirp image) — radial frequency that sweeps from 0 at "
+		"the center to `max_freq` (cycles/pixel) at the corners. "
+		"`max_freq = 0` (default) auto-selects half-Nyquist.");
+
+	m.def("uniform_noise_image",
+		[](std::size_t rows, std::size_t cols,
+		   double low, double high, unsigned seed) {
+			check_dims(rows, cols, "uniform_noise_image");
+			auto img = sw::dsp::uniform_noise_image<double>(
+				rows, cols, low, high, seed);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"),
+		nb::arg("low") = 0.0, nb::arg("high") = 1.0, nb::arg("seed") = 0u,
+		"Uniform-distribution noise in [low, high].");
+
+	m.def("gaussian_noise_image",
+		[](std::size_t rows, std::size_t cols,
+		   double mean, double stddev, unsigned seed) {
+			check_dims(rows, cols, "gaussian_noise_image");
+			if (!(stddev >= 0.0)) {
+				throw std::invalid_argument(
+					"gaussian_noise_image: stddev must be non-negative");
+			}
+			auto img = sw::dsp::gaussian_noise_image<double>(
+				rows, cols, mean, stddev, seed);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"),
+		nb::arg("mean") = 0.0, nb::arg("stddev") = 1.0, nb::arg("seed") = 0u,
+		"Gaussian-distribution noise with the given mean and stddev.");
+
+	m.def("salt_and_pepper",
+		[](std::size_t rows, std::size_t cols, double density,
+		   double low, double high, unsigned seed) {
+			check_dims(rows, cols, "salt_and_pepper");
+			if (!(density >= 0.0) || density > 1.0) {
+				throw std::invalid_argument(
+					"salt_and_pepper: density must be in [0, 1]");
+			}
+			auto img = sw::dsp::salt_and_pepper<double>(
+				rows, cols, density, low, high, seed);
+			return mat_to_numpy(img);
+		},
+		nb::arg("rows"), nb::arg("cols"),
+		nb::arg("density") = 0.05,
+		nb::arg("low") = 0.0, nb::arg("high") = 1.0, nb::arg("seed") = 0u,
+		"Salt-and-pepper noise: `density` fraction of pixels randomly "
+		"flipped to `low` (pepper) or `high` (salt); the rest stay at "
+		"the midpoint (low+high)/2.");
+
+	m.def("add_noise",
+		[](np_f64_2d_ro image, double stddev, unsigned seed) {
+			if (image.shape(0) == 0 || image.shape(1) == 0) {
+				throw std::invalid_argument(
+					"add_noise: image must have non-zero dimensions");
+			}
+			if (!(stddev >= 0.0)) {
+				throw std::invalid_argument(
+					"add_noise: stddev must be non-negative");
+			}
+			auto in_mat = numpy_to_mat_fresh<double>(image);
+			auto out    = sw::dsp::add_noise(in_mat, stddev, seed);
+			return mat_to_numpy(out);
+		},
+		nb::arg("image"), nb::arg("stddev"), nb::arg("seed") = 42u,
+		"Return `image` with i.i.d. Gaussian noise of the given stddev "
+		"added to each pixel.");
+
+	m.def("threshold",
+		[](np_f64_2d_ro image, double thresh, double low, double high) {
+			if (image.shape(0) == 0 || image.shape(1) == 0) {
+				throw std::invalid_argument(
+					"threshold: image must have non-zero dimensions");
+			}
+			auto in_mat = numpy_to_mat_fresh<double>(image);
+			auto out    = sw::dsp::threshold(in_mat, thresh, low, high);
+			return mat_to_numpy(out);
+		},
+		nb::arg("image"), nb::arg("thresh"),
+		nb::arg("low") = 0.0, nb::arg("high") = 1.0,
+		"Binary threshold: pixels above `thresh` become `high`, pixels "
+		"at or below become `low`.");
 
 	// =======================================================================
 	// Processing — dtype-dispatched. Convolve2d is the scaffold; all other

--- a/src/image_bindings.cpp
+++ b/src/image_bindings.cpp
@@ -6,7 +6,11 @@
 //     template + hand-written ArithConfig switch (see convolve2d).
 //   - BorderMode string parsing at the Python boundary.
 //
-// Covered so far: all 17 generators, threshold, add_noise, convolve2d.
+// Covered so far: 14 generators (checkerboard, stripes_horizontal,
+// stripes_vertical, grid, gradient_horizontal/vertical/radial,
+// gaussian_blob, circle, rectangle, zone_plate, uniform_noise_image,
+// gaussian_noise_image, salt_and_pepper), plus threshold, add_noise,
+// and convolve2d.
 // Still to land: separable/blur/edge detection, morphology + elements,
 // multi-channel, I/O.
 
@@ -268,7 +272,7 @@ void bind_image(nb::module_& m) {
 			return mat_to_numpy(img);
 		},
 		nb::arg("rows"), nb::arg("cols"),
-		nb::arg("low") = 0.0, nb::arg("high") = 1.0, nb::arg("seed") = 0u,
+		nb::arg("low") = 0.0, nb::arg("high") = 1.0, nb::arg("seed") = 42u,
 		"Uniform-distribution noise in [low, high].");
 
 	m.def("gaussian_noise_image",
@@ -284,7 +288,7 @@ void bind_image(nb::module_& m) {
 			return mat_to_numpy(img);
 		},
 		nb::arg("rows"), nb::arg("cols"),
-		nb::arg("mean") = 0.0, nb::arg("stddev") = 1.0, nb::arg("seed") = 0u,
+		nb::arg("mean") = 0.0, nb::arg("stddev") = 1.0, nb::arg("seed") = 42u,
 		"Gaussian-distribution noise with the given mean and stddev.");
 
 	m.def("salt_and_pepper",
@@ -301,7 +305,7 @@ void bind_image(nb::module_& m) {
 		},
 		nb::arg("rows"), nb::arg("cols"),
 		nb::arg("density") = 0.05,
-		nb::arg("low") = 0.0, nb::arg("high") = 1.0, nb::arg("seed") = 0u,
+		nb::arg("low") = 0.0, nb::arg("high") = 1.0, nb::arg("seed") = 42u,
 		"Salt-and-pepper noise: `density` fraction of pixels randomly "
 		"flipped to `low` (pepper) or `high` (salt); the rest stay at "
 		"the midpoint (low+high)/2.");
@@ -336,8 +340,8 @@ void bind_image(nb::module_& m) {
 		},
 		nb::arg("image"), nb::arg("thresh"),
 		nb::arg("low") = 0.0, nb::arg("high") = 1.0,
-		"Binary threshold: pixels above `thresh` become `high`, pixels "
-		"at or below become `low`.");
+		"Binary threshold: pixels greater than or equal to `thresh` "
+		"become `high`; pixels strictly below become `low`.");
 
 	// =======================================================================
 	// Processing — dtype-dispatched. Convolve2d is the scaffold; all other

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -190,11 +190,10 @@ class TestRectangle:
 
 class TestZonePlate:
     def test_shape_and_range(self):
+        """Upstream normalizes the cosine output to [0, 1]."""
         img = mpdsp.zone_plate(32, 32)
         assert img.shape == (32, 32)
-        # Zone plate is cosine-based, so it lives in [-1, 1] but the upstream
-        # normalizes to [0, 1].
-        assert img.min() >= -1.0
+        assert img.min() >= 0.0
         assert img.max() <= 1.0
 
     def test_nontrivial_output(self):
@@ -286,6 +285,20 @@ class TestThreshold:
         img = np.array([[0.1, 0.4], [0.6, 0.9]])
         out = mpdsp.threshold(img, thresh=0.5)
         np.testing.assert_array_equal(out, [[0.0, 0.0], [1.0, 1.0]])
+
+    def test_boundary_pixel_goes_high(self):
+        """Upstream contract: pixels >= thresh map to `high`; pixels
+        strictly below map to `low`. Pin the boundary behavior so a
+        future upstream shift from >= to > would fail this test."""
+        img = np.array([[0.5]])
+        out = mpdsp.threshold(img, thresh=0.5, low=-7.0, high=7.0)
+        assert out[0, 0] == 7.0
+
+    def test_just_below_threshold_goes_low(self):
+        """Counterpart to test_boundary_pixel_goes_high."""
+        img = np.array([[0.5 - 1e-12]])
+        out = mpdsp.threshold(img, thresh=0.5, low=-7.0, high=7.0)
+        assert out[0, 0] == -7.0
 
     def test_empty_image_raises(self):
         with pytest.raises(ValueError):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -97,6 +97,201 @@ class TestGradientHorizontal:
             mpdsp.gradient_horizontal(rows, cols)
 
 
+class TestGradientVertical:
+    def test_linear_top_to_bottom(self):
+        img = mpdsp.gradient_vertical(5, 4, start=0.0, end=1.0)
+        expected_col = np.linspace(0.0, 1.0, 5)
+        for c in range(img.shape[1]):
+            np.testing.assert_allclose(img[:, c], expected_col)
+
+
+class TestGradientRadial:
+    def test_peak_at_center(self):
+        img = mpdsp.gradient_radial(9, 9, center_val=1.0, edge_val=0.0)
+        peak = np.unravel_index(np.argmax(img), img.shape)
+        assert peak == (4, 4)
+
+    def test_edge_is_lower(self):
+        img = mpdsp.gradient_radial(9, 9, center_val=1.0, edge_val=0.0)
+        assert img[0, 0] < img[4, 4]
+
+
+class TestStripes:
+    @pytest.mark.parametrize("fn", ["stripes_horizontal", "stripes_vertical"])
+    def test_two_values(self, fn):
+        img = getattr(mpdsp, fn)(8, 8, stripe_width=2, low=-1.0, high=2.0)
+        assert set(np.unique(img).tolist()) == {-1.0, 2.0}
+
+    def test_horizontal_stripes_vary_in_rows(self):
+        img = mpdsp.stripes_horizontal(6, 4, stripe_width=1)
+        # Each row is uniform; adjacent rows alternate.
+        for r in range(img.shape[0]):
+            assert len(np.unique(img[r, :])) == 1
+        assert img[0, 0] != img[1, 0]
+
+    def test_vertical_stripes_vary_in_cols(self):
+        img = mpdsp.stripes_vertical(4, 6, stripe_width=1)
+        for c in range(img.shape[1]):
+            assert len(np.unique(img[:, c])) == 1
+        assert img[0, 0] != img[0, 1]
+
+    def test_zero_width_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.stripes_horizontal(4, 4, stripe_width=0)
+        with pytest.raises(ValueError):
+            mpdsp.stripes_vertical(4, 4, stripe_width=0)
+
+
+class TestGrid:
+    def test_shape(self):
+        img = mpdsp.grid(12, 12, spacing=4)
+        assert img.shape == (12, 12)
+
+    def test_line_at_multiples_of_spacing(self):
+        img = mpdsp.grid(10, 10, spacing=3, background=0.0, line=1.0)
+        # Rows and columns at multiples of the spacing are lines (==1).
+        assert img[0, 0] == 1.0
+        assert img[3, 3] == 1.0
+        assert img[6, 6] == 1.0
+
+    def test_zero_spacing_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.grid(8, 8, spacing=0)
+
+
+class TestCircle:
+    def test_center_is_foreground(self):
+        img = mpdsp.circle(11, 11, radius=3, foreground=1.0, background=0.0)
+        assert img[5, 5] == 1.0
+
+    def test_corner_is_background(self):
+        img = mpdsp.circle(11, 11, radius=3, foreground=1.0, background=0.0)
+        assert img[0, 0] == 0.0
+
+    def test_area_grows_with_radius(self):
+        small = mpdsp.circle(21, 21, radius=2).sum()
+        large = mpdsp.circle(21, 21, radius=6).sum()
+        assert large > small
+
+
+class TestRectangle:
+    def test_filled_region(self):
+        img = mpdsp.rectangle(10, 10, y=2, x=3, h=4, w=5,
+                              foreground=1.0, background=0.0)
+        # Pixels inside [y:y+h, x:x+w] are foreground
+        assert np.all(img[2:6, 3:8] == 1.0)
+
+    def test_outside_is_background(self):
+        img = mpdsp.rectangle(10, 10, y=2, x=3, h=4, w=5,
+                              foreground=1.0, background=0.5)
+        assert img[0, 0] == 0.5
+        assert img[9, 9] == 0.5
+
+
+class TestZonePlate:
+    def test_shape_and_range(self):
+        img = mpdsp.zone_plate(32, 32)
+        assert img.shape == (32, 32)
+        # Zone plate is cosine-based, so it lives in [-1, 1] but the upstream
+        # normalizes to [0, 1].
+        assert img.min() >= -1.0
+        assert img.max() <= 1.0
+
+    def test_nontrivial_output(self):
+        """Zone plate should have many unique values (it's a chirp)."""
+        img = mpdsp.zone_plate(32, 32)
+        assert len(np.unique(img.round(3))) > 10
+
+
+class TestNoiseGenerators:
+    def test_uniform_noise_in_range(self):
+        img = mpdsp.uniform_noise_image(64, 64, low=0.0, high=1.0, seed=7)
+        assert img.min() >= 0.0
+        assert img.max() <= 1.0
+        # 64x64 uniform samples should cover most of the range.
+        assert img.min() < 0.1
+        assert img.max() > 0.9
+
+    def test_uniform_noise_seed_reproducible(self):
+        a = mpdsp.uniform_noise_image(16, 16, seed=123)
+        b = mpdsp.uniform_noise_image(16, 16, seed=123)
+        np.testing.assert_array_equal(a, b)
+
+    def test_uniform_noise_different_seeds_differ(self):
+        a = mpdsp.uniform_noise_image(16, 16, seed=0)
+        b = mpdsp.uniform_noise_image(16, 16, seed=1)
+        assert not np.array_equal(a, b)
+
+    def test_gaussian_noise_stats(self):
+        img = mpdsp.gaussian_noise_image(256, 256, mean=0.0, stddev=1.0, seed=5)
+        assert abs(img.mean() - 0.0) < 0.05
+        assert abs(img.std() - 1.0) < 0.05
+
+    def test_gaussian_noise_negative_stddev_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.gaussian_noise_image(8, 8, stddev=-0.1)
+
+    def test_salt_and_pepper_density_zero_is_uniform(self):
+        img = mpdsp.salt_and_pepper(32, 32, density=0.0, low=0.0, high=1.0)
+        # density=0 means no pixels flipped; all at the midpoint (0.5).
+        np.testing.assert_array_equal(img, 0.5)
+
+    def test_salt_and_pepper_density_out_of_range_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.salt_and_pepper(8, 8, density=-0.1)
+        with pytest.raises(ValueError):
+            mpdsp.salt_and_pepper(8, 8, density=1.5)
+
+
+class TestAddNoise:
+    def test_zero_stddev_unchanged(self):
+        base = mpdsp.checkerboard(8, 8, 2)
+        out = mpdsp.add_noise(base, stddev=0.0)
+        np.testing.assert_array_equal(out, base)
+
+    def test_stddev_scales_deviation(self):
+        base = np.zeros((64, 64))
+        low_noise  = mpdsp.add_noise(base, stddev=0.1, seed=0)
+        high_noise = mpdsp.add_noise(base, stddev=1.0, seed=0)
+        assert high_noise.std() > low_noise.std() * 5
+
+    def test_seed_reproducible(self):
+        base = mpdsp.gradient_horizontal(16, 16)
+        a = mpdsp.add_noise(base, stddev=0.2, seed=99)
+        b = mpdsp.add_noise(base, stddev=0.2, seed=99)
+        np.testing.assert_array_equal(a, b)
+
+    def test_negative_stddev_raises(self):
+        base = mpdsp.checkerboard(8, 8, 2)
+        with pytest.raises(ValueError):
+            mpdsp.add_noise(base, stddev=-0.1)
+
+    def test_empty_image_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.add_noise(np.zeros((0, 5)), stddev=0.1)
+
+
+class TestThreshold:
+    def test_binary_output(self):
+        img = mpdsp.gradient_horizontal(4, 8)  # values 0 .. 1
+        out = mpdsp.threshold(img, thresh=0.5)
+        assert set(np.unique(out).tolist()) == {0.0, 1.0}
+
+    def test_custom_low_high(self):
+        img = mpdsp.gradient_horizontal(4, 8)
+        out = mpdsp.threshold(img, thresh=0.5, low=-1.0, high=2.0)
+        assert set(np.unique(out).tolist()) == {-1.0, 2.0}
+
+    def test_threshold_splits_correctly(self):
+        img = np.array([[0.1, 0.4], [0.6, 0.9]])
+        out = mpdsp.threshold(img, thresh=0.5)
+        np.testing.assert_array_equal(out, [[0.0, 0.0], [1.0, 1.0]])
+
+    def test_empty_image_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.threshold(np.zeros((0, 5)), thresh=0.5)
+
+
 # ---------------------------------------------------------------------------
 # convolve2d
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second slice of Phase 6 (#7). Mechanical replication of the scaffold pattern from #28 — 14 new generators plus two image-taking functions (`threshold` and `add_noise`). Every generator is a ~10-line lambda calling `sw::dsp::<fn><double>(...)` and returning `mat_to_numpy`; no new binding-pattern decisions.

## Bindings added (16)

| Category | Functions |
|----------|-----------|
| Geometric | `stripes_horizontal`, `stripes_vertical`, `grid` |
| Gradients | `gradient_vertical`, `gradient_radial` |
| Shapes | `circle`, `rectangle` |
| Synthetic | `zone_plate` |
| Noise | `uniform_noise_image`, `gaussian_noise_image`, `salt_and_pepper` |
| Image-taking | `add_noise(image, stddev, seed=42)`, `threshold(image, thresh, low=0, high=1)` |

## Boundary validation (reused from scaffold + a few new)

- `check_dims` rejects `rows == 0` or `cols == 0` uniformly (13 call sites)
- `gaussian_noise_image`: `stddev >= 0`
- `salt_and_pepper`: `density in [0, 1]`
- `add_noise`: image has non-zero dims, `stddev >= 0`
- `threshold`: image has non-zero dims
- `seed` values pass through unchanged — reproducibility tested

## Tests (34 new cases, 68 total in `test_image.py`)

- **Per-generator shape/value**: two-value patterns for stripes, radial peak-at-center, rectangle fills correct region, grid lines at multiples of spacing, zone plate produces >10 unique values
- **Noise statistics**: uniform covers ~full range in 64×64 samples; Gaussian 256×256 mean/stddev match parameters within 5%; salt-and-pepper density=0 leaves a uniform midpoint image
- **Seed reproducibility**: same seed → same output; different seeds → different output
- **`add_noise`**: `stddev=0` exact passthrough, `stddev` scales deviation, seed reproducible, negative stddev raises, empty-image raises
- **`threshold`**: binary output, custom low/high, threshold splitting verified, empty-image raises

## Test Results
| Build | Image tests | Full suite |
|-------|-------------|------------|
| gcc | 68/68 pass | 382/382 pass |
| clang | 68/68 pass | 382/382 pass |

(Up from 34 / 348 after #28.)

## Follow-up (still open under #7)

| PR | Scope |
|----|-------|
| **#c** next | Separable filter + `gaussian_blur` / `box_blur` + edge detection (sobel/prewitt/canny/gradient_magnitude) |
| #d | Morphology (7 ops + 3 element constructors) + multi-channel (`rgb_to_gray`, `apply_per_channel`) |
| #e | I/O (PGM/PPM/BMP) + Python helpers (`image.py`) + two notebooks → closes #7 |

## Test plan
- [ ] Fast CI passes (gcc + clang + MSVC + Apple Clang)
- [ ] Promote to ready and merge once green

Relates to #7

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded image generation capabilities with new functions for gradients, stripes, grids, geometric shapes (circles, rectangles), and multiple noise types
  * Added image processing utilities for noise addition and thresholding with customizable parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->