### PR TITLE
fix(build): wheel install path + 0.4.1.post1 bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,22 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_BUILD: pip install nanobind numpy
           CIBW_TEST_REQUIRES: pytest numpy matplotlib
-          CIBW_TEST_COMMAND: pytest {project}/tests/ -v --tb=short || echo "Tests not yet available"
+          # `MPDSP_REQUIRE_CORE=1` flips tests/test_version.py from skip-on-
+          # missing-_core to fail-on-missing-_core. Set in the *test* env so
+          # only the wheel-test pytest run sees it, not the build.
+          CIBW_TEST_ENVIRONMENT: "MPDSP_REQUIRE_CORE=1"
+          # Two-stage gate. Smoke test first (must pass — asserts the _core
+          # extension imported cleanly and at least one binding is reachable
+          # via the `mpdsp` namespace), then the full pytest run. An earlier
+          # release shipped with _core.so installed to the wrong path; HAS_CORE
+          # silently went False and the test suite skipped everything, so the
+          # broken wheel reached TestPyPI. Never let that happen again.
+          CIBW_TEST_COMMAND: >-
+            python -c "import mpdsp, sys;
+            assert mpdsp.HAS_CORE, f'_core not importable: {mpdsp.__core_import_error__!r}';
+            assert callable(mpdsp.butterworth_lowpass), 'butterworth_lowpass missing';
+            print(f'smoke ok: mpdsp {mpdsp.__version__} dsp {mpdsp.__dsp_version__}')"
+            && pytest {project}/tests/ -v --tb=short
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,5 +211,9 @@ if(MSVC)
   target_compile_options(_core PRIVATE /std:c++20)
 endif()
 
-# Install the module into the Python package
-install(TARGETS _core LIBRARY DESTINATION mpdsp)
+# Install the module into the Python package.
+# scikit-build-core's `wheel.install-dir = "mpdsp"` already prefixes all CMake
+# install paths with `mpdsp/`, so DESTINATION must be `.` — using `mpdsp` here
+# double-nests the extension to `mpdsp/mpdsp/_core.so` and mpdsp.__init__.py's
+# `from mpdsp._core import ...` silently falls through to HAS_CORE=False.
+install(TARGETS _core LIBRARY DESTINATION .)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,18 @@ wheel.install-dir = "mpdsp"
 # `project(mp-dsp-python VERSION X.Y.Z)` line in CMakeLists.txt. This
 # keeps Python wheel metadata, the C++ CMake target, and any
 # downstream CMake consumers in lockstep automatically.
+#
+# `result` templates the captured X.Y.Z with an optional PEP 440
+# post-release suffix. CMake's project(VERSION) doesn't accept
+# `.postN`, so post-releases live in the `result` template here rather
+# than in CMakeLists.txt. When upstream mixed-precision-dsp bumps
+# (tracked via `project(VERSION ...)` and MPDSP_DSP_PIN), reset this
+# to `"{value}"` so the wheel version matches the new upstream triple.
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"
 input = "CMakeLists.txt"
 regex = '(?i)project\s*\(\s*mp-dsp-python[^)]*VERSION\s+(?P<value>[0-9]+\.[0-9]+\.[0-9]+)'
+result = "{value}.post1"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -29,7 +29,14 @@ except ImportError:  # pragma: no cover  -- pre-3.8 fallback not used
 # CSV I/O (pure Python, always available)
 from mpdsp.io import load_sweep
 
-# C++ bindings (available after building the nanobind module)
+# C++ bindings (available after building the nanobind module).
+# The try/except exists so pure-Python paths (mpdsp.io, mpdsp.plotting) still
+# work in unbuilt source checkouts. But a *failed* import in an installed
+# wheel is a packaging bug — silently falling through to HAS_CORE=False once
+# shipped wheels with `_core.so` installed to the wrong path (see the
+# CMakeLists.txt install() comment). Stash the underlying exception on the
+# module so users can diagnose without re-importing.
+__core_import_error__ = None
 try:
     from mpdsp._core import (
         # Signal generators
@@ -102,10 +109,21 @@ try:
     from mpdsp._core import dsp_version as __dsp_version__
     from mpdsp._core import dsp_version_info as __dsp_version_info__
     HAS_CORE = True
-except ImportError:
+except ImportError as _e:
     HAS_CORE = False
     __dsp_version__ = None
     __dsp_version_info__ = None
+    __core_import_error__ = _e
+    import warnings as _warnings
+    _warnings.warn(
+        f"mpdsp._core failed to import: {_e}. "
+        f"C++ bindings unavailable (filters, spectral, quantization, image). "
+        f"This is expected for unbuilt source checkouts but indicates a "
+        f"packaging bug in an installed wheel.",
+        ImportWarning,
+        stacklevel=2,
+    )
+    del _warnings, _e
 
 # Plotting (requires matplotlib)
 try:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -16,9 +16,31 @@ file guards three invariants:
 
 from __future__ import annotations
 
+import os
 import re
 
 import mpdsp
+
+
+# In CI wheel-test runs we set MPDSP_REQUIRE_CORE=1 so a silently-failed
+# _core import (broken install path, missing symbol, ABI mismatch) fails
+# the test instead of skipping it. Local source-checkout runs leave the
+# var unset — those may legitimately have no extension built yet.
+_REQUIRE_CORE = os.environ.get("MPDSP_REQUIRE_CORE") == "1"
+
+
+def _skip_or_fail_if_no_core():
+    if mpdsp.HAS_CORE:
+        return
+    msg = (
+        f"mpdsp._core unavailable (import error: "
+        f"{mpdsp.__core_import_error__!r}); "
+        f"running against {mpdsp.__file__}"
+    )
+    if _REQUIRE_CORE:
+        raise AssertionError(msg)
+    import pytest
+    pytest.skip(msg)
 
 
 def test_version_attribute_is_well_formed():
@@ -38,18 +60,14 @@ def test_dsp_version_attribute_is_well_formed():
     triple reconstructs to the same string — is pinned in
     `test_dsp_version_info_matches_string`.
     """
-    if not mpdsp.HAS_CORE:
-        import pytest
-        pytest.skip("mpdsp._core not available")
+    _skip_or_fail_if_no_core()
     assert isinstance(mpdsp.__dsp_version__, str)
     assert re.match(r"^\d+\.\d+\.\d+", mpdsp.__dsp_version__)
 
 
 def test_dsp_version_info_triple():
     """__dsp_version_info__ is a (major, minor, patch) tuple of ints."""
-    if not mpdsp.HAS_CORE:
-        import pytest
-        pytest.skip("mpdsp._core not available")
+    _skip_or_fail_if_no_core()
     info = mpdsp.__dsp_version_info__
     assert isinstance(info, tuple)
     assert len(info) == 3
@@ -58,9 +76,7 @@ def test_dsp_version_info_triple():
 
 def test_dsp_version_info_matches_string():
     """The tuple reconstructs to the string form."""
-    if not mpdsp.HAS_CORE:
-        import pytest
-        pytest.skip("mpdsp._core not available")
+    _skip_or_fail_if_no_core()
     major, minor, patch = mpdsp.__dsp_version_info__
     assert f"{major}.{minor}.{patch}" == mpdsp.__dsp_version__
 
@@ -75,9 +91,7 @@ def test_lockstep_prefix():
     corresponding Python bump, or a developer is running against a
     non-matching local peer checkout. Both are worth surfacing.
     """
-    if not mpdsp.HAS_CORE:
-        import pytest
-        pytest.skip("mpdsp._core not available")
+    _skip_or_fail_if_no_core()
     # Strip any pre-release or post-release marker in the third segment
     # (e.g. "0.4.1rc1" or "0.4.1.post1" -> "0.4.1"). Regex grabs the
     # numeric X.Y.Z prefix, which is what we pin against dsp_version.


### PR DESCRIPTION
## Summary
- TestPyPI 0.4.1 wheels installed `_core.so` to `site-packages/mpdsp/mpdsp/_core.so` (nested), so `from mpdsp._core import ...` failed at import and every binding was missing. `HAS_CORE` silently flipped to `False`.
- Root cause: double prefix. `pyproject.toml` has `wheel.install-dir = "mpdsp"` AND `CMakeLists.txt` had `install(TARGETS _core DESTINATION mpdsp)`.
- This PR fixes the install path, ships the patched wheel as `0.4.1.post1` (PEP 440 post-release, per the versioning convention for Python-only packaging fixes), and hardens four different silent-failure points that let the broken wheel through CI.

## Changes
- `CMakeLists.txt` — `install(TARGETS _core LIBRARY DESTINATION .)` + explanatory comment.
- `pyproject.toml` — add `result = "{value}.post1"` to the regex metadata provider so the wheel ships as `0.4.1.post1` without changing `project(VERSION)` (CMake doesn't accept `.postN`).
- `python/mpdsp/__init__.py` — capture the underlying `ImportError` on `__core_import_error__` and emit an `ImportWarning` when `HAS_CORE` flips to `False`.
- `tests/test_version.py` — new helper `_skip_or_fail_if_no_core()` gated on `MPDSP_REQUIRE_CORE=1`. CI wheel tests fail hard; local source checkouts still skip.
- `.github/workflows/publish.yml` — `CIBW_TEST_ENVIRONMENT: "MPDSP_REQUIRE_CORE=1"` plus a two-stage `CIBW_TEST_COMMAND`: unconditional smoke test (asserts `HAS_CORE`, calls `butterworth_lowpass`) then the full pytest run. Removed the `|| echo "Tests not yet available"` fail-open.

## Why a post-release
Upstream `mixed-precision-dsp` is still at `v0.4.1` and nothing about the C++ API changed — this is purely a packaging fix. Per the convention documented in `CMakeLists.txt`, Python-only patches ship as PEP 440 post-releases without bumping `project(VERSION)` or the peer pins.

## Validation path
1. Merge this PR.
2. Trigger `publish.yml` with `target=testpypi`. The new smoke test will refuse to publish if `_core` isn't importable.
3. `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ mpdsp==0.4.1.post1` in a clean venv, then verify `mpdsp.butterworth_lowpass(...)` works.
4. Cut real `v0.4.1.post1` release.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] TestPyPI republish succeeds and the wheel imports cleanly in a fresh venv
- [ ] Promote to ready when satisfied: \`gh pr ready\`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed C++ extension module installation path to prevent incorrect directory nesting in wheel distributions.

* **New Features**
  * Added import warnings and error tracking when C++ bindings fail to load.

* **Chores**
  * Updated version numbering scheme to post-release format.
  * Strengthened wheel testing to enforce C++ bindings availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->