### PR TITLE
feat(image): morphology, structuring elements, and multi-channel

### DIFF
--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -61,6 +61,13 @@ try:
         # Image — edge detection
         sobel_x, sobel_y, prewitt_x, prewitt_y,
         gradient_magnitude, canny,
+        # Image — morphology
+        make_rect_element, make_cross_element, make_ellipse_element,
+        dilate, erode,
+        morphological_open, morphological_close,
+        morphological_gradient, tophat, blackhat,
+        # Image — multi-channel
+        rgb_to_gray,
         # Introspection
         available_dtypes,
     )
@@ -90,3 +97,7 @@ if HAS_CORE:
         plot_adaptive_convergence,
         collect_adaptive_weights,
     )
+
+# Image multi-channel helpers (pure Python; no matplotlib dependency yet)
+if HAS_CORE:
+    from mpdsp.image import apply_per_channel

--- a/python/mpdsp/image.py
+++ b/python/mpdsp/image.py
@@ -1,0 +1,50 @@
+"""Multi-channel convenience helpers for image processing.
+
+The C++ bindings in `mpdsp._core` operate on single-channel NumPy 2D
+float64 arrays. RGB / RGBA processing is handled at the Python level by
+unpacking the channels, running the per-channel pipeline, and re-packing
+the results — `apply_per_channel` is that three-liner made explicit.
+
+Pipeline / grid plotting helpers will land in a follow-up PR alongside
+the image-processing notebooks.
+"""
+
+from typing import Callable, Tuple
+
+import numpy as np
+
+
+def apply_per_channel(r: np.ndarray, g: np.ndarray, b: np.ndarray,
+                      func: Callable[[np.ndarray], np.ndarray]
+                      ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Run a single-channel image function across three RGB planes.
+
+    Parameters
+    ----------
+    r, g, b : numpy.ndarray
+        Three 2D float64 arrays of the same shape (red, green, blue planes).
+    func : callable
+        A function that takes a single 2D NumPy array and returns one.
+        Typical callers pass a lambda that calls one of the `mpdsp` image
+        processors, e.g. ``lambda plane: mpdsp.gaussian_blur(plane, sigma=1)``.
+
+    Returns
+    -------
+    tuple of (r_out, g_out, b_out)
+        The three independently-processed planes. Shape checking is on the
+        caller — `func` is trusted to preserve whatever shape contract it
+        documents.
+
+    Raises
+    ------
+    ValueError
+        If the three input planes don't have identical shapes.
+    """
+    r = np.asarray(r)
+    g = np.asarray(g)
+    b = np.asarray(b)
+    if not (r.shape == g.shape == b.shape):
+        raise ValueError(
+            f"apply_per_channel: r/g/b must have the same shape; got "
+            f"{r.shape}, {g.shape}, {b.shape}")
+    return func(r), func(g), func(b)

--- a/src/_binding_helpers.hpp
+++ b/src/_binding_helpers.hpp
@@ -50,6 +50,10 @@ using np_f64_ro    = nb::ndarray<nb::numpy, const double, nb::ndim<1>, nb::c_con
 using np_f64_2d    = nb::ndarray<nb::numpy, double, nb::ndim<2>>;
 using np_f64_2d_ro = nb::ndarray<nb::numpy, const double, nb::ndim<2>, nb::c_contig>;
 
+// Boolean 2D (used for morphology structuring elements).
+using np_bool_2d    = nb::ndarray<nb::numpy, bool, nb::ndim<2>>;
+using np_bool_2d_ro = nb::ndarray<nb::numpy, const bool, nb::ndim<2>, nb::c_contig>;
+
 // ---------------------------------------------------------------------------
 // Owning output-buffer builders. Ownership is transferred to the nb::capsule
 // only after the capsule constructor succeeds, so a throw on the capsule
@@ -66,6 +70,24 @@ inline np_f64 make_f64_array(std::size_t n, double*& out_ptr) {
 	out_ptr = data;
 	std::size_t shape[1] = { n };
 	return np_f64(data, 1, shape, owner);
+}
+
+inline np_bool_2d make_bool_2d_array(std::size_t rows, std::size_t cols,
+                                     bool*& out_ptr) {
+	if (cols != 0 && rows > std::numeric_limits<std::size_t>::max() / cols) {
+		throw std::overflow_error(
+			"make_bool_2d_array: rows * cols overflows size_t");
+	}
+	std::size_t total = rows * cols;
+	auto buf = std::unique_ptr<bool[]>(new bool[total]);
+	bool* data = buf.get();
+	nb::capsule owner(data, [](void* p) noexcept {
+		delete[] static_cast<bool*>(p);
+	});
+	buf.release();
+	out_ptr = data;
+	std::size_t shape[2] = { rows, cols };
+	return np_bool_2d(data, 2, shape, owner);
 }
 
 inline np_f64_2d make_f64_2d_array(std::size_t rows, std::size_t cols,
@@ -171,6 +193,35 @@ inline mtl::mat::dense2D<T> numpy_to_mat_fresh(np_f64_2d_ro src) {
 	for (std::size_t r = 0; r < rows; ++r) {
 		for (std::size_t c = 0; c < cols; ++c) {
 			dst(r, c) = static_cast<T>(data[r * cols + c]);
+		}
+	}
+	return dst;
+}
+
+// Boolean-matrix marshalling. dense2D<bool> -> NumPy bool array (copy).
+inline np_bool_2d bool_mat_to_numpy(const mtl::mat::dense2D<bool>& m) {
+	std::size_t rows = m.num_rows();
+	std::size_t cols = m.num_cols();
+	bool* out_ptr = nullptr;
+	auto arr = make_bool_2d_array(rows, cols, out_ptr);
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			out_ptr[r * cols + c] = m(r, c);
+		}
+	}
+	return arr;
+}
+
+// NumPy bool array -> freshly-allocated dense2D<bool>. Used by morphology
+// bindings that take a structuring element.
+inline mtl::mat::dense2D<bool> numpy_to_bool_mat_fresh(np_bool_2d_ro src) {
+	std::size_t rows = src.shape(0);
+	std::size_t cols = src.shape(1);
+	mtl::mat::dense2D<bool> dst(rows, cols);
+	const bool* data = src.data();
+	for (std::size_t r = 0; r < rows; ++r) {
+		for (std::size_t c = 0; c < cols; ++c) {
+			dst(r, c) = data[r * cols + c];
 		}
 	}
 	return dst;

--- a/src/image_bindings.cpp
+++ b/src/image_bindings.cpp
@@ -22,6 +22,7 @@
 #include <sw/dsp/image/edge.hpp>
 #include <sw/dsp/image/generators.hpp>
 #include <sw/dsp/image/image.hpp>
+#include <sw/dsp/image/morphology.hpp>
 #include <sw/dsp/image/separable.hpp>
 
 #include "_binding_helpers.hpp"
@@ -36,8 +37,12 @@ namespace nb = nanobind;
 using mpdsp::bindings::np_f64_ro;
 using mpdsp::bindings::np_f64_2d;
 using mpdsp::bindings::np_f64_2d_ro;
+using mpdsp::bindings::np_bool_2d;
+using mpdsp::bindings::np_bool_2d_ro;
 using mpdsp::bindings::mat_to_numpy;
+using mpdsp::bindings::bool_mat_to_numpy;
 using mpdsp::bindings::numpy_to_mat_fresh;
+using mpdsp::bindings::numpy_to_bool_mat_fresh;
 using mpdsp::bindings::numpy_to_vec_fresh;
 using mpdsp::bindings::dispatch_dtype_fn;
 
@@ -517,4 +522,133 @@ void bind_image(nb::module_& m) {
 		"Canny edge detector: Gaussian smooth, Sobel gradients, non-maximum "
 		"suppression, hysteresis thresholding. Returns a binary edge map "
 		"(0.0 for non-edge, 1.0 for edge).");
+
+	// =======================================================================
+	// Morphology — structuring-element constructors (return NumPy bool 2D)
+	// and the seven gray-level ops (image: float64 2D, element: bool 2D,
+	// dtype selects internal arithmetic).
+	// =======================================================================
+
+	m.def("make_rect_element",
+		[](std::size_t rows, std::size_t cols) {
+			if (rows == 0 || cols == 0) {
+				throw std::invalid_argument(
+					"make_rect_element: rows and cols must be positive");
+			}
+			return bool_mat_to_numpy(sw::dsp::make_rect_element(rows, cols));
+		},
+		nb::arg("rows"), nb::arg("cols"),
+		"Rectangular structuring element of shape (rows, cols), all True.");
+
+	m.def("make_cross_element",
+		[](std::size_t size) {
+			if (size == 0) {
+				throw std::invalid_argument(
+					"make_cross_element: size must be positive");
+			}
+			return bool_mat_to_numpy(sw::dsp::make_cross_element(size));
+		},
+		nb::arg("size"),
+		"Cross-shaped structuring element of size `size`x`size`: True along "
+		"the center row and center column, False elsewhere.");
+
+	m.def("make_ellipse_element",
+		[](std::size_t size) {
+			if (size == 0) {
+				throw std::invalid_argument(
+					"make_ellipse_element: size must be positive");
+			}
+			return bool_mat_to_numpy(sw::dsp::make_ellipse_element(size));
+		},
+		nb::arg("size"),
+		"Elliptical (disk-like) structuring element of size `size`x`size`.");
+
+	// Morphology ops share a dispatch body: fetch image + element, instantiate
+	// the right T, call upstream. Wrap the repeating shell in a lambda so each
+	// op registration stays one line.
+	auto bind_morph_op = [&m](const char* name, auto op) {
+		m.def(name,
+			[name, op](np_f64_2d_ro image, np_bool_2d_ro element,
+			            const std::string& dtype) {
+				if (image.shape(0) == 0 || image.shape(1) == 0) {
+					throw std::invalid_argument(
+						std::string(name) + ": image must have non-zero dimensions");
+				}
+				if (element.shape(0) == 0 || element.shape(1) == 0) {
+					throw std::invalid_argument(
+						std::string(name) + ": element must have non-zero dimensions");
+				}
+				auto config = mpdsp::parse_config(dtype);
+				auto elem_mat = numpy_to_bool_mat_fresh(element);
+				return dispatch_dtype_fn(config, name, [&]<typename T>() {
+					auto img_mat = numpy_to_mat_fresh<T>(image);
+					return mat_to_numpy(op.template operator()<T>(img_mat, elem_mat));
+				});
+			},
+			nb::arg("image"), nb::arg("element"),
+			nb::arg("dtype") = "reference");
+	};
+
+	bind_morph_op("dilate", []<typename T>(const mtl::mat::dense2D<T>& img,
+	                                        const mtl::mat::dense2D<bool>& elem) {
+		return sw::dsp::dilate<T>(img, elem);
+	});
+	bind_morph_op("erode", []<typename T>(const mtl::mat::dense2D<T>& img,
+	                                       const mtl::mat::dense2D<bool>& elem) {
+		return sw::dsp::erode<T>(img, elem);
+	});
+	bind_morph_op("morphological_open",
+		[]<typename T>(const mtl::mat::dense2D<T>& img,
+		               const mtl::mat::dense2D<bool>& elem) {
+			return sw::dsp::morphological_open<T>(img, elem);
+		});
+	bind_morph_op("morphological_close",
+		[]<typename T>(const mtl::mat::dense2D<T>& img,
+		               const mtl::mat::dense2D<bool>& elem) {
+			return sw::dsp::morphological_close<T>(img, elem);
+		});
+	bind_morph_op("morphological_gradient",
+		[]<typename T>(const mtl::mat::dense2D<T>& img,
+		               const mtl::mat::dense2D<bool>& elem) {
+			return sw::dsp::morphological_gradient<T>(img, elem);
+		});
+	bind_morph_op("tophat", []<typename T>(const mtl::mat::dense2D<T>& img,
+	                                        const mtl::mat::dense2D<bool>& elem) {
+		return sw::dsp::tophat<T>(img, elem);
+	});
+	bind_morph_op("blackhat", []<typename T>(const mtl::mat::dense2D<T>& img,
+	                                          const mtl::mat::dense2D<bool>& elem) {
+		return sw::dsp::blackhat<T>(img, elem);
+	});
+
+	// =======================================================================
+	// Multi-channel — rgb_to_gray. (apply_per_channel is a pure-Python
+	// convenience in mpdsp/image.py since it just iterates a callable.)
+	// =======================================================================
+
+	m.def("rgb_to_gray",
+		[](np_f64_2d_ro r, np_f64_2d_ro g, np_f64_2d_ro b,
+		   const std::string& dtype) {
+			if (r.shape(0) != g.shape(0) || r.shape(0) != b.shape(0) ||
+			    r.shape(1) != g.shape(1) || r.shape(1) != b.shape(1)) {
+				throw std::invalid_argument(
+					"rgb_to_gray: r, g, b must all have the same shape");
+			}
+			if (r.shape(0) == 0 || r.shape(1) == 0) {
+				throw std::invalid_argument(
+					"rgb_to_gray: channels must have non-zero dimensions");
+			}
+			auto config = mpdsp::parse_config(dtype);
+			return dispatch_dtype_fn(config, "rgb_to_gray", [&]<typename T>() {
+				sw::dsp::Image<T, 3> rgb;
+				rgb[0] = numpy_to_mat_fresh<T>(r);
+				rgb[1] = numpy_to_mat_fresh<T>(g);
+				rgb[2] = numpy_to_mat_fresh<T>(b);
+				return mat_to_numpy(sw::dsp::rgb_to_gray<T>(rgb));
+			});
+		},
+		nb::arg("r"), nb::arg("g"), nb::arg("b"),
+		nb::arg("dtype") = "reference",
+		"Convert an RGB image (three NumPy 2D arrays) to grayscale using "
+		"ITU-R BT.601 weights: Y = 0.299*R + 0.587*G + 0.114*B.");
 }

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -625,3 +625,258 @@ def test_canny_posit_differs_from_reference():
     # edge and the other doesn't.
     different_pixels = int((ref != posit).sum())
     assert different_pixels > 0
+
+
+# ---------------------------------------------------------------------------
+# Morphology — structuring element constructors
+# ---------------------------------------------------------------------------
+
+
+class TestElementConstructors:
+    def test_rect_element_shape_and_dtype(self):
+        elem = mpdsp.make_rect_element(3, 5)
+        assert elem.shape == (3, 5)
+        assert elem.dtype == np.bool_
+
+    def test_rect_element_all_true(self):
+        elem = mpdsp.make_rect_element(4, 4)
+        assert elem.all()
+
+    def test_cross_element_shape(self):
+        elem = mpdsp.make_cross_element(5)
+        assert elem.shape == (5, 5)
+        assert elem.dtype == np.bool_
+
+    def test_cross_element_center_row_col_true(self):
+        elem = mpdsp.make_cross_element(5)
+        # Center row (row 2) and center column (col 2) are all True.
+        assert elem[2, :].all()
+        assert elem[:, 2].all()
+        # Off-cross corners are False.
+        assert not elem[0, 0]
+        assert not elem[0, 4]
+        assert not elem[4, 0]
+        assert not elem[4, 4]
+
+    def test_ellipse_element_shape(self):
+        elem = mpdsp.make_ellipse_element(5)
+        assert elem.shape == (5, 5)
+        assert elem.dtype == np.bool_
+
+    def test_ellipse_element_center_true(self):
+        elem = mpdsp.make_ellipse_element(7)
+        # Center pixel must be inside the ellipse.
+        assert elem[3, 3]
+
+    def test_ellipse_element_corners_false(self):
+        elem = mpdsp.make_ellipse_element(7)
+        assert not elem[0, 0]
+        assert not elem[0, 6]
+        assert not elem[6, 0]
+        assert not elem[6, 6]
+
+    @pytest.mark.parametrize("ctor,args", [
+        ("make_rect_element", (0, 3)),
+        ("make_rect_element", (3, 0)),
+        ("make_cross_element", (0,)),
+        ("make_ellipse_element", (0,)),
+    ])
+    def test_zero_dims_rejected(self, ctor, args):
+        with pytest.raises(ValueError):
+            getattr(mpdsp, ctor)(*args)
+
+
+# ---------------------------------------------------------------------------
+# Morphology — dilate / erode / open / close / gradient / tophat / blackhat
+# ---------------------------------------------------------------------------
+
+
+class TestDilateErode:
+    def test_dilate_grows_foreground(self):
+        """Dilation expands bright regions under a rect element."""
+        img = mpdsp.circle(21, 21, radius=3)
+        elem = mpdsp.make_rect_element(3, 3)
+        out = mpdsp.dilate(img, elem)
+        assert (out > 0.5).sum() > (img > 0.5).sum()
+
+    def test_erode_shrinks_foreground(self):
+        """Erosion shrinks bright regions."""
+        img = mpdsp.circle(21, 21, radius=5)
+        elem = mpdsp.make_rect_element(3, 3)
+        out = mpdsp.erode(img, elem)
+        assert (out > 0.5).sum() < (img > 0.5).sum()
+
+    def test_dilate_identity_element_unchanged(self):
+        """A 1x1 element (single true pixel) is the identity for dilation."""
+        img = mpdsp.gaussian_blob(9, 9, sigma=2.0)
+        elem = mpdsp.make_rect_element(1, 1)
+        out = mpdsp.dilate(img, elem)
+        np.testing.assert_array_equal(out, img)
+
+    def test_erode_identity_element_unchanged(self):
+        img = mpdsp.gaussian_blob(9, 9, sigma=2.0)
+        elem = mpdsp.make_rect_element(1, 1)
+        out = mpdsp.erode(img, elem)
+        np.testing.assert_array_equal(out, img)
+
+    def test_empty_image_raises(self):
+        elem = mpdsp.make_rect_element(3, 3)
+        with pytest.raises(ValueError):
+            mpdsp.dilate(np.zeros((0, 5)), elem)
+
+    def test_empty_element_raises(self):
+        img = mpdsp.circle(11, 11, radius=3)
+        with pytest.raises(ValueError):
+            mpdsp.dilate(img, np.zeros((0, 3), dtype=bool))
+
+
+class TestMorphologicalOpenClose:
+    def test_open_removes_small_peaks(self):
+        """Opening is erode-then-dilate; it removes isolated salt peaks."""
+        img = np.zeros((15, 15))
+        img[7, 7] = 1.0  # isolated peak
+        elem = mpdsp.make_rect_element(3, 3)
+        out = mpdsp.morphological_open(img, elem)
+        assert out[7, 7] == 0.0
+
+    def test_close_fills_small_holes(self):
+        """Closing is dilate-then-erode; it fills isolated pepper holes."""
+        img = np.ones((15, 15))
+        img[7, 7] = 0.0  # isolated hole
+        elem = mpdsp.make_rect_element(3, 3)
+        out = mpdsp.morphological_close(img, elem)
+        assert out[7, 7] == 1.0
+
+    def test_open_then_close_roughly_idempotent(self):
+        """Opening followed by closing should largely preserve a smooth
+        shape like a circle (aside from the edge-pixel effects)."""
+        img = mpdsp.circle(31, 31, radius=8)
+        elem = mpdsp.make_rect_element(3, 3)
+        oc = mpdsp.morphological_close(mpdsp.morphological_open(img, elem), elem)
+        # Majority of pixels unchanged.
+        diff = np.abs(oc - img)
+        assert (diff < 1e-9).mean() > 0.9
+
+
+class TestMorphologicalGradientTophatBlackhat:
+    def test_gradient_highlights_edges(self):
+        """Morphological gradient = dilate - erode; it's positive only at
+        edges of foreground regions."""
+        img = mpdsp.circle(21, 21, radius=5)
+        elem = mpdsp.make_rect_element(3, 3)
+        out = mpdsp.morphological_gradient(img, elem)
+        # Interior of the circle (far from edge): should be ~0.
+        assert out[10, 10] < 1e-9
+        # On the circle boundary (radius=5 from center): should be > 0.
+        assert out[10, 5] > 0.5 or out[5, 10] > 0.5
+
+    def test_tophat_extracts_small_bright(self):
+        """White tophat = image - opening; extracts small bright features
+        that opening removes."""
+        base = np.zeros((15, 15))
+        base[7, 7] = 1.0
+        elem = mpdsp.make_rect_element(3, 3)
+        out = mpdsp.tophat(base, elem)
+        # The isolated peak survives tophat (opening removes it, so
+        # image - opening preserves it).
+        assert out[7, 7] == pytest.approx(1.0)
+
+    def test_blackhat_extracts_small_dark(self):
+        """Black tophat = closing - image; extracts small dark features
+        that closing fills."""
+        base = np.ones((15, 15))
+        base[7, 7] = 0.0
+        elem = mpdsp.make_rect_element(3, 3)
+        out = mpdsp.blackhat(base, elem)
+        # The isolated hole becomes 1 in blackhat (closing fills it).
+        assert out[7, 7] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Morphology — dtype dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [
+    "reference", "gpu_baseline", "ml_hw", "cf24", "half",
+    "posit_full", "tiny_posit",
+])
+def test_dilate_runs_under_each_dtype(dtype):
+    img = mpdsp.circle(11, 11, radius=3)
+    elem = mpdsp.make_rect_element(3, 3)
+    out = mpdsp.dilate(img, elem, dtype=dtype)
+    assert out.shape == img.shape
+    assert np.all(np.isfinite(out))
+
+
+# ---------------------------------------------------------------------------
+# Multi-channel — rgb_to_gray + apply_per_channel
+# ---------------------------------------------------------------------------
+
+
+class TestRgbToGray:
+    def test_pure_red_gives_luminance_weight(self):
+        """Y = 0.299*R + 0.587*G + 0.114*B. Pure R=1 yields 0.299."""
+        r = np.ones((4, 4))
+        g = np.zeros((4, 4))
+        b = np.zeros((4, 4))
+        gray = mpdsp.rgb_to_gray(r, g, b)
+        assert gray.shape == r.shape
+        np.testing.assert_allclose(gray, 0.299)
+
+    def test_pure_green_gives_luminance_weight(self):
+        r = np.zeros((4, 4))
+        g = np.ones((4, 4))
+        b = np.zeros((4, 4))
+        gray = mpdsp.rgb_to_gray(r, g, b)
+        np.testing.assert_allclose(gray, 0.587)
+
+    def test_pure_blue_gives_luminance_weight(self):
+        r = np.zeros((4, 4))
+        g = np.zeros((4, 4))
+        b = np.ones((4, 4))
+        gray = mpdsp.rgb_to_gray(r, g, b)
+        np.testing.assert_allclose(gray, 0.114)
+
+    def test_white_input_white_output(self):
+        """R=G=B=1 -> Y = 0.299 + 0.587 + 0.114 = 1.0 exactly."""
+        r = np.ones((4, 4))
+        gray = mpdsp.rgb_to_gray(r, r, r)
+        np.testing.assert_allclose(gray, 1.0)
+
+    def test_shape_mismatch_raises(self):
+        r = np.ones((4, 4))
+        g = np.ones((5, 4))  # wrong shape
+        b = np.ones((4, 4))
+        with pytest.raises(ValueError):
+            mpdsp.rgb_to_gray(r, g, b)
+
+
+class TestApplyPerChannel:
+    def test_applies_to_each_plane_independently(self):
+        r = np.ones((3, 3))
+        g = np.ones((3, 3)) * 2.0
+        b = np.ones((3, 3)) * 3.0
+        out_r, out_g, out_b = mpdsp.apply_per_channel(r, g, b,
+                                                       lambda p: p * 10.0)
+        np.testing.assert_allclose(out_r, 10.0)
+        np.testing.assert_allclose(out_g, 20.0)
+        np.testing.assert_allclose(out_b, 30.0)
+
+    def test_composes_with_mpdsp_processors(self):
+        """Common usage: per-channel Gaussian blur."""
+        r = mpdsp.gaussian_blob(16, 16, sigma=3.0)
+        g = mpdsp.gaussian_blob(16, 16, sigma=4.0)
+        b = mpdsp.gaussian_blob(16, 16, sigma=5.0)
+        out_r, out_g, out_b = mpdsp.apply_per_channel(
+            r, g, b, lambda p: mpdsp.gaussian_blur(p, sigma=1.0))
+        assert out_r.shape == r.shape
+        assert out_g.shape == g.shape
+        assert out_b.shape == b.shape
+
+    def test_shape_mismatch_raises(self):
+        r = np.ones((4, 4))
+        g = np.ones((5, 4))
+        b = np.ones((4, 4))
+        with pytest.raises(ValueError):
+            mpdsp.apply_per_channel(r, g, b, lambda p: p)


### PR DESCRIPTION
## Summary

Fourth slice of Phase 6 (#7). Three structuring-element constructors, seven gray-level morphology ops, and the multi-channel bridge (`rgb_to_gray` + `apply_per_channel`).

## New shared helpers (`_binding_helpers.hpp`)

Morphology adds boolean 2D I/O to the binding-helpers surface:

- `np_bool_2d` / `np_bool_2d_ro` typedefs
- `make_bool_2d_array(rows, cols)` owning output builder
- `bool_mat_to_numpy(dense2D<bool>)`
- `numpy_to_bool_mat_fresh(np_bool_2d_ro)`

All three element constructors return NumPy bool 2D; the seven morphology ops take `float64` image + `bool` element and dtype-dispatch the internal arithmetic via the same `dispatch_dtype_fn` pattern from #30.

## New bindings

**Element constructors** (return NumPy bool 2D):
- `make_rect_element(rows, cols)` — all True
- `make_cross_element(size)` — center row + column True
- `make_ellipse_element(size)` — disk-like

**Morphology** (image: float64, element: bool, dtype):
- `dilate`, `erode`
- `morphological_open`, `morphological_close`
- `morphological_gradient` (= dilate − erode)
- `tophat` (= image − open), `blackhat` (= close − image)

**Multi-channel**:
- `rgb_to_gray(r, g, b, dtype)` — ITU-R BT.601 weights (0.299/0.587/0.114)
- `apply_per_channel(r, g, b, func)` — pure Python in new `python/mpdsp/image.py`

`apply_per_channel` lives in Python because it's trivially three calls to `func`. The plotting helpers from the issue (`plot_image`, `plot_image_grid`, `plot_pipeline`) will land in the next PR alongside the notebooks.

## Tests (38 new, 156 total)

**Element constructors**:
- Shape + dtype (`np.bool_`)
- Structural correctness: cross has True on center row/col and False at corners; ellipse has True at center and False at corners
- Zero-dim rejection across all three constructors

**Morphology**:
- `dilate` expands / `erode` shrinks on a circle
- 1×1 element is identity for both
- `open` removes isolated peaks; `close` fills isolated holes
- `open+close` roughly idempotent on smooth shapes (>90% pixels unchanged)
- `morphological_gradient` is ~0 in interiors and positive on edges
- `tophat` preserves isolated bright pixels; `blackhat` highlights isolated dark pixels
- `dilate` dtype-dispatched across all 7 dtypes

**Multi-channel**:
- `rgb_to_gray` luminance weights verified on pure R (0.299), G (0.587), B (0.114); white input → white output exact; shape mismatch rejected
- `apply_per_channel` independent per-plane scaling; composes with `mpdsp.gaussian_blur`; shape mismatch rejected

## Test Results
| Build | Image tests | Full suite |
|-------|-------------|------------|
| gcc | 156/156 pass | 470/470 pass |
| clang | 156/156 pass | 470/470 pass |

(Up from 118 / 432 after #30.)

## One PR left to close #7

| PR | Scope |
|----|-------|
| **#e** | I/O (PGM/PPM/BMP read/write) + Python plotting helpers (`plot_image`, `plot_image_grid`, `plot_pipeline`) + notebooks `07_image_processing.ipynb` + `08_sensor_noise.ipynb` → **closes #7** |

## Test plan
- [x] Fast CI passes (gcc + clang + MSVC + Apple Clang)
- [x] Promote to ready and merge once green

Relates to #7

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added morphological image operations: dilate, erode, open, close, gradient, tophat, and blackhat
  * Added structuring element creators (rectangular, cross, elliptical shapes)
  * Added RGB to grayscale color space conversion
  * Added multi-channel image processing support

* **Tests**
  * Added comprehensive test coverage for morphology operations and color conversion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->