### PR TITLE
chore: lockstep version sync with mixed-precision-dsp (0.4.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,14 @@
 cmake_minimum_required(VERSION 3.22)
-project(mp-dsp-python LANGUAGES CXX)
+
+# Version tracks the mixed-precision-dsp C++ library in lockstep (see
+# docs convention matching mtl5 / mtl5-python). Python-only patches
+# ship as PEP 440 post-releases (e.g. 0.4.1.post1) without bumping
+# this value. scikit-build-core reads the version from this line via
+# the regex provider configured in pyproject.toml — do not hardcode
+# it anywhere else.
+project(mp-dsp-python
+	VERSION 0.4.1
+	LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,15 @@
 [build-system]
-requires = ["scikit-build-core>=0.8", "nanobind>=2.0"]
+# Regex version metadata provider requires scikit-build-core >= 0.10.
+requires = ["scikit-build-core>=0.10", "nanobind>=2.0"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "mpdsp"
-version = "0.1.0"
+# Version is sourced from CMakeLists.txt via scikit-build-core's regex
+# provider (see [tool.scikit-build.metadata.version] below). We track
+# mixed-precision-dsp in lockstep; Python-only patches use PEP 440
+# post-releases. Do not hardcode the version here.
+dynamic = ["version"]
 description = "Python integration layer for the mixed-precision DSP library"
 readme = "README.md"
 license = { text = "MIT" }
@@ -47,6 +52,15 @@ Documentation = "https://github.com/stillwater-sc/mixed-precision-dsp"
 cmake.build-type = "Release"
 wheel.packages = ["python/mpdsp"]
 wheel.install-dir = "mpdsp"
+
+# Single source of truth for the package version: read it from the
+# `project(mp-dsp-python VERSION X.Y.Z)` line in CMakeLists.txt. This
+# keeps Python wheel metadata, the C++ CMake target, and any
+# downstream CMake consumers in lockstep automatically.
+[tool.scikit-build.metadata.version]
+provider = "scikit_build_core.metadata.regex"
+input = "CMakeLists.txt"
+regex = '(?i)project\s*\(\s*mp-dsp-python[^)]*VERSION\s+(?P<value>[0-9]+\.[0-9]+\.[0-9]+)'
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -3,9 +3,28 @@ mpdsp — Python integration layer for the mixed-precision DSP library.
 
 Provides nanobind bindings to sw::dsp (C++20), matplotlib visualizations,
 and Jupyter notebooks for mixed-precision DSP research.
+
+Versioning: __version__ is sourced from the installed wheel metadata,
+which in turn is read from CMakeLists.txt at build time. We track the
+mixed-precision-dsp C++ library version in lockstep. __dsp_version__
+(available once the C++ module loads) reports the version of the
+upstream library the wheel was compiled against — useful for runtime
+verification in research setups where the two can drift during
+development.
 """
 
-__version__ = "0.1.0"
+# Read the installed-package version from wheel metadata so there's
+# exactly one source of truth. Falls back to "0+unknown" when run from
+# an unbuilt source checkout (no wheel metadata present).
+try:
+    from importlib.metadata import PackageNotFoundError, version as _pkg_version
+    try:
+        __version__ = _pkg_version("mpdsp")
+    except PackageNotFoundError:
+        __version__ = "0+unknown"
+    del _pkg_version, PackageNotFoundError
+except ImportError:  # pragma: no cover  -- pre-3.8 fallback not used
+    __version__ = "0+unknown"
 
 # CSV I/O (pure Python, always available)
 from mpdsp.io import load_sweep
@@ -75,9 +94,18 @@ try:
         # Introspection
         available_dtypes,
     )
+    # The underlying mixed-precision-dsp C++ library version the wheel
+    # was built against, sourced from sw::dsp::version.hpp. Matches
+    # __version__ when the lockstep convention holds; divergence means
+    # someone is running a mismatched source checkout, which is what
+    # runtime introspection is for.
+    from mpdsp._core import dsp_version as __dsp_version__
+    from mpdsp._core import dsp_version_info as __dsp_version_info__
     HAS_CORE = True
 except ImportError:
     HAS_CORE = False
+    __dsp_version__ = None
+    __dsp_version_info__ = None
 
 # Plotting (requires matplotlib)
 try:

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -5,6 +5,8 @@
 
 #include <nanobind/nanobind.h>
 
+#include <sw/dsp/version.hpp>
+
 namespace nb = nanobind;
 
 // Forward declarations for sub-module binders
@@ -18,6 +20,16 @@ void bind_image(nb::module_& m);
 
 NB_MODULE(_core, m) {
 	m.doc() = "mpdsp C++ core: mixed-precision DSP bindings via nanobind";
+
+	// Expose the upstream C++ library version the wheel was built against.
+	// Python mirror is mpdsp.__dsp_version__. This is the runtime-checkable
+	// analogue to the build-time lockstep between this package's __version__
+	// and the mixed-precision-dsp release it wraps.
+	m.attr("dsp_version") = sw::dsp::version_string;
+	m.attr("dsp_version_info") = nb::make_tuple(
+		sw::dsp::version_major,
+		sw::dsp::version_minor,
+		sw::dsp::version_patch);
 
 	bind_signals(m);
 	bind_quantization(m);

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -30,12 +30,19 @@ def test_version_attribute_is_well_formed():
 
 
 def test_dsp_version_attribute_is_well_formed():
-    """__dsp_version__ comes from the upstream C++ library."""
+    """__dsp_version__ comes from the upstream C++ library.
+
+    We accept any trailing suffix (e.g. `-dev`, `+git-abc123`) after the
+    numeric prefix so development builds of the peer library don't make
+    this test a liability. The strict invariant — that the numeric
+    triple reconstructs to the same string — is pinned in
+    `test_dsp_version_info_matches_string`.
+    """
     if not mpdsp.HAS_CORE:
         import pytest
         pytest.skip("mpdsp._core not available")
     assert isinstance(mpdsp.__dsp_version__, str)
-    assert re.match(r"^\d+\.\d+\.\d+$", mpdsp.__dsp_version__)
+    assert re.match(r"^\d+\.\d+\.\d+", mpdsp.__dsp_version__)
 
 
 def test_dsp_version_info_triple():
@@ -71,11 +78,11 @@ def test_lockstep_prefix():
     if not mpdsp.HAS_CORE:
         import pytest
         pytest.skip("mpdsp._core not available")
-    py_prefix = ".".join(mpdsp.__version__.split(".")[:3])
-    # Strip any pre-release marker in the third segment
-    # (e.g. "0.4.1rc1" -> "0.4.1"). Regex grabs the numeric prefix.
-    py_prefix_clean = re.match(r"^(\d+\.\d+\.\d+)", mpdsp.__version__).group(1)
-    assert py_prefix_clean == mpdsp.__dsp_version__, (
+    # Strip any pre-release or post-release marker in the third segment
+    # (e.g. "0.4.1rc1" or "0.4.1.post1" -> "0.4.1"). Regex grabs the
+    # numeric X.Y.Z prefix, which is what we pin against dsp_version.
+    py_prefix = re.match(r"^(\d+\.\d+\.\d+)", mpdsp.__version__).group(1)
+    assert py_prefix == mpdsp.__dsp_version__, (
         f"Version lockstep broken: mpdsp.__version__={mpdsp.__version__} "
-        f"prefix={py_prefix_clean} but __dsp_version__={mpdsp.__dsp_version__}"
+        f"prefix={py_prefix} but __dsp_version__={mpdsp.__dsp_version__}"
     )

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,81 @@
+"""Version-sync tests: pin the lockstep convention between the Python
+package version, the C++ library version, and the single source of
+truth in CMakeLists.txt.
+
+Convention (see pyproject.toml): __version__ is sourced dynamically
+from CMakeLists.txt by scikit-build-core's regex provider. This test
+file guards three invariants:
+
+  1. mpdsp.__version__ is readable and well-formed
+  2. mpdsp.__dsp_version__ reports the upstream C++ library version
+     the wheel was built against
+  3. The two match at X.Y.Z (i.e. lockstep held at build time). If a
+     developer is intentionally running a Python-only post-release
+     like 0.4.1.post1, the X.Y.Z prefix still matches.
+"""
+
+from __future__ import annotations
+
+import re
+
+import mpdsp
+
+
+def test_version_attribute_is_well_formed():
+    """__version__ is a PEP 440 version string."""
+    assert isinstance(mpdsp.__version__, str)
+    # Must start with X.Y.Z; suffix (post-release, dev, etc.) is optional.
+    assert re.match(r"^\d+\.\d+\.\d+", mpdsp.__version__), (
+        f"unexpected version: {mpdsp.__version__}")
+
+
+def test_dsp_version_attribute_is_well_formed():
+    """__dsp_version__ comes from the upstream C++ library."""
+    if not mpdsp.HAS_CORE:
+        import pytest
+        pytest.skip("mpdsp._core not available")
+    assert isinstance(mpdsp.__dsp_version__, str)
+    assert re.match(r"^\d+\.\d+\.\d+$", mpdsp.__dsp_version__)
+
+
+def test_dsp_version_info_triple():
+    """__dsp_version_info__ is a (major, minor, patch) tuple of ints."""
+    if not mpdsp.HAS_CORE:
+        import pytest
+        pytest.skip("mpdsp._core not available")
+    info = mpdsp.__dsp_version_info__
+    assert isinstance(info, tuple)
+    assert len(info) == 3
+    assert all(isinstance(x, int) and x >= 0 for x in info)
+
+
+def test_dsp_version_info_matches_string():
+    """The tuple reconstructs to the string form."""
+    if not mpdsp.HAS_CORE:
+        import pytest
+        pytest.skip("mpdsp._core not available")
+    major, minor, patch = mpdsp.__dsp_version_info__
+    assert f"{major}.{minor}.{patch}" == mpdsp.__dsp_version__
+
+
+def test_lockstep_prefix():
+    """The Python package's X.Y.Z prefix matches the C++ library's
+    version string. A Python-only post-release (`0.4.1.post1`) still
+    starts with the same X.Y.Z — that's the whole point of post-
+    releases in PEP 440 — so a prefix check is what we want here.
+
+    Failure means either the C++ peer was upgraded without a
+    corresponding Python bump, or a developer is running against a
+    non-matching local peer checkout. Both are worth surfacing.
+    """
+    if not mpdsp.HAS_CORE:
+        import pytest
+        pytest.skip("mpdsp._core not available")
+    py_prefix = ".".join(mpdsp.__version__.split(".")[:3])
+    # Strip any pre-release marker in the third segment
+    # (e.g. "0.4.1rc1" -> "0.4.1"). Regex grabs the numeric prefix.
+    py_prefix_clean = re.match(r"^(\d+\.\d+\.\d+)", mpdsp.__version__).group(1)
+    assert py_prefix_clean == mpdsp.__dsp_version__, (
+        f"Version lockstep broken: mpdsp.__version__={mpdsp.__version__} "
+        f"prefix={py_prefix_clean} but __dsp_version__={mpdsp.__dsp_version__}"
+    )


### PR DESCRIPTION
## Summary

Adopts **Option A (full lockstep)** of the versioning design we discussed — `mp-dsp-python` version tracks `mixed-precision-dsp` in lockstep, matching the `mtl5` / `mtl5-python` precedent. Three mechanical changes plus tests that pin the convention.

Bumps `mpdsp` from `0.1.0` (stale) to `0.4.1` (matching the upstream C++ peer we've been wrapping through Phases 1–6).

## Changes

### 1. Single source of truth — `CMakeLists.txt`

```cmake
project(mp-dsp-python
    VERSION 0.4.1
    LANGUAGES CXX)
```

The version literal here is now the only hardcoded version string in the repo. Everything else reads from it at build time.

### 2. `pyproject.toml` pulls dynamically via `scikit-build-core` regex

- Replaced `version = "0.1.0"` with `dynamic = ["version"]`
- Added `[tool.scikit-build.metadata.version]` with the regex provider pointing at the `project(... VERSION X.Y.Z ...)` line in `CMakeLists.txt`
- Bumped build requirement from `scikit-build-core>=0.8` to `>=0.10` (regex provider was added in 0.10)

Verified: `pip install -e .` reports `"Successfully installed mpdsp-0.4.1"` without the version being set anywhere else.

### 3. `python/mpdsp/__init__.py` drops hardcoded `__version__`

Sourced from installed wheel metadata via `importlib.metadata.version("mpdsp")`. Falls back to `"0+unknown"` when run from an unbuilt source checkout — better than silently reporting a stale literal.

### 4. Runtime introspection: `mpdsp.__dsp_version__`

`src/bindings.cpp` now includes `<sw/dsp/version.hpp>` and exposes:

- `mpdsp._core.dsp_version` — string (e.g. `"0.4.1"`)
- `mpdsp._core.dsp_version_info` — tuple `(major, minor, patch)`

Re-exported as `mpdsp.__dsp_version__` and `mpdsp.__dsp_version_info__`. This is the runtime-checkable analogue to the build-time lockstep — a developer who worries about mismatch between the loaded wheel and the peer C++ library can assert it directly.

### 5. `tests/test_version.py` pins the convention

Five tests:
- `__version__` well-formed (PEP 440)
- `__dsp_version__` well-formed
- `__dsp_version_info__` is a `(major, minor, patch)` triple of ints
- Tuple reconstructs to the string form
- **Lockstep prefix matches** — allows PEP 440 post-releases (a hypothetical `mpdsp-0.4.1.post1` for a Python-only bindings bugfix still satisfies the X.Y.Z prefix match against dsp 0.4.1)

## Test Results
| Build | Version tests | Full suite |
|-------|---------------|------------|
| gcc | 5/5 pass | 490/490 pass |
| clang | 5/5 pass | 490/490 pass |

(Up from 485 after #34.)

## Developer workflow going forward

- **C++ peer bumps** → update the `VERSION` literal in `CMakeLists.txt` in the same commit as the peer-pin change. That's the only place that needs editing.
- **Python-only bindings bugfix** → ship as `0.X.Y.postN` (PEP 440 post-release). Still locks to the same C++ version at the X.Y.Z prefix.
- **Runtime verification** → `import mpdsp; assert mpdsp.__version__.startswith(mpdsp.__dsp_version__)`.

## User-visible behavior

```python
>>> import mpdsp
>>> mpdsp.__version__
'0.4.1'
>>> mpdsp.__dsp_version__
'0.4.1'
>>> mpdsp.__dsp_version_info__
(0, 4, 1)
```

## Test plan
- [x] Fast CI passes (gcc + clang + MSVC + Apple Clang)
- [x] Version tests render in CI output
- [x] Promote to ready and merge once green

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * C++ core library version information is now accessible from the Python package via `__dsp_version__` and `__dsp_version_info__` attributes.

* **Chores**
  * Updated build and version management system; project version bumped to 0.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->