### PR TITLE
chore(build): pin peer dependencies to specific tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,28 @@ project(mp-dsp-python
 	VERSION 0.4.1
 	LANGUAGES CXX)
 
+# ---------------------------------------------------------------------------
+# Peer dependency pins.
+#
+# Update these together with `project(... VERSION ...)` at release time so
+# the wheel built for mpdsp X.Y.Z always links against known-good snapshots
+# of the peers. These pins only affect the FetchContent fallback path —
+# when a sibling checkout of the peer is found next to this repo (see the
+# `_DSP_CANDIDATES` / `_UNI_CANDIDATES` / `_MTL5_CANDIDATES` loops below),
+# that local source is used instead. For wheel builds under cibuildwheel,
+# which has no siblings to find, the pins are what determines what gets
+# compiled into the binary.
+#
+# Override at configure time with `-DMPDSP_DSP_PIN=main` (etc.) to build
+# against an unreleased upstream without editing this file.
+# ---------------------------------------------------------------------------
+set(MPDSP_DSP_PIN       "v0.4.1" CACHE STRING
+	"mixed-precision-dsp git tag / branch / SHA to fetch")
+set(MPDSP_UNIVERSAL_PIN "v4.6.9" CACHE STRING
+	"universal git tag / branch / SHA to fetch")
+set(MPDSP_MTL5_PIN      "v5.2.0" CACHE STRING
+	"mtl5 git tag / branch / SHA to fetch")
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -76,7 +98,7 @@ if(NOT _DSP_FOUND)
   include(FetchContent)
   FetchContent_Declare(dsp
     GIT_REPOSITORY https://github.com/stillwater-sc/mixed-precision-dsp.git
-    GIT_TAG main
+    GIT_TAG ${MPDSP_DSP_PIN}
     GIT_SHALLOW TRUE
   )
   FetchContent_Populate(dsp)
@@ -107,7 +129,7 @@ if(NOT _UNI_FOUND)
   include(FetchContent)
   FetchContent_Declare(universal
     GIT_REPOSITORY https://github.com/stillwater-sc/universal.git
-    GIT_TAG main
+    GIT_TAG ${MPDSP_UNIVERSAL_PIN}
     GIT_SHALLOW TRUE
   )
   FetchContent_Populate(universal)
@@ -141,7 +163,7 @@ else()
     include(FetchContent)
     FetchContent_Declare(mtl5
       GIT_REPOSITORY https://github.com/stillwater-sc/mtl5.git
-      GIT_TAG main
+      GIT_TAG ${MPDSP_MTL5_PIN}
       GIT_SHALLOW TRUE
     )
     FetchContent_Populate(mtl5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,19 @@ set(MPDSP_UNIVERSAL_PIN "v4.6.9" CACHE STRING
 set(MPDSP_MTL5_PIN      "v5.2.0" CACHE STRING
 	"mtl5 git tag / branch / SHA to fetch")
 
+# Shallow-fetch is a big speedup for tags and branches, but git's shallow
+# protocol doesn't support fetching an arbitrary commit SHA — it needs a
+# refname. Detect SHA-looking pins (7–40 hex chars, no non-hex characters)
+# and turn off GIT_SHALLOW for those cases only.
+foreach(_pin IN ITEMS DSP UNIVERSAL MTL5)
+	if(MPDSP_${_pin}_PIN MATCHES "^[a-fA-F0-9]+$" AND
+	   NOT MPDSP_${_pin}_PIN MATCHES "^[a-fA-F0-9]{1,6}$")
+		set(_MPDSP_${_pin}_SHALLOW FALSE)
+	else()
+		set(_MPDSP_${_pin}_SHALLOW TRUE)
+	endif()
+endforeach()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -99,7 +112,7 @@ if(NOT _DSP_FOUND)
   FetchContent_Declare(dsp
     GIT_REPOSITORY https://github.com/stillwater-sc/mixed-precision-dsp.git
     GIT_TAG ${MPDSP_DSP_PIN}
-    GIT_SHALLOW TRUE
+    GIT_SHALLOW ${_MPDSP_DSP_SHALLOW}
   )
   FetchContent_Populate(dsp)
   target_include_directories(sw_dsp INTERFACE "${dsp_SOURCE_DIR}/include")
@@ -130,7 +143,7 @@ if(NOT _UNI_FOUND)
   FetchContent_Declare(universal
     GIT_REPOSITORY https://github.com/stillwater-sc/universal.git
     GIT_TAG ${MPDSP_UNIVERSAL_PIN}
-    GIT_SHALLOW TRUE
+    GIT_SHALLOW ${_MPDSP_UNIVERSAL_SHALLOW}
   )
   FetchContent_Populate(universal)
   target_include_directories(sw_dsp INTERFACE
@@ -164,7 +177,7 @@ else()
     FetchContent_Declare(mtl5
       GIT_REPOSITORY https://github.com/stillwater-sc/mtl5.git
       GIT_TAG ${MPDSP_MTL5_PIN}
-      GIT_SHALLOW TRUE
+      GIT_SHALLOW ${_MPDSP_MTL5_SHALLOW}
     )
     FetchContent_Populate(mtl5)
     target_include_directories(sw_dsp INTERFACE "${mtl5_SOURCE_DIR}/include")


### PR DESCRIPTION
## Summary

Closes step 2 of the first-release checklist in `docs/publishing.md` — the reproducibility fix for wheel builds.

Replaces `GIT_TAG main` across the three `FetchContent_Declare` blocks (mixed-precision-dsp, Universal, MTL5) with **cache-variable pins at the top of `CMakeLists.txt`**. A wheel built today vs tomorrow now binds against the same upstream snapshot, which is essential for published wheels.

## Initial pin values

Matching the first planned PyPI release:

| Peer | Pin | Notes |
|------|-----|-------|
| `MPDSP_DSP_PIN` | `v0.4.1` | Lockstep with `mpdsp` package version |
| `MPDSP_UNIVERSAL_PIN` | `v4.6.9` | Latest tagged Universal release |
| `MPDSP_MTL5_PIN` | `v5.2.0` | Matches what `mtl5-python` pins to |

## Why cache variables rather than literals

1. **All three pins live in one labeled block** near `project(VERSION)` — release-time update is a single location to edit.
2. **Local development against unreleased upstream** is a single flag without editing source:
   ```bash
   cmake -DMPDSP_DSP_PIN=main ...
   ```
3. **CI can exercise the unreleased-upstream path** (nightly regression against peer `main` branches) by passing overrides to `cibuildwheel` or a separate workflow.

## What the pins do NOT affect

The **local-peer-directory fallback path** is untouched. When a sibling peer checkout is found (e.g. `../mixed-precision-dsp`), that local source is still used and the pin is irrelevant. This matters for:

- Developers working on coordinated cross-repo changes (use local siblings, ignore pins)
- `cibuildwheel` containers (no siblings available — pins determine what's baked into the wheel)

## Changes

- `CMakeLists.txt` — +25 / −3 lines
  - New pins block right after `project(...)` (15 lines)
  - Three `GIT_TAG main` → `GIT_TAG ${MPDSP_*_PIN}` substitutions (3 × 1 line)

## Test Results

| Build | Full suite |
|-------|------------|
| gcc (local peers found, pins irrelevant) | 490/490 pass |
| clang (local peers found, pins irrelevant) | 490/490 pass |
| `cmake configure -DMPDSP_DSP_PIN=test-override-tag` | Cache variable correctly populated |

The FetchContent path with pinned tags will be exercised when CI runs cibuildwheel containers; sibling checkouts don't exist there. Local builds with siblings are the common developer case and that path is the one unchanged.

## Next step from the publishing guide

Once this is merged, the remaining first-release checklist is:

1. ~~Merge PR #35 (version lockstep)~~ — done
2. ~~Pin peer dependencies~~ — **this PR**
3. Configure trusted publishers on PyPI + TestPyPI (manual, outside the repo)
4. Dry-run to TestPyPI via `workflow_dispatch`
5. Tag `v0.4.1` → published to PyPI

## Test plan
- [x] Fast CI passes (gcc + clang + MSVC + Apple Clang)
- [x] Promote to ready and merge once green

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system flexibility by making dependency version pinning configurable through CMake variables, enabling more control over upstream Git references for build dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->