### PR TITLE
feat(image): separable filter, blurs, edge detection with dtype dispatch

### DIFF
--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -56,7 +56,11 @@ try:
         uniform_noise_image, gaussian_noise_image, salt_and_pepper,
         add_noise, threshold,
         # Image — processing
-        convolve2d,
+        convolve2d, separable_filter,
+        gaussian_blur, box_blur,
+        # Image — edge detection
+        sobel_x, sobel_y, prewitt_x, prewitt_y,
+        gradient_magnitude, canny,
         # Introspection
         available_dtypes,
     )

--- a/src/_binding_helpers.hpp
+++ b/src/_binding_helpers.hpp
@@ -176,6 +176,20 @@ inline mtl::mat::dense2D<T> numpy_to_mat_fresh(np_f64_2d_ro src) {
 	return dst;
 }
 
+// 1D counterpart to numpy_to_mat_fresh: convert a NumPy 1D array to a
+// freshly-allocated dense_vector<T>. Useful when a processor takes 1D
+// kernels alongside a 2D image.
+template <typename T>
+inline mtl::vec::dense_vector<T> numpy_to_vec_fresh(np_f64_ro src) {
+	std::size_t n = src.shape(0);
+	mtl::vec::dense_vector<T> dst(n);
+	const double* data = src.data();
+	for (std::size_t i = 0; i < n; ++i) {
+		dst[i] = static_cast<T>(data[i]);
+	}
+	return dst;
+}
+
 // ---------------------------------------------------------------------------
 // Arithmetic-config dispatcher. Given a class template Impl<T> deriving from
 // Base, construct the right instantiation for the requested ArithConfig and
@@ -185,6 +199,37 @@ inline mtl::mat::dense2D<T> numpy_to_mat_fresh(np_f64_2d_ro src) {
 // A future ArithConfig enumerator that's added without extending the switch
 // raises instead of silently dispatching to double.
 // ---------------------------------------------------------------------------
+
+// Free-function counterpart to make_impl_for_dtype. Takes a generic lambda
+// (C++20 explicit-template-argument lambda) and invokes it for the T that
+// matches `config`, returning whatever the lambda returns. Intended for
+// dtype-dispatched processors like convolve2d / sobel_* / canny that are
+// free templates, not class Impl<T>.
+//
+// Usage:
+//   auto out = dispatch_dtype_fn(config, "sobel_x", [&]<typename T>() {
+//       auto m = numpy_to_mat_fresh<T>(image);
+//       return mat_to_numpy(sw::dsp::sobel_x<T>(m, border));
+//   });
+template <class Callable>
+inline auto dispatch_dtype_fn(mpdsp::ArithConfig config, const char* cls,
+                               Callable&& f) {
+	using mpdsp::ArithConfig;
+	using mpdsp::cf24;
+	using mpdsp::half_;
+	using mpdsp::p32;
+	using tiny_posit_t = sw::universal::posit<8, 2>;
+	switch (config) {
+	case ArithConfig::reference:    return f.template operator()<double>();
+	case ArithConfig::gpu_baseline: return f.template operator()<float>();
+	case ArithConfig::ml_hw:        return f.template operator()<half_>();
+	case ArithConfig::cf24_config:  return f.template operator()<cf24>();
+	case ArithConfig::half_config:  return f.template operator()<half_>();
+	case ArithConfig::posit_full:   return f.template operator()<p32>();
+	case ArithConfig::tiny_posit:   return f.template operator()<tiny_posit_t>();
+	}
+	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
+}
 
 template <template<class> class Impl, class Base, class... Args>
 inline std::unique_ptr<Base>

--- a/src/image_bindings.cpp
+++ b/src/image_bindings.cpp
@@ -19,8 +19,10 @@
 #include <nanobind/stl/string.h>
 
 #include <sw/dsp/image/convolve2d.hpp>
+#include <sw/dsp/image/edge.hpp>
 #include <sw/dsp/image/generators.hpp>
 #include <sw/dsp/image/image.hpp>
+#include <sw/dsp/image/separable.hpp>
 
 #include "_binding_helpers.hpp"
 #include "types.hpp"
@@ -31,10 +33,13 @@
 
 namespace nb = nanobind;
 
+using mpdsp::bindings::np_f64_ro;
 using mpdsp::bindings::np_f64_2d;
 using mpdsp::bindings::np_f64_2d_ro;
 using mpdsp::bindings::mat_to_numpy;
 using mpdsp::bindings::numpy_to_mat_fresh;
+using mpdsp::bindings::numpy_to_vec_fresh;
+using mpdsp::bindings::dispatch_dtype_fn;
 
 namespace {
 
@@ -65,54 +70,16 @@ static void check_dims(std::size_t rows, std::size_t cols, const char* name) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Dtype dispatcher for free-function processors.
+// Processors share the pattern:
 //
-// Free functions like convolve2d can't use make_impl_for_dtype<Impl, Base>
-// (that one constructs a class Impl<T>). Instead, a per-function dispatcher
-// instantiates the upstream function template at the requested T, ferries
-// NumPy input through dense2D<T>, runs, and ships the result back as
-// NumPy float64. Future processing bindings use the same shape.
-// ---------------------------------------------------------------------------
-
-template <typename T>
-static np_f64_2d convolve2d_typed(np_f64_2d_ro image, np_f64_2d_ro kernel,
-                                   sw::dsp::BorderMode border, double pad) {
-	auto in_mat  = numpy_to_mat_fresh<T>(image);
-	auto kern    = numpy_to_mat_fresh<T>(kernel);
-	auto result  = sw::dsp::convolve2d<T, T>(in_mat, kern, border, static_cast<T>(pad));
-	return mat_to_numpy(result);
-}
-
-static np_f64_2d convolve2d_dispatch(np_f64_2d_ro image, np_f64_2d_ro kernel,
-                                     const std::string& border_name,
-                                     double pad,
-                                     const std::string& dtype) {
-	auto config = mpdsp::parse_config(dtype);
-	auto border = parse_border(border_name);
-	using mpdsp::ArithConfig;
-	using mpdsp::cf24;
-	using mpdsp::half_;
-	using mpdsp::p32;
-	using tiny_posit_t = sw::universal::posit<8, 2>;
-	switch (config) {
-	case ArithConfig::reference:
-		return convolve2d_typed<double>(image, kernel, border, pad);
-	case ArithConfig::gpu_baseline:
-		return convolve2d_typed<float>(image, kernel, border, pad);
-	case ArithConfig::ml_hw:
-		return convolve2d_typed<half_>(image, kernel, border, pad);
-	case ArithConfig::cf24_config:
-		return convolve2d_typed<cf24>(image, kernel, border, pad);
-	case ArithConfig::half_config:
-		return convolve2d_typed<half_>(image, kernel, border, pad);
-	case ArithConfig::posit_full:
-		return convolve2d_typed<p32>(image, kernel, border, pad);
-	case ArithConfig::tiny_posit:
-		return convolve2d_typed<tiny_posit_t>(image, kernel, border, pad);
-	}
-	throw std::invalid_argument("convolve2d: unsupported ArithConfig");
-}
+//   auto config = mpdsp::parse_config(dtype);
+//   return dispatch_dtype_fn(config, "<name>", [&]<typename T>() {
+//       auto m = numpy_to_mat_fresh<T>(image);
+//       return mat_to_numpy(sw::dsp::<fn><T>(m, ...));
+//   });
+//
+// The lambda body is where the per-function work lives; the surrounding
+// dispatcher machinery is shared in _binding_helpers.hpp.
 
 } // namespace
 
@@ -360,7 +327,15 @@ void bind_image(nb::module_& m) {
 				throw std::invalid_argument(
 					"convolve2d: kernel must have non-zero dimensions");
 			}
-			return convolve2d_dispatch(image, kernel, border, pad, dtype);
+			auto config = mpdsp::parse_config(dtype);
+			auto bm = parse_border(border);
+			return dispatch_dtype_fn(config, "convolve2d", [&]<typename T>() {
+				auto in_mat = numpy_to_mat_fresh<T>(image);
+				auto kern   = numpy_to_mat_fresh<T>(kernel);
+				auto result = sw::dsp::convolve2d<T, T>(
+					in_mat, kern, bm, static_cast<T>(pad));
+				return mat_to_numpy(result);
+			});
 		},
 		nb::arg("image"), nb::arg("kernel"),
 		nb::arg("border") = "reflect_101", nb::arg("pad") = 0.0,
@@ -369,4 +344,177 @@ void bind_image(nb::module_& m) {
 		"reflect, reflect_101, or wrap; `pad` is the fill value for "
 		"border='constant'. `dtype` selects the internal arithmetic — see "
 		"available_dtypes().");
+
+	m.def("separable_filter",
+		[](np_f64_2d_ro image, np_f64_ro row_kernel, np_f64_ro col_kernel,
+		   const std::string& border, double pad, const std::string& dtype) {
+			if (image.shape(0) == 0 || image.shape(1) == 0) {
+				throw std::invalid_argument(
+					"separable_filter: image must have non-zero dimensions");
+			}
+			if (row_kernel.shape(0) == 0 || col_kernel.shape(0) == 0) {
+				throw std::invalid_argument(
+					"separable_filter: row_kernel and col_kernel must be non-empty");
+			}
+			auto config = mpdsp::parse_config(dtype);
+			auto bm = parse_border(border);
+			return dispatch_dtype_fn(config, "separable_filter",
+			                          [&]<typename T>() {
+				auto in_mat = numpy_to_mat_fresh<T>(image);
+				auto rk     = numpy_to_vec_fresh<T>(row_kernel);
+				auto ck     = numpy_to_vec_fresh<T>(col_kernel);
+				auto result = sw::dsp::separable_filter<T, T>(
+					in_mat, rk, ck, bm, static_cast<T>(pad));
+				return mat_to_numpy(result);
+			});
+		},
+		nb::arg("image"), nb::arg("row_kernel"), nb::arg("col_kernel"),
+		nb::arg("border") = "reflect_101", nb::arg("pad") = 0.0,
+		nb::arg("dtype") = "reference",
+		"Apply a row kernel then a column kernel (separable 2D filter). "
+		"Equivalent to convolve2d with an outer-product kernel but cheaper "
+		"for K rows * L cols -> O(K+L) per pixel instead of O(K*L).");
+
+	m.def("gaussian_blur",
+		[](np_f64_2d_ro image, double sigma, std::size_t radius,
+		   const std::string& border, const std::string& dtype) {
+			if (image.shape(0) == 0 || image.shape(1) == 0) {
+				throw std::invalid_argument(
+					"gaussian_blur: image must have non-zero dimensions");
+			}
+			if (!(sigma > 0.0)) {
+				throw std::invalid_argument(
+					"gaussian_blur: sigma must be positive");
+			}
+			auto config = mpdsp::parse_config(dtype);
+			auto bm = parse_border(border);
+			return dispatch_dtype_fn(config, "gaussian_blur",
+			                          [&]<typename T>() {
+				auto in_mat = numpy_to_mat_fresh<T>(image);
+				auto result = sw::dsp::gaussian_blur<T>(in_mat, sigma, radius, bm);
+				return mat_to_numpy(result);
+			});
+		},
+		nb::arg("image"), nb::arg("sigma"), nb::arg("radius") = std::size_t{0},
+		nb::arg("border") = "reflect_101", nb::arg("dtype") = "reference",
+		"Separable Gaussian blur. `radius=0` auto-selects a radius that "
+		"captures most of the Gaussian tail (usually ceil(3*sigma)).");
+
+	m.def("box_blur",
+		[](np_f64_2d_ro image, std::size_t size,
+		   const std::string& border, const std::string& dtype) {
+			if (image.shape(0) == 0 || image.shape(1) == 0) {
+				throw std::invalid_argument(
+					"box_blur: image must have non-zero dimensions");
+			}
+			if (size == 0) {
+				throw std::invalid_argument(
+					"box_blur: size must be positive");
+			}
+			auto config = mpdsp::parse_config(dtype);
+			auto bm = parse_border(border);
+			return dispatch_dtype_fn(config, "box_blur",
+			                          [&]<typename T>() {
+				auto in_mat = numpy_to_mat_fresh<T>(image);
+				auto result = sw::dsp::box_blur<T>(in_mat, size, bm);
+				return mat_to_numpy(result);
+			});
+		},
+		nb::arg("image"), nb::arg("size"),
+		nb::arg("border") = "reflect_101", nb::arg("dtype") = "reference",
+		"Box-average blur with an `size x size` uniform kernel.");
+
+	// =======================================================================
+	// Edge detection — Sobel / Prewitt gradient components, their magnitude,
+	// and Canny edge maps. All dtype-dispatched via the same lambda pattern.
+	// =======================================================================
+
+	auto bind_edge_op = [&m](const char* name, auto op) {
+		m.def(name,
+			[name, op](np_f64_2d_ro image, const std::string& border,
+			            const std::string& dtype) {
+				if (image.shape(0) == 0 || image.shape(1) == 0) {
+					throw std::invalid_argument(
+						std::string(name) + ": image must have non-zero dimensions");
+				}
+				auto config = mpdsp::parse_config(dtype);
+				auto bm = parse_border(border);
+				return dispatch_dtype_fn(config, name, [&]<typename T>() {
+					auto in_mat = numpy_to_mat_fresh<T>(image);
+					return mat_to_numpy(op.template operator()<T>(in_mat, bm));
+				});
+			},
+			nb::arg("image"),
+			nb::arg("border") = "reflect_101",
+			nb::arg("dtype") = "reference");
+	};
+
+	bind_edge_op("sobel_x", []<typename T>(const mtl::mat::dense2D<T>& img,
+	                                        sw::dsp::BorderMode bm) {
+		return sw::dsp::sobel_x<T>(img, bm);
+	});
+	bind_edge_op("sobel_y", []<typename T>(const mtl::mat::dense2D<T>& img,
+	                                        sw::dsp::BorderMode bm) {
+		return sw::dsp::sobel_y<T>(img, bm);
+	});
+	bind_edge_op("prewitt_x", []<typename T>(const mtl::mat::dense2D<T>& img,
+	                                          sw::dsp::BorderMode bm) {
+		return sw::dsp::prewitt_x<T>(img, bm);
+	});
+	bind_edge_op("prewitt_y", []<typename T>(const mtl::mat::dense2D<T>& img,
+	                                          sw::dsp::BorderMode bm) {
+		return sw::dsp::prewitt_y<T>(img, bm);
+	});
+
+	m.def("gradient_magnitude",
+		[](np_f64_2d_ro gx, np_f64_2d_ro gy, const std::string& dtype) {
+			if (gx.shape(0) != gy.shape(0) || gx.shape(1) != gy.shape(1)) {
+				throw std::invalid_argument(
+					"gradient_magnitude: gx and gy must have the same shape");
+			}
+			if (gx.shape(0) == 0 || gx.shape(1) == 0) {
+				throw std::invalid_argument(
+					"gradient_magnitude: inputs must have non-zero dimensions");
+			}
+			auto config = mpdsp::parse_config(dtype);
+			return dispatch_dtype_fn(config, "gradient_magnitude",
+			                          [&]<typename T>() {
+				auto gx_mat = numpy_to_mat_fresh<T>(gx);
+				auto gy_mat = numpy_to_mat_fresh<T>(gy);
+				return mat_to_numpy(
+					sw::dsp::gradient_magnitude<T>(gx_mat, gy_mat));
+			});
+		},
+		nb::arg("gx"), nb::arg("gy"), nb::arg("dtype") = "reference",
+		"Pixel-wise sqrt(gx^2 + gy^2). Typically fed Sobel or Prewitt "
+		"gradient outputs.");
+
+	m.def("canny",
+		[](np_f64_2d_ro image, double low_threshold, double high_threshold,
+		   double sigma, const std::string& dtype) {
+			if (image.shape(0) == 0 || image.shape(1) == 0) {
+				throw std::invalid_argument(
+					"canny: image must have non-zero dimensions");
+			}
+			if (!(sigma > 0.0)) {
+				throw std::invalid_argument(
+					"canny: sigma must be positive");
+			}
+			if (!(low_threshold >= 0.0) || !(high_threshold >= low_threshold)) {
+				throw std::invalid_argument(
+					"canny: thresholds must satisfy 0 <= low <= high");
+			}
+			auto config = mpdsp::parse_config(dtype);
+			return dispatch_dtype_fn(config, "canny", [&]<typename T>() {
+				auto in_mat = numpy_to_mat_fresh<T>(image);
+				auto result = sw::dsp::canny<T>(in_mat, low_threshold,
+				                                 high_threshold, sigma);
+				return mat_to_numpy(result);
+			});
+		},
+		nb::arg("image"), nb::arg("low_threshold"), nb::arg("high_threshold"),
+		nb::arg("sigma") = 1.0, nb::arg("dtype") = "reference",
+		"Canny edge detector: Gaussian smooth, Sobel gradients, non-maximum "
+		"suppression, hysteresis thresholding. Returns a binary edge map "
+		"(0.0 for non-edge, 1.0 for edge).");
 }

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -395,3 +395,233 @@ class TestConvolve2dDtypeDispatch:
         alt = mpdsp.convolve2d(img, kernel, dtype="half")
         err = np.max(np.abs(ref - alt)) / (np.max(np.abs(ref)) + 1e-12)
         assert err < 0.02
+
+
+# ---------------------------------------------------------------------------
+# Separable filter
+# ---------------------------------------------------------------------------
+
+
+class TestSeparableFilter:
+    def test_identity_kernels_round_trip(self):
+        img = mpdsp.checkerboard(8, 8, block_size=2)
+        one = np.array([1.0])
+        out = mpdsp.separable_filter(img, one, one)
+        np.testing.assert_array_equal(out, img)
+
+    def test_matches_convolve2d_for_outer_product(self):
+        """Separable with row/col kernels should match convolve2d with the
+        outer-product kernel to within floating-point tolerance."""
+        img = mpdsp.gaussian_blob(16, 16, sigma=3.0)
+        r = np.array([0.25, 0.5, 0.25])
+        c = np.array([1.0, 2.0, 1.0])
+        sep = mpdsp.separable_filter(img, r, c)
+        ref = mpdsp.convolve2d(img, np.outer(c, r))
+        np.testing.assert_allclose(sep, ref, atol=1e-12)
+
+    def test_empty_image_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.separable_filter(np.zeros((0, 5)),
+                                    np.array([1.0]), np.array([1.0]))
+
+    def test_empty_kernel_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.separable_filter(np.ones((5, 5)),
+                                    np.array([]), np.array([1.0]))
+
+
+# ---------------------------------------------------------------------------
+# Gaussian + box blur
+# ---------------------------------------------------------------------------
+
+
+class TestGaussianBlur:
+    def test_shape_preserved(self):
+        img = mpdsp.gaussian_blob(16, 16, sigma=3.0)
+        out = mpdsp.gaussian_blur(img, sigma=1.5)
+        assert out.shape == img.shape
+
+    def test_blurring_reduces_high_frequency(self):
+        """A checkerboard has max high-frequency content; blurring should
+        reduce the peak-to-peak range of interior pixels."""
+        img = mpdsp.checkerboard(16, 16, block_size=1)
+        blurred = mpdsp.gaussian_blur(img, sigma=1.0)
+        interior = blurred[2:-2, 2:-2]
+        assert interior.max() < 1.0
+        assert interior.min() > 0.0
+
+    def test_explicit_radius(self):
+        img = mpdsp.gaussian_blob(24, 24, sigma=3.0)
+        out = mpdsp.gaussian_blur(img, sigma=1.0, radius=5)
+        assert out.shape == img.shape
+
+    def test_non_positive_sigma_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.gaussian_blur(np.ones((5, 5)), sigma=0.0)
+
+    def test_empty_image_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.gaussian_blur(np.zeros((0, 5)), sigma=1.0)
+
+
+class TestBoxBlur:
+    def test_uniform_input_unchanged(self):
+        """Box blur of a uniform image with reflect_101 border is the same
+        uniform image (average of equal values is the same value)."""
+        img = np.full((10, 10), 0.42)
+        out = mpdsp.box_blur(img, size=3)
+        np.testing.assert_allclose(out, 0.42)
+
+    def test_reduces_variance_on_noise(self):
+        rng = np.random.default_rng(0)
+        img = rng.standard_normal((32, 32))
+        out = mpdsp.box_blur(img, size=5)
+        assert out.std() < img.std()
+
+    def test_zero_size_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.box_blur(np.ones((5, 5)), size=0)
+
+
+# ---------------------------------------------------------------------------
+# Edge detection — Sobel / Prewitt / gradient_magnitude / Canny
+# ---------------------------------------------------------------------------
+
+
+class TestSobel:
+    def _vertical_edge(self):
+        """Half-white / half-black image with a vertical edge at x=16."""
+        return mpdsp.rectangle(32, 32, y=0, x=16, h=32, w=16)
+
+    def test_sobel_x_detects_vertical_edge(self):
+        img = self._vertical_edge()
+        sx = mpdsp.sobel_x(img)
+        # sobel_x responds to horizontal derivative; a vertical edge
+        # at column 16 produces non-zero values along that column.
+        assert np.max(np.abs(sx[:, 15:18])) > 0.5
+        # Interior of the uniform regions should be ~0.
+        assert np.max(np.abs(sx[10:20, 2:8])) < 1e-9
+        assert np.max(np.abs(sx[10:20, 24:30])) < 1e-9
+
+    def test_sobel_y_zero_on_vertical_edge(self):
+        """A purely vertical edge has no vertical derivative — sobel_y → 0."""
+        img = self._vertical_edge()
+        sy = mpdsp.sobel_y(img)
+        assert np.max(np.abs(sy)) < 1e-9
+
+    def test_sobel_y_detects_horizontal_edge(self):
+        img = mpdsp.rectangle(32, 32, y=16, x=0, h=16, w=32)
+        sy = mpdsp.sobel_y(img)
+        assert np.max(np.abs(sy[15:18, :])) > 0.5
+
+    def test_empty_image_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.sobel_x(np.zeros((0, 5)))
+
+
+class TestPrewitt:
+    def test_prewitt_x_detects_vertical_edge(self):
+        img = mpdsp.rectangle(32, 32, y=0, x=16, h=32, w=16)
+        px = mpdsp.prewitt_x(img)
+        assert np.max(np.abs(px[:, 15:18])) > 0.5
+
+    def test_prewitt_y_zero_on_vertical_edge(self):
+        img = mpdsp.rectangle(32, 32, y=0, x=16, h=32, w=16)
+        py = mpdsp.prewitt_y(img)
+        assert np.max(np.abs(py)) < 1e-9
+
+
+class TestGradientMagnitude:
+    def test_zeros_input_zero_output(self):
+        z = np.zeros((8, 8))
+        gm = mpdsp.gradient_magnitude(z, z)
+        np.testing.assert_array_equal(gm, 0.0)
+
+    def test_sqrt_sum_of_squares(self):
+        gx = np.array([[3.0, 0.0], [0.0, 4.0]])
+        gy = np.array([[4.0, 0.0], [0.0, 3.0]])
+        gm = mpdsp.gradient_magnitude(gx, gy)
+        # sqrt(3^2 + 4^2) = 5 on both diagonal elements.
+        assert gm[0, 0] == pytest.approx(5.0)
+        assert gm[1, 1] == pytest.approx(5.0)
+        assert gm[0, 1] == 0.0
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            mpdsp.gradient_magnitude(np.zeros((4, 4)), np.zeros((4, 5)))
+
+
+class TestCanny:
+    def test_binary_output(self):
+        img = mpdsp.rectangle(32, 32, y=0, x=16, h=32, w=16)
+        edges = mpdsp.canny(img, low_threshold=0.1, high_threshold=0.3)
+        assert set(np.unique(edges).tolist()) == {0.0, 1.0}
+
+    def test_edges_appear_near_true_edge(self):
+        """For a half-image, Canny should place edge pixels near x=16."""
+        img = mpdsp.rectangle(32, 32, y=0, x=16, h=32, w=16)
+        edges = mpdsp.canny(img, low_threshold=0.1, high_threshold=0.3)
+        edge_cols = np.where(edges > 0.5)[1]
+        assert len(edge_cols) > 0
+        # Edges cluster near column 16.
+        assert abs(np.median(edge_cols) - 16) <= 2
+
+    def test_no_edges_on_uniform_image(self):
+        img = np.full((16, 16), 0.5)
+        edges = mpdsp.canny(img, low_threshold=0.1, high_threshold=0.3)
+        assert edges.sum() == 0.0
+
+    def test_invalid_thresholds_raise(self):
+        img = np.ones((8, 8))
+        # low > high
+        with pytest.raises(ValueError):
+            mpdsp.canny(img, low_threshold=0.5, high_threshold=0.1)
+        # negative low
+        with pytest.raises(ValueError):
+            mpdsp.canny(img, low_threshold=-0.1, high_threshold=0.3)
+
+    def test_non_positive_sigma_raises(self):
+        img = np.ones((8, 8))
+        with pytest.raises(ValueError):
+            mpdsp.canny(img, low_threshold=0.1, high_threshold=0.3, sigma=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Processor dtype dispatch — one parametrized sanity test covers all 9
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [
+    "reference", "gpu_baseline", "ml_hw", "cf24", "half",
+    "posit_full", "tiny_posit",
+])
+class TestProcessorDtypeDispatch:
+    def test_gaussian_blur_runs(self, dtype):
+        img = mpdsp.gaussian_blob(16, 16, sigma=3.0)
+        out = mpdsp.gaussian_blur(img, sigma=1.0, dtype=dtype)
+        assert out.shape == img.shape
+        assert np.all(np.isfinite(out))
+
+    def test_sobel_x_runs(self, dtype):
+        img = mpdsp.rectangle(16, 16, y=0, x=8, h=16, w=8)
+        out = mpdsp.sobel_x(img, dtype=dtype)
+        assert out.shape == img.shape
+
+    def test_gradient_magnitude_runs(self, dtype):
+        gx = mpdsp.gaussian_blob(8, 8, sigma=2.0)
+        gy = mpdsp.gaussian_blob(8, 8, sigma=2.0)
+        out = mpdsp.gradient_magnitude(gx, gy, dtype=dtype)
+        assert out.shape == gx.shape
+
+
+def test_canny_posit_differs_from_reference():
+    """Acceptance criterion from issue #7: canny(..., dtype='tiny_posit')
+    produces measurably different edges than reference."""
+    rng = np.random.default_rng(3)
+    img = mpdsp.gaussian_blob(32, 32, sigma=4.0) + 0.02 * rng.standard_normal((32, 32))
+    ref   = mpdsp.canny(img, low_threshold=0.05, high_threshold=0.15, dtype="reference")
+    posit = mpdsp.canny(img, low_threshold=0.05, high_threshold=0.15, dtype="tiny_posit")
+    # Each is a binary edge map; differences are pixels where one has an
+    # edge and the other doesn't.
+    different_pixels = int((ref != posit).sum())
+    assert different_pixels > 0


### PR DESCRIPTION
## Summary

Third slice of Phase 6 (#7). Nine new dtype-dispatched processors, plus two shared helpers in `_binding_helpers.hpp` to keep per-function boilerplate tight.

## Two new helpers

`_binding_helpers.hpp`:

- **`numpy_to_vec_fresh<T>(src)`** — 1D counterpart to `numpy_to_mat_fresh`. First caller is `separable_filter` which takes two 1D kernels alongside a 2D image.
- **`dispatch_dtype_fn(config, name, callable)`** — free-function counterpart to `make_impl_for_dtype`. Invokes a C++20 explicit-template-argument lambda for the T matching `config` and returns whatever the lambda returns. Replaces the `ArithConfig` switch that previously lived in each processor's `*_dispatch` function — cuts ~15 lines per processor.

## Nine new bindings

| Function | Signature |
|----------|-----------|
| `separable_filter` | `(image, row_kernel, col_kernel, border=\"reflect_101\", pad=0, dtype)` |
| `gaussian_blur` | `(image, sigma, radius=0, border, dtype)` |
| `box_blur` | `(image, size, border, dtype)` |
| `sobel_x` / `sobel_y` | `(image, border, dtype)` |
| `prewitt_x` / `prewitt_y` | `(image, border, dtype)` |
| `gradient_magnitude` | `(gx, gy, dtype)` |
| `canny` | `(image, low_threshold, high_threshold, sigma=1.0, dtype)` — returns binary edge map |

## Refactor

`convolve2d`'s hand-written per-function `*_typed` + `*_dispatch` pair (from #28) is replaced by the same `dispatch_dtype_fn(...)` lambda pattern every new processor uses. All 10 image processors now read identically.

## Validation

- Non-zero image dims on every processor
- Non-empty kernels where applicable (`separable`, `convolve2d`)
- `sigma > 0` for `gaussian_blur` and `canny`
- `size > 0` for `box_blur`
- `0 <= low_threshold <= high_threshold` for `canny`
- Matching shapes for `gradient_magnitude(gx, gy)`

## Tests (48 new, 118 total)

- **Separable**: identity kernels exact round-trip; matches `convolve2d` with outer-product kernel to 1e-12
- **Blurs**: shape preservation, HF reduction, uniform-input invariance (box), sigma/size rejection
- **Sobel/Prewitt**: detect vertical edge as expected; Y-component is zero on vertical edge (directional correctness)
- **Gradient magnitude**: `sqrt(gx² + gy²)`, shape mismatch rejected
- **Canny**: binary output, edges cluster near true edge location, uniform image yields no edges, invalid-threshold rejection
- **Processor dtype dispatch**: parametrized across all 7 dtypes for `gaussian_blur`, `sobel_x`, `gradient_magnitude`
- **Acceptance criterion from #7**: `canny(dtype=\"tiny_posit\")` produces measurably different edges than `reference`

## Test Results
| Build | Image tests | Full suite |
|-------|-------------|------------|
| gcc | 118/118 pass | 432/432 pass |
| clang | 118/118 pass | 432/432 pass |

(Up from 70 / 384 after #29.)

## Follow-up (remaining under #7)

| PR | Scope |
|----|-------|
| **#d** | Morphology (7 ops + 3 element constructors) + multi-channel (`rgb_to_gray`, `apply_per_channel`) |
| **#e** | I/O (PGM/PPM/BMP) + Python helpers (`image.py`) + two notebooks → closes #7 |

## Test plan
- [x] Fast CI passes (gcc + clang + MSVC + Apple Clang)
- [x] Promote to ready and merge once green

Relates to #7

Generated with [Claude Code](https://claude.com/claude-code)