### PR TITLE
feat(dashboard): Streamlit filter-designer for mixed-precision IIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,25 @@ Jupyter notebooks tailored to mixed-precision DSP research:
 | **Precision-cost frontier** | SQNR vs. bits-per-sample Pareto plot |
 | **Kalman tracking** | State estimation convergence across types |
 
+### Interactive Filter Designer
+
+A Streamlit dashboard at `scripts/plot_dashboard.py` exposes every IIR
+family (Butterworth, Chebyshev I/II, Bessel, Legendre, Elliptic, RBJ
+biquads) with live magnitude/phase plots, pole-zero diagrams, impulse
+and step response, and a side-by-side mixed-precision comparison across
+all 7 arithmetic configurations — modeled on Vinnie Falco's classic
+DSPFilters demo, with the mixed-precision angle that is the whole point
+of this library.
+
+```bash
+pip install mpdsp[dashboard]
+streamlit run scripts/plot_dashboard.py
+```
+
+Full walkthrough (install paths for local / SSH-tunnel / LAN, tab-by-tab
+tour, mixed-precision interpretation guide, export conventions) in
+[`docs/dashboard.md`](docs/dashboard.md).
+
 ## How
 
 ### Repository Structure

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,297 @@
+# Interactive Filter Designer
+
+A Streamlit dashboard for designing IIR filters and evaluating them
+under mixed-precision arithmetic. Modeled on Vinnie Falco's classic
+[DSPFilters](https://github.com/vinniefalco/DSPFilters) demo, with the
+side-by-side arithmetic comparison that is the whole point of `mpdsp`.
+
+The dashboard lives at `scripts/plot_dashboard.py` in the repo and
+ships with `mpdsp[dashboard]` via its Streamlit + matplotlib extras.
+
+---
+
+## Contents
+
+- [Install and launch](#install-and-launch)
+- [Tour of the tabs](#tour-of-the-tabs)
+- [Interpreting the mixed-precision comparison](#interpreting-the-mixed-precision-comparison)
+- [Exports](#exports)
+- [Extending the dashboard](#extending-the-dashboard)
+
+---
+
+## Install and launch
+
+The dashboard depends on Streamlit and matplotlib, wrapped in the
+`dashboard` extra:
+
+```bash
+pip install mpdsp[dashboard]
+```
+
+Then from a checkout of this repository (or any directory containing
+`scripts/plot_dashboard.py`):
+
+```bash
+streamlit run scripts/plot_dashboard.py
+```
+
+Streamlit will print three URLs; open the **Local URL** in a browser
+and the app appears. Streamlit listens on `localhost:8501` by default.
+
+### Running on a remote machine
+
+Three common setups, safest first.
+
+#### SSH tunnel (recommended)
+
+Forward the Streamlit port over SSH. No firewall changes, no public
+exposure, and the dashboard survives your LAN's IP plan changing.
+
+On the remote box:
+
+```bash
+streamlit run scripts/plot_dashboard.py
+```
+
+From your laptop:
+
+```bash
+ssh -L 8501:localhost:8501 user@remote
+```
+
+Then browse to `http://localhost:8501` on the laptop. The tunnel lives
+as long as the SSH session.
+
+#### LAN access (open the port, scope by subnet)
+
+If multiple people on your LAN need access and you don't want to hand
+out SSH keys:
+
+```bash
+# On the remote box — open the firewall to the LAN only
+sudo ufw allow from 192.168.1.0/24 to any port 8501 proto tcp \
+    comment 'Streamlit mpdsp dashboard'
+
+# Bind Streamlit to all interfaces (it listens on loopback by default)
+streamlit run scripts/plot_dashboard.py --server.address 0.0.0.0
+```
+
+Adjust `192.168.1.0/24` to whatever CIDR your LAN actually uses. Skip
+the subnet scope (`sudo ufw allow 8501/tcp`) only if you understand
+that Streamlit has no authentication.
+
+#### Public exposure
+
+**Don't.** Streamlit ships with no authentication. If you genuinely
+need a public dashboard, put it behind a reverse proxy with TLS and
+basic auth, or use
+[`streamlit_authenticator`](https://github.com/mkhorasani/Streamlit-Authenticator)
+— scope well beyond this document.
+
+---
+
+## Tour of the tabs
+
+The sidebar drives what the whole dashboard renders. The four tabs in
+the main panel are views of the same filter — changing any sidebar
+control re-renders all of them.
+
+### Sidebar: filter design
+
+- **Family** — Butterworth, Chebyshev I, Chebyshev II, Bessel,
+  Legendre, Elliptic, RBJ. The first six are classical "order-based"
+  designs; RBJ biquads are parameter-based and add shelving and
+  allpass topologies.
+- **Topology** — which variant of the family (lowpass / highpass /
+  bandpass / bandstop, plus RBJ's allpass and lowshelf/highshelf).
+- **Order** — only for the six classical families; 1 to 8. RBJ biquads
+  are fixed 2nd-order.
+- **Sample rate (Hz)** — default 44 100.
+- **Cutoff / Center + Bandwidth / Width** — position and width of the
+  passband/stopband. Upper bound is always Nyquist (sample_rate / 2)
+  minus a 100 Hz margin to avoid edge artifacts.
+- **Family-specific extras** — the sidebar grows the appropriate
+  controls as you switch families:
+  - Chebyshev I: `ripple_db` (passband ripple, in dB).
+  - Chebyshev II: `stopband_db` (stopband attenuation, in dB).
+  - Elliptic: `ripple_db` + `rolloff` (the second controls how fast
+    the transition between passband and stopband is).
+  - RBJ LP/HP/AP: `q` (0.7071 is critically damped).
+  - RBJ BP/BS: `bandwidth` (in octaves).
+  - RBJ shelves: `gain_db` + `q`.
+
+### Sidebar: mixed precision
+
+A multiselect over the 7 pre-instantiated arithmetic configurations
+(`mpdsp.available_dtypes()`):
+
+`reference`, `gpu_baseline`, `ml_hw`, `posit_full`, `tiny_posit`,
+`cf24`, `half`.
+
+The selection drives the **Time domain** and **Mixed-precision
+comparison** tabs, plus the SQNR annotations overlaid on the main
+magnitude plot.
+
+### Sidebar: test signal
+
+The signal the filter is exercised on for SQNR measurements:
+
+- **Shape** — `sine` (a pure tone, easy interpretation), `chirp` (full
+  band sweep, catches transition-band artifacts), or `white_noise`
+  (flat spectrum, stresses numerical error at every frequency).
+- **Length** — 128 to 8192 samples.
+- **Frequency** — only for `sine`.
+
+### Tab 1: Frequency response
+
+The canonical filter-designer view: magnitude (in dB, log scale) and
+unwrapped phase (in radians) over the full `[0, fs/2]` band.
+
+- The **reference curve** is the double-precision frequency response
+  computed from the designed biquad coefficients.
+- If you have any non-reference dtypes selected, they appear as
+  **annotations in the legend** showing the SQNR between that dtype's
+  processed-signal output and the reference. Genuine per-dtype
+  magnitude response requires spectral `dtype=` dispatch, tracked in
+  #40.
+
+### Tab 2: Pole / zero
+
+- The **unit circle** is drawn for reference — stability requires all
+  poles strictly inside it.
+- **Red crosses** mark the pole locations in the z-plane.
+- The title shows the **stability margin** (`1 - max|pole|`): larger
+  is safer.
+- Below the plot, a **per-stage biquad coefficient table** lists
+  `(b0, b1, b2, a1, a2)` for every stage. Always in double — these
+  are the design-time coefficients before any quantization.
+
+### Tab 3: Time domain
+
+Impulse and step response for every selected dtype, overlaid on the
+same pair of axes. Useful for:
+
+- Spotting **instability under quantization** — a reference-stable
+  filter whose `tiny_posit` version blows up exponentially shows up
+  immediately here.
+- Comparing **transient envelope accuracy** — how closely a 6-bit
+  posit tracks the reference ripple on a step response.
+- Seeing **ringing bound** — the peak overshoot on a step.
+
+### Tab 4: Mixed-precision comparison
+
+The payoff tab, and the reason this dashboard exists rather than
+`scipy.signal`.
+
+- **DataFrame** — one row per selected dtype. Columns:
+  - `dtype` — the arithmetic config key.
+  - `sqnr_db` — Signal-to-Quantization-Noise Ratio, in dB, against
+    `reference`. Higher is better. `inf` means exact match.
+  - `max_abs_error` — the largest absolute difference per sample.
+  - `max_rel_error` — the largest relative difference per sample.
+  - `error` — the exception message if a dtype raised (e.g., an
+    unsupported operation), else `None`.
+- **Pole-displacement bar chart** — how far each dtype's quantized
+  coefficients drift the pole locations from reference. Computed via
+  `IIRFilter.pole_displacement(dtype)`.
+
+---
+
+## Interpreting the mixed-precision comparison
+
+Knowing what the numbers mean saves hours. Rules of thumb accumulated
+from the included notebooks:
+
+| SQNR | What it usually means |
+|------|-----------------------|
+| `inf` | Bit-exact with the reference. Your chosen dtype is effectively double for this design. |
+| > 120 dB | Numerically indistinguishable from reference for most applications. `gpu_baseline` sits here. |
+| 60 – 120 dB | High-quality audio / instrumentation regime. `cf24`, `posit_full`, `ml_hw` typical. |
+| 40 – 60 dB | Acceptable for telephony, control, many sensor paths. `half` typical. |
+| 20 – 40 dB | Noise-floor regime — only OK for already-noisy signals. |
+| < 20 dB | The filter has **hit the precision floor**. `tiny_posit` lands here on high-Q filters; the output is dominated by quantization error, not the filter's designed shape. |
+| negative (and growing negative over time) | The quantized filter has gone **unstable**. Compare to the reference's stability margin — most likely the margin was already tight. |
+
+Two common pitfalls surface on this tab:
+
+1. **High-order, low-cutoff filters collapse first.** When poles cluster
+   near the unit circle (high Q), small coefficient displacement knocks
+   them out or around. Watch the pole-displacement bars for the
+   low-precision dtypes before deciding "it works."
+2. **Different test signals produce different SQNR.** A chirp excites
+   the full band; a 440 Hz sine in a lowpass that has a 1 kHz cutoff
+   basically measures the passband, which is the easy region. The
+   SQNR from `chirp` is closer to worst-case; `sine` is closer to
+   best-case. Be explicit about which you're reporting.
+
+---
+
+## Exports
+
+Every tab that produces a figure has a **Download PNG** button. The
+pole/zero tab additionally exports the biquad coefficients as CSV,
+and the mixed-precision tab exports its comparison DataFrame as CSV.
+
+Filenames encode the design so multiple experiments can be diff'd
+later:
+
+```
+butterworth_lowpass_n4_freq.png
+butterworth_lowpass_n4_polezero.png
+butterworth_lowpass_n4_coefficients.csv
+butterworth_lowpass_n4_time.png
+butterworth_lowpass_n4_comparison.csv
+butterworth_lowpass_n4_displacement.png
+
+rbj_lowshelf_freq.png          # no order in filename for RBJ
+```
+
+The pattern is `{family}_{topology}_n{order}_{view}.{ext}` for the
+classical families and `rbj_{topology}_{view}.{ext}` for RBJ biquads
+(which have no `order` concept).
+
+---
+
+## Extending the dashboard
+
+The dashboard is a single file, ~470 lines. Two extension points are
+worth knowing.
+
+### Adding a new filter family
+
+Add an entry to `ORDER_FAMILIES` in `scripts/plot_dashboard.py` if
+it's a classical order-based design, or to `RBJ_VARIANTS` if it's a
+new biquad variant. For an order-based family the schema is:
+
+```python
+"MyFamily": FamilySpec(
+    "MyFamily",
+    extra_params=("my_extra_param",),   # names passed to the makers
+    makers={
+        "lowpass":  mpdsp.myfamily_lowpass,
+        "highpass": mpdsp.myfamily_highpass,
+        "bandpass": mpdsp.myfamily_bandpass,
+        "bandstop": mpdsp.myfamily_bandstop,
+    },
+),
+```
+
+And add the extra parameter's `(min, max, default, step)` tuple to the
+`default_range` dict inside `main()` so the sidebar slider knows how
+to render it.
+
+### Adding a new view (tab)
+
+Write a pure function `plot_my_view(filt, ...) -> matplotlib.Figure`
+and add a new `st.tabs([...])` entry alongside the existing four.
+Keep the helper pure-function (no Streamlit calls inside) — that lets
+the same function run headlessly for testing, which is how the
+existing four helpers are validated in CI.
+
+### Dispatching on a new arithmetic config
+
+New configs come from upstream `mp-dsp-python` via `src/types.hpp`
+and surface through `mpdsp.available_dtypes()`. The dashboard picks
+them up automatically — no dashboard changes needed. Just remember
+to rebuild the wheel.

--- a/scripts/plot_dashboard.py
+++ b/scripts/plot_dashboard.py
@@ -18,7 +18,7 @@ library.
 from __future__ import annotations
 
 import io
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable
 
 import matplotlib.pyplot as plt
@@ -45,7 +45,14 @@ class FamilySpec:
     name: str
     has_order: bool = True
     extra_params: tuple = ()          # names of extra kwargs (e.g. "ripple_db")
-    makers: dict = None               # topology -> callable
+    makers: dict[str, Callable] = field(default_factory=dict)  # topology -> callable
+
+    def __post_init__(self):
+        # A FamilySpec with no topologies is useless and would TypeError at
+        # the first `spec.makers[topology]` lookup. Fail fast at construction.
+        if not self.makers:
+            raise ValueError(f"FamilySpec({self.name!r}) must define at least "
+                             "one topology in `makers`.")
 
 
 ORDER_FAMILIES: dict[str, FamilySpec] = {
@@ -234,8 +241,15 @@ def plot_pole_zero(filt):
     return fig
 
 
-def plot_impulse_step(filt, dtypes: list[str], length: int = 256):
-    """Impulse and step response across selected dtypes."""
+def plot_impulse_step(filt, dtypes: list[str], length: int = 256
+                       ) -> tuple[plt.Figure, list[str]]:
+    """Impulse and step response across selected dtypes.
+
+    Returns `(fig, failures)` — each `failures` entry is a human-readable
+    string like "tiny_posit: unsupported operation" that the caller can
+    surface through `st.warning`. Swallowing silently would leave the
+    user with an empty plot and no indication why.
+    """
     impulse = np.zeros(length)
     impulse[0] = 1.0
     step = np.ones(length)
@@ -248,15 +262,19 @@ def plot_impulse_step(filt, dtypes: list[str], length: int = 256):
         ax.grid(True, alpha=0.4)
         ax.axhline(0.0, color="0.85", linewidth=0.5)
 
+    failures: list[str] = []
     for dt in dtypes:
         try:
             ax_imp.plot(filt.process(impulse, dtype=dt), label=dt, linewidth=1.2)
             ax_step.plot(filt.process(step, dtype=dt), label=dt, linewidth=1.2)
-        except Exception:
-            continue
+        except Exception as e:  # noqa: BLE001
+            failures.append(f"{dt}: {e}")
+            # Render the failure as a legend-only entry so the user sees
+            # which dtype didn't contribute a trace.
+            ax_imp.plot([], [], " ", label=f"{dt}: error")
     ax_imp.legend(loc="best", fontsize="small")
     fig.tight_layout()
-    return fig
+    return fig, failures
 
 
 def figure_to_png_bytes(fig, dpi: int = 150) -> bytes:
@@ -265,17 +283,50 @@ def figure_to_png_bytes(fig, dpi: int = 150) -> bytes:
     return buf.getvalue()
 
 
-def plot_pole_displacement(filt, dtypes: list[str]):
-    """Bar chart: how far each dtype drifts the poles from the reference."""
+def freq_slider_bounds(nyquist: float, preferred_min: float,
+                       preferred_default: float, margin_frac: float = 0.02
+                       ) -> tuple[float, float, float]:
+    """Derive (min, max, default) for a frequency slider keyed to Nyquist.
+
+    At very low sample rates the "preferred" constants (e.g. 20 Hz minimum
+    cutoff, 1 kHz default) would invert `min_value > max_value` or place
+    the default outside `[min, max]`, which Streamlit rejects with an
+    API exception. Clamp everything back into a valid range, preserving
+    the preferred values when the sample rate is high enough. `margin_frac`
+    keeps the upper bound strictly below Nyquist so edge-frequency designs
+    don't land on numerical edge cases in the filter constructors.
+    """
+    hi = max(1.0, nyquist * (1.0 - margin_frac))
+    # preferred_min must not exceed half the usable band, else the slider
+    # becomes single-valued or degenerate.
+    lo = min(preferred_min, hi * 0.5) if hi > 2.0 else hi * 0.5
+    default = min(max(preferred_default, lo), hi)
+    return lo, hi, default
+
+
+def plot_pole_displacement(filt, dtypes: list[str]
+                            ) -> tuple[plt.Figure, list[str]]:
+    """Bar chart: how far each dtype drifts the poles from the reference.
+
+    Returns `(fig, failures)` so the caller can surface per-dtype error
+    messages through `st.warning` — a bar silently dropped from the plot
+    would leave no trail. A short placeholder appears on the chart for
+    every failing dtype so the user can see what was attempted.
+    """
     labels, values = [], []
+    failures: list[str] = []
     for dt in dtypes:
         if dt == "reference":
             continue
         try:
-            labels.append(dt)
-            values.append(filt.pole_displacement(dt))
-        except Exception:
+            d = filt.pole_displacement(dt)
+        except Exception as e:  # noqa: BLE001
+            failures.append(f"{dt}: {e}")
+            labels.append(f"{dt} (err)")
+            values.append(0.0)
             continue
+        labels.append(dt)
+        values.append(d)
     fig, ax = plt.subplots(figsize=(8, 4))
     if not labels:
         ax.text(0.5, 0.5, "No non-reference dtypes selected.",
@@ -286,7 +337,7 @@ def plot_pole_displacement(filt, dtypes: list[str]):
         ax.set_title("How far do quantized coefficients drift the poles?")
         ax.grid(True, alpha=0.3, axis="y")
     fig.tight_layout()
-    return fig
+    return fig, failures
 
 
 # ---------------------------------------------------------------------------
@@ -318,24 +369,27 @@ def main():
         topology = st.sidebar.selectbox("Topology", list(spec.makers.keys()))
         order = st.sidebar.slider("Order", 1, 8, 4)
 
+    # 1 kHz sample-rate floor keeps all derived slider bounds comfortably
+    # above the fixed preferred minimums; the previous 100 Hz floor could
+    # drive nyquist below some slider lower bounds and crash the app.
     sample_rate = st.sidebar.number_input(
-        "Sample rate (Hz)", min_value=100.0, max_value=384_000.0,
+        "Sample rate (Hz)", min_value=1_000.0, max_value=384_000.0,
         value=44_100.0, step=1000.0)
 
     nyquist = sample_rate / 2.0
     freq_params: dict = {}
     if topology in ("lowpass", "highpass", "allpass", "lowshelf", "highshelf"):
+        lo, hi, default = freq_slider_bounds(nyquist, 20.0, nyquist / 4)
         freq_params["cutoff"] = st.sidebar.slider(
-            "Cutoff (Hz)", 20.0, float(nyquist - 100.0),
-            min(1000.0, nyquist / 4), step=10.0)
+            "Cutoff (Hz)", lo, hi, default, step=10.0)
     else:  # bandpass / bandstop
+        lo, hi, default = freq_slider_bounds(nyquist, 50.0, nyquist / 4)
         freq_params["center"] = st.sidebar.slider(
-            "Center frequency (Hz)", 50.0, float(nyquist - 100.0),
-            min(1000.0, nyquist / 4), step=10.0)
+            "Center frequency (Hz)", lo, hi, default, step=10.0)
         if family != "RBJ":
+            lo, hi, default = freq_slider_bounds(nyquist, 20.0, nyquist / 8)
             freq_params["width"] = st.sidebar.slider(
-                "Bandwidth (Hz)", 20.0, float(nyquist - 100.0),
-                min(500.0, nyquist / 8), step=10.0)
+                "Bandwidth (Hz)", lo, hi, default, step=10.0)
 
     # Family-specific extra parameters.
     extra: dict = {}
@@ -381,14 +435,17 @@ def main():
     sig_kind = st.sidebar.selectbox("Shape", ["sine", "chirp", "white_noise"])
     sig_length = st.sidebar.slider("Length (samples)", 128, 8192, 2048, step=128)
     if sig_kind == "sine":
-        sig_freq = st.sidebar.slider("Frequency (Hz)", 20.0, float(nyquist - 100.0),
-                                     min(440.0, nyquist / 10), step=10.0)
+        lo, hi, default = freq_slider_bounds(nyquist, 20.0, nyquist / 10)
+        sig_freq = st.sidebar.slider("Frequency (Hz)", lo, hi, default, step=10.0)
         signal = mpdsp.sine(length=sig_length, frequency=sig_freq,
                             sample_rate=sample_rate)
     elif sig_kind == "chirp":
-        signal = mpdsp.chirp(length=sig_length, f_start=20.0,
-                             f_end=float(nyquist - 100.0),
-                             sample_rate=sample_rate)
+        # f_start/f_end: use the same Nyquist margin as the sliders so the
+        # chirp doesn't drive the design up to the exact Nyquist edge.
+        _, hi, _ = freq_slider_bounds(nyquist, 1.0, nyquist / 2)
+        f_start = min(20.0, hi * 0.5)
+        signal = mpdsp.chirp(length=sig_length, f_start=f_start,
+                             f_end=hi, sample_rate=sample_rate)
     else:
         signal = mpdsp.white_noise(length=sig_length, amplitude=0.5, seed=1)
 
@@ -404,17 +461,24 @@ def main():
     else:
         tag = f"{family.lower().replace(' ', '')}_{topology}_n{order}"
 
+    # Each tab renders a matplotlib Figure, then pipes bytes out for the
+    # PNG download button, then calls `plt.close(fig)`. Without the close,
+    # matplotlib's pyplot registry retains every figure generated on every
+    # slider change, steadily leaking memory in long-lived sessions.
+
     with tab_freq:
         fig = plot_magnitude_phase(filt, sample_rate, selected_dtypes, signal)
         st.pyplot(fig)
         st.download_button("Download PNG", figure_to_png_bytes(fig),
                            f"{tag}_freq.png", "image/png")
+        plt.close(fig)
 
     with tab_pz:
         fig = plot_pole_zero(filt)
         st.pyplot(fig)
         st.download_button("Download PNG", figure_to_png_bytes(fig),
                            f"{tag}_polezero.png", "image/png")
+        plt.close(fig)
         if filt.num_stages() > 0:
             coefs = filt.coefficients()
             st.caption(f"{len(coefs)} biquad stage(s). "
@@ -439,10 +503,13 @@ def main():
                                f"{tag}_coefficients.csv", "text/csv")
 
     with tab_time:
-        fig = plot_impulse_step(filt, selected_dtypes)
+        fig, time_failures = plot_impulse_step(filt, selected_dtypes)
         st.pyplot(fig)
         st.download_button("Download PNG", figure_to_png_bytes(fig),
                            f"{tag}_time.png", "image/png")
+        plt.close(fig)
+        for msg in time_failures:
+            st.warning(f"Time-domain plot skipped {msg}", icon="⚠️")
 
     with tab_prec:
         if not selected_dtypes:
@@ -454,11 +521,14 @@ def main():
             st.download_button("Download comparison CSV",
                                df.to_csv(index=False).encode(),
                                f"{tag}_comparison.csv", "text/csv")
-            fig = plot_pole_displacement(filt, selected_dtypes)
+            fig, disp_failures = plot_pole_displacement(filt, selected_dtypes)
             st.pyplot(fig)
             st.download_button("Download displacement PNG",
                                figure_to_png_bytes(fig),
                                f"{tag}_displacement.png", "image/png")
+            plt.close(fig)
+            for msg in disp_failures:
+                st.warning(f"Pole displacement skipped {msg}", icon="⚠️")
 
     st.caption(
         "Free-function analysis primitives (`biquad_poles`, "

--- a/scripts/plot_dashboard.py
+++ b/scripts/plot_dashboard.py
@@ -1,0 +1,471 @@
+"""Streamlit filter-designer dashboard for mpdsp.
+
+Run with:
+    pip install mpdsp[dashboard]
+    streamlit run scripts/plot_dashboard.py
+
+The dashboard exposes every IIR family, every topology (LP/HP/BP/BS plus
+RBJ shelves/allpass), all 7 mixed-precision arithmetic configurations,
+and the numerical-analysis metrics that mpdsp's IIRFilter carries
+(stability margin, condition number, worst-case sensitivity, per-dtype
+pole displacement).
+
+The goal is feature parity with the classic DSPFilters demo app, plus
+the mixed-precision comparison view that's the whole point of this
+library.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from typing import Callable
+
+import matplotlib.pyplot as plt
+import numpy as np
+import streamlit as st
+
+import mpdsp
+from mpdsp.filters import compare_filters
+
+
+# ---------------------------------------------------------------------------
+# Filter-family registry.
+#
+# Each family binds four topologies (LP/HP/BP/BS) to constructor functions,
+# plus any family-specific parameters (ripple, stopband, rolloff). RBJ is
+# an outlier — its constructors don't take `order` and add shelf/allpass
+# variants — so it gets its own branch in `build_filter()` rather than
+# being forced into this schema.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FamilySpec:
+    name: str
+    has_order: bool = True
+    extra_params: tuple = ()          # names of extra kwargs (e.g. "ripple_db")
+    makers: dict = None               # topology -> callable
+
+
+ORDER_FAMILIES: dict[str, FamilySpec] = {
+    "Butterworth": FamilySpec(
+        "Butterworth",
+        makers={
+            "lowpass":  mpdsp.butterworth_lowpass,
+            "highpass": mpdsp.butterworth_highpass,
+            "bandpass": mpdsp.butterworth_bandpass,
+            "bandstop": mpdsp.butterworth_bandstop,
+        },
+    ),
+    "Chebyshev I": FamilySpec(
+        "Chebyshev I",
+        extra_params=("ripple_db",),
+        makers={
+            "lowpass":  mpdsp.chebyshev1_lowpass,
+            "highpass": mpdsp.chebyshev1_highpass,
+            "bandpass": mpdsp.chebyshev1_bandpass,
+            "bandstop": mpdsp.chebyshev1_bandstop,
+        },
+    ),
+    "Chebyshev II": FamilySpec(
+        "Chebyshev II",
+        extra_params=("stopband_db",),
+        makers={
+            "lowpass":  mpdsp.chebyshev2_lowpass,
+            "highpass": mpdsp.chebyshev2_highpass,
+            "bandpass": mpdsp.chebyshev2_bandpass,
+            "bandstop": mpdsp.chebyshev2_bandstop,
+        },
+    ),
+    "Bessel": FamilySpec(
+        "Bessel",
+        makers={
+            "lowpass":  mpdsp.bessel_lowpass,
+            "highpass": mpdsp.bessel_highpass,
+            "bandpass": mpdsp.bessel_bandpass,
+            "bandstop": mpdsp.bessel_bandstop,
+        },
+    ),
+    "Legendre": FamilySpec(
+        "Legendre",
+        makers={
+            "lowpass":  mpdsp.legendre_lowpass,
+            "highpass": mpdsp.legendre_highpass,
+            "bandpass": mpdsp.legendre_bandpass,
+            "bandstop": mpdsp.legendre_bandstop,
+        },
+    ),
+    "Elliptic": FamilySpec(
+        "Elliptic",
+        extra_params=("ripple_db", "rolloff"),
+        makers={
+            "lowpass":  mpdsp.elliptic_lowpass,
+            "highpass": mpdsp.elliptic_highpass,
+            "bandpass": mpdsp.elliptic_bandpass,
+            "bandstop": mpdsp.elliptic_bandstop,
+        },
+    ),
+}
+
+
+# RBJ biquads are a different shape: no `order`, per-variant parameter set,
+# and include shelf/allpass topologies that don't exist elsewhere. Each
+# entry is (maker, list of (param_name, default, min, max)).
+RBJ_VARIANTS: dict[str, tuple[Callable, tuple]] = {
+    "lowpass":   (mpdsp.rbj_lowpass,   (("q", 0.7071, 0.1, 10.0),)),
+    "highpass":  (mpdsp.rbj_highpass,  (("q", 0.7071, 0.1, 10.0),)),
+    "bandpass":  (mpdsp.rbj_bandpass,  (("bandwidth", 1.0, 0.1, 4.0),)),
+    "bandstop":  (mpdsp.rbj_bandstop,  (("bandwidth", 1.0, 0.1, 4.0),)),
+    "allpass":   (mpdsp.rbj_allpass,   (("q", 0.7071, 0.1, 10.0),)),
+    "lowshelf":  (mpdsp.rbj_lowshelf,  (("gain_db", 6.0, -24.0, 24.0),
+                                         ("q", 0.7071, 0.1, 10.0))),
+    "highshelf": (mpdsp.rbj_highshelf, (("gain_db", 6.0, -24.0, 24.0),
+                                         ("q", 0.7071, 0.1, 10.0))),
+}
+
+
+# ---------------------------------------------------------------------------
+# Filter construction.
+# Isolated in a function so Streamlit's caching keeps re-design cheap when
+# only downstream controls (dtype selection, signal params) change. Filter
+# objects aren't picklable (they hold C++ state), so we cache coefficients
+# and rebuild — cheap enough that the user won't notice.
+# ---------------------------------------------------------------------------
+
+
+def build_filter(family: str, topology: str, order: int, sample_rate: float,
+                 freq_params: dict, extra: dict):
+    """Construct an IIRFilter from sidebar selections.
+
+    `freq_params` holds cutoff / center / width keyed to the topology; `extra`
+    holds ripple / stopband / rolloff / q keyed to the family or RBJ variant.
+    """
+    if family == "RBJ":
+        maker, _ = RBJ_VARIANTS[topology]
+        if topology in ("lowpass", "highpass", "allpass"):
+            return maker(sample_rate, freq_params["cutoff"], extra["q"])
+        if topology in ("bandpass", "bandstop"):
+            return maker(sample_rate, freq_params["center"], extra["bandwidth"])
+        if topology in ("lowshelf", "highshelf"):
+            return maker(sample_rate, freq_params["cutoff"],
+                         extra["gain_db"], extra["q"])
+        raise ValueError(f"Unknown RBJ topology: {topology}")
+
+    spec = ORDER_FAMILIES[family]
+    maker = spec.makers[topology]
+    args = [order, sample_rate]
+    if topology in ("lowpass", "highpass"):
+        args.append(freq_params["cutoff"])
+    else:  # bandpass / bandstop
+        args.extend([freq_params["center"], freq_params["width"]])
+    for p in spec.extra_params:
+        args.append(extra[p])
+    return maker(*args)
+
+
+# ---------------------------------------------------------------------------
+# Plotting helpers. Each returns a matplotlib Figure for st.pyplot().
+# ---------------------------------------------------------------------------
+
+
+def plot_magnitude_phase(filt, sample_rate: float, dtypes: list[str] | None,
+                         signal: np.ndarray | None, num_freqs: int = 1024):
+    """Magnitude (dB) + unwrapped phase across the full [0, fs/2] band.
+
+    If `dtypes` and `signal` are provided, overlays per-dtype magnitude
+    responses computed from the filter's quantized coefficients. Today this
+    just annotates the reference curve with SQNR per dtype; true per-dtype
+    frequency response requires upstream support (#40) for mixed-precision
+    spectral analysis.
+    """
+    freqs = np.linspace(0.0, 0.5, num_freqs)
+    H = filt.frequency_response(freqs)
+    mag_db = 20.0 * np.log10(np.maximum(np.abs(H), 1e-12))
+    phase = np.unwrap(np.angle(H))
+
+    fig, (ax_mag, ax_phase) = plt.subplots(2, 1, figsize=(9, 6), sharex=True)
+    ax_mag.plot(freqs * sample_rate, mag_db, linewidth=1.6, label="reference")
+    ax_mag.set_ylabel("Magnitude (dB)")
+    ax_mag.grid(True, alpha=0.4)
+    ax_mag.set_ylim(bottom=max(-160.0, mag_db.min() - 6.0))
+
+    if dtypes and signal is not None:
+        ref_out = filt.process(signal, dtype="reference")
+        for dt in dtypes:
+            if dt == "reference":
+                continue
+            try:
+                out = filt.process(signal, dtype=dt)
+                sqnr = mpdsp.sqnr_db(ref_out, out)
+                ax_mag.plot([], [], " ", label=f"{dt}: SQNR={sqnr:.1f} dB")
+            except Exception as e:  # noqa: BLE001 - surface whatever upstream throws
+                ax_mag.plot([], [], " ", label=f"{dt}: error")
+        ax_mag.legend(loc="best", fontsize="small")
+
+    ax_phase.plot(freqs * sample_rate, phase, linewidth=1.4, color="C1")
+    ax_phase.set_xlabel("Frequency (Hz)")
+    ax_phase.set_ylabel("Phase (rad, unwrapped)")
+    ax_phase.grid(True, alpha=0.4)
+
+    fig.tight_layout()
+    return fig
+
+
+def plot_pole_zero(filt):
+    poles = np.asarray(filt.poles())
+    theta = np.linspace(0.0, 2 * np.pi, 256)
+    fig, ax = plt.subplots(figsize=(6, 6))
+    ax.plot(np.cos(theta), np.sin(theta), color="0.6", linewidth=0.8)
+    ax.axhline(0.0, color="0.85", linewidth=0.5)
+    ax.axvline(0.0, color="0.85", linewidth=0.5)
+    ax.scatter(poles.real, poles.imag, marker="x", s=90, color="C3",
+               linewidths=2, label=f"poles (n={len(poles)})")
+    ax.set_aspect("equal")
+    ax.set_xlim(-1.2, 1.2)
+    ax.set_ylim(-1.2, 1.2)
+    ax.set_xlabel("Re(z)")
+    ax.set_ylabel("Im(z)")
+    ax.set_title(f"Pole locations — stability margin = "
+                 f"{filt.stability_margin():.4f}")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="upper right")
+    fig.tight_layout()
+    return fig
+
+
+def plot_impulse_step(filt, dtypes: list[str], length: int = 256):
+    """Impulse and step response across selected dtypes."""
+    impulse = np.zeros(length)
+    impulse[0] = 1.0
+    step = np.ones(length)
+
+    fig, (ax_imp, ax_step) = plt.subplots(2, 1, figsize=(9, 6), sharex=True)
+    ax_imp.set_ylabel("Impulse response")
+    ax_step.set_ylabel("Step response")
+    ax_step.set_xlabel("Sample")
+    for ax in (ax_imp, ax_step):
+        ax.grid(True, alpha=0.4)
+        ax.axhline(0.0, color="0.85", linewidth=0.5)
+
+    for dt in dtypes:
+        try:
+            ax_imp.plot(filt.process(impulse, dtype=dt), label=dt, linewidth=1.2)
+            ax_step.plot(filt.process(step, dtype=dt), label=dt, linewidth=1.2)
+        except Exception:
+            continue
+    ax_imp.legend(loc="best", fontsize="small")
+    fig.tight_layout()
+    return fig
+
+
+def figure_to_png_bytes(fig, dpi: int = 150) -> bytes:
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight")
+    return buf.getvalue()
+
+
+def plot_pole_displacement(filt, dtypes: list[str]):
+    """Bar chart: how far each dtype drifts the poles from the reference."""
+    labels, values = [], []
+    for dt in dtypes:
+        if dt == "reference":
+            continue
+        try:
+            labels.append(dt)
+            values.append(filt.pole_displacement(dt))
+        except Exception:
+            continue
+    fig, ax = plt.subplots(figsize=(8, 4))
+    if not labels:
+        ax.text(0.5, 0.5, "No non-reference dtypes selected.",
+                ha="center", va="center", transform=ax.transAxes)
+    else:
+        ax.bar(labels, values, color="C2")
+        ax.set_ylabel("Pole displacement (unitless)")
+        ax.set_title("How far do quantized coefficients drift the poles?")
+        ax.grid(True, alpha=0.3, axis="y")
+    fig.tight_layout()
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# The Streamlit app.
+# ---------------------------------------------------------------------------
+
+
+def main():
+    st.set_page_config(page_title="mpdsp filter designer",
+                       layout="wide", initial_sidebar_state="expanded")
+    st.title("Mixed-Precision IIR Filter Designer")
+    st.caption(
+        "Interactive DSPFilters-style explorer built on `mpdsp "
+        f"{mpdsp.__version__}` (wraps `sw::dsp {mpdsp.__dsp_version__}`). "
+        "Every IIR family, every topology, compared across all 7 mixed-"
+        "precision arithmetic configurations."
+    )
+
+    # --- Sidebar: design controls ---
+    st.sidebar.header("Filter design")
+    families = ["RBJ"] + list(ORDER_FAMILIES.keys())
+    family = st.sidebar.selectbox("Family", families, index=1)  # Butterworth default
+
+    if family == "RBJ":
+        topology = st.sidebar.selectbox("Topology", list(RBJ_VARIANTS.keys()))
+        order = None
+    else:
+        spec = ORDER_FAMILIES[family]
+        topology = st.sidebar.selectbox("Topology", list(spec.makers.keys()))
+        order = st.sidebar.slider("Order", 1, 8, 4)
+
+    sample_rate = st.sidebar.number_input(
+        "Sample rate (Hz)", min_value=100.0, max_value=384_000.0,
+        value=44_100.0, step=1000.0)
+
+    nyquist = sample_rate / 2.0
+    freq_params: dict = {}
+    if topology in ("lowpass", "highpass", "allpass", "lowshelf", "highshelf"):
+        freq_params["cutoff"] = st.sidebar.slider(
+            "Cutoff (Hz)", 20.0, float(nyquist - 100.0),
+            min(1000.0, nyquist / 4), step=10.0)
+    else:  # bandpass / bandstop
+        freq_params["center"] = st.sidebar.slider(
+            "Center frequency (Hz)", 50.0, float(nyquist - 100.0),
+            min(1000.0, nyquist / 4), step=10.0)
+        if family != "RBJ":
+            freq_params["width"] = st.sidebar.slider(
+                "Bandwidth (Hz)", 20.0, float(nyquist - 100.0),
+                min(500.0, nyquist / 8), step=10.0)
+
+    # Family-specific extra parameters.
+    extra: dict = {}
+    if family == "RBJ":
+        for pname, default, pmin, pmax in RBJ_VARIANTS[topology][1]:
+            extra[pname] = st.sidebar.slider(pname, float(pmin), float(pmax),
+                                             float(default), step=0.01)
+    else:
+        spec = ORDER_FAMILIES[family]
+        for p in spec.extra_params:
+            default_range = {
+                "ripple_db":   (0.01, 3.0, 0.5, 0.01),
+                "stopband_db": (10.0, 80.0, 40.0, 1.0),
+                "rolloff":     (0.1, 2.0, 1.0, 0.05),
+            }[p]
+            pmin, pmax, default, step = default_range
+            extra[p] = st.sidebar.slider(p, pmin, pmax, default, step=step)
+
+    # --- Build the filter ---
+    try:
+        filt = build_filter(family, topology, order, sample_rate,
+                            freq_params, extra)
+    except Exception as e:  # noqa: BLE001
+        st.error(f"Filter design failed: {e}")
+        st.stop()
+
+    # --- Top metrics strip ---
+    col1, col2, col3, col4 = st.columns(4)
+    col1.metric("Stages", f"{filt.num_stages()}")
+    col2.metric("Stability margin", f"{filt.stability_margin():.4f}")
+    col3.metric("Condition number", f"{filt.condition_number():.2e}")
+    col4.metric("Worst-case sens.", f"{filt.worst_case_sensitivity():.4f}")
+
+    # --- Precision selector (shared across tabs) ---
+    st.sidebar.header("Mixed precision")
+    all_dtypes = mpdsp.available_dtypes()
+    selected_dtypes = st.sidebar.multiselect(
+        "Compare dtypes", all_dtypes,
+        default=["reference", "gpu_baseline", "posit_full", "tiny_posit"])
+
+    # --- Test signal (used for SQNR measurements) ---
+    st.sidebar.header("Test signal")
+    sig_kind = st.sidebar.selectbox("Shape", ["sine", "chirp", "white_noise"])
+    sig_length = st.sidebar.slider("Length (samples)", 128, 8192, 2048, step=128)
+    if sig_kind == "sine":
+        sig_freq = st.sidebar.slider("Frequency (Hz)", 20.0, float(nyquist - 100.0),
+                                     min(440.0, nyquist / 10), step=10.0)
+        signal = mpdsp.sine(length=sig_length, frequency=sig_freq,
+                            sample_rate=sample_rate)
+    elif sig_kind == "chirp":
+        signal = mpdsp.chirp(length=sig_length, f_start=20.0,
+                             f_end=float(nyquist - 100.0),
+                             sample_rate=sample_rate)
+    else:
+        signal = mpdsp.white_noise(length=sig_length, amplitude=0.5, seed=1)
+
+    # --- Tabs ---
+    tab_freq, tab_pz, tab_time, tab_prec = st.tabs(
+        ["Frequency response", "Pole / zero", "Time domain",
+         "Mixed-precision comparison"])
+
+    # Build the shared descriptor used in export filenames so the same
+    # design can be tagged across multiple downloads.
+    if family == "RBJ":
+        tag = f"rbj_{topology}"
+    else:
+        tag = f"{family.lower().replace(' ', '')}_{topology}_n{order}"
+
+    with tab_freq:
+        fig = plot_magnitude_phase(filt, sample_rate, selected_dtypes, signal)
+        st.pyplot(fig)
+        st.download_button("Download PNG", figure_to_png_bytes(fig),
+                           f"{tag}_freq.png", "image/png")
+
+    with tab_pz:
+        fig = plot_pole_zero(filt)
+        st.pyplot(fig)
+        st.download_button("Download PNG", figure_to_png_bytes(fig),
+                           f"{tag}_polezero.png", "image/png")
+        if filt.num_stages() > 0:
+            coefs = filt.coefficients()
+            st.caption(f"{len(coefs)} biquad stage(s). "
+                       "Coefficients are always designed in `double`.")
+            coef_dict = {"stage": list(range(len(coefs))),
+                          "b0": [c[0] for c in coefs],
+                          "b1": [c[1] for c in coefs],
+                          "b2": [c[2] for c in coefs],
+                          "a1": [c[3] for c in coefs],
+                          "a2": [c[4] for c in coefs]}
+            st.dataframe(coef_dict, hide_index=True)
+            # CSV export via pandas if available; fallback to manual join.
+            try:
+                import pandas as pd
+                csv_bytes = pd.DataFrame(coef_dict).to_csv(index=False).encode()
+            except ImportError:
+                rows = [",".join(coef_dict.keys())]
+                for i in range(len(coefs)):
+                    rows.append(",".join(str(coef_dict[k][i]) for k in coef_dict))
+                csv_bytes = "\n".join(rows).encode()
+            st.download_button("Download coefficients CSV", csv_bytes,
+                               f"{tag}_coefficients.csv", "text/csv")
+
+    with tab_time:
+        fig = plot_impulse_step(filt, selected_dtypes)
+        st.pyplot(fig)
+        st.download_button("Download PNG", figure_to_png_bytes(fig),
+                           f"{tag}_time.png", "image/png")
+
+    with tab_prec:
+        if not selected_dtypes:
+            st.info("Pick at least one dtype in the sidebar.")
+        else:
+            df = compare_filters(filt, signal, dtypes=selected_dtypes)
+            st.dataframe(df, hide_index=True)
+            # pandas is already in mpdsp's runtime deps so `to_csv` is safe.
+            st.download_button("Download comparison CSV",
+                               df.to_csv(index=False).encode(),
+                               f"{tag}_comparison.csv", "text/csv")
+            fig = plot_pole_displacement(filt, selected_dtypes)
+            st.pyplot(fig)
+            st.download_button("Download displacement PNG",
+                               figure_to_png_bytes(fig),
+                               f"{tag}_displacement.png", "image/png")
+
+    st.caption(
+        "Free-function analysis primitives (`biquad_poles`, "
+        "`coefficient_sensitivity`, `biquad_condition_number`) and dtype "
+        "dispatch on spectral transforms are planned — see issue #8 and #40."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements the interactive dashboard deliverable from #8.

## What this is
A Streamlit app modeled on Vinnie Falco's classic DSPFilters demo, wrapping mpdsp's already-shipped `IIRFilter` API (`.frequency_response`, `.poles`, `.stability_margin`, `.condition_number`, `.worst_case_sensitivity`, `.pole_displacement`, `.coefficients`) plus `mpdsp.compare_filters`. The mixed-precision angle is the payoff — the 7 arithmetic configs get compared side by side in a way DSPFilters never could.

## Coverage

### Families and topologies (31 combinations)
| Family | LP | HP | BP | BS | Allpass | Shelves |
|--------|----|----|----|----|---------|---------|
| Butterworth | ✓ | ✓ | ✓ | ✓ | — | — |
| Chebyshev I (`ripple_db`) | ✓ | ✓ | ✓ | ✓ | — | — |
| Chebyshev II (`stopband_db`) | ✓ | ✓ | ✓ | ✓ | — | — |
| Bessel | ✓ | ✓ | ✓ | ✓ | — | — |
| Legendre | ✓ | ✓ | ✓ | ✓ | — | — |
| Elliptic (`ripple_db`, `rolloff`) | ✓ | ✓ | ✓ | ✓ | — | — |
| RBJ biquads | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ (low/high) |

### Views (tabs)
- **Frequency response** — magnitude (dB) + unwrapped phase. Selected dtypes get annotated in the legend with their SQNR against the reference.
- **Pole / zero** — unit circle + pole crosses + stability-margin title + per-stage biquad coefficient table.
- **Time domain** — impulse + step response overlaid per selected dtype.
- **Mixed-precision comparison** — `compare_filters` DataFrame (SQNR, max-abs, max-rel error per dtype) + pole-displacement bar chart.

### Always-visible metrics strip
`num_stages`, `stability_margin`, `condition_number`, `worst_case_sensitivity`.

### Test-signal knobs
Sine / chirp / white_noise at configurable length and frequency so SQNR measurements reflect the kind of signal a researcher cares about, not a fixed tone.

### Exports
- Every figure has a PNG download button.
- The biquad coefficient table and the comparison DataFrame both have CSV download buttons.
- Filename convention: `butterworth_lowpass_n4_freq.png`, `chebyshev1_bandpass_n6_comparison.csv`, etc.

## Launch
```
pip install mpdsp[dashboard]
streamlit run scripts/plot_dashboard.py
```

## Validation
Headless sweep (no browser required):

```
--- Order families ---
  Butterworth     lowpass    ok  (2 stages, margin=0.0529)
  ...(all 24 combinations green)...
--- RBJ variants ---
  RBJ lowpass    ok  (1 stages)
  ...(all 7 green)...
--- Plot helpers ---
  plot_magnitude_phase:      Figure
  plot_pole_zero:            Figure
  plot_impulse_step:         Figure
  plot_pole_displacement:    Figure
PNG export: ok (69 KB, correct signature)
```

Streamlit's runtime also boots clean (`streamlit run --server.headless`) with no import errors.

## Non-goals for this PR
The three remaining #8 deliverables (free-function analysis primitives like `biquad_poles`, `notebook 09_numerical_analysis.ipynb`, and `project_onto` which overlaps with #40) are tracked as follow-ups in the refreshed comment on #8.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an interactive Mixed-Precision IIR Filter Designer dashboard supporting multiple filter families (Butterworth, Chebyshev, Bessel, Legendre, Elliptic, and RBJ biquad variants).
  * Includes comprehensive visualization and analysis capabilities: frequency response and phase plots, pole/zero diagrams with stability metrics, time-domain responses, and mixed-precision filter comparisons with coefficient export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->