### PR TITLE
feat(scripts): pole-zero displacement in legend + 2x3 grid + PDF

### DIFF
--- a/scripts/plot_pole_zero.py
+++ b/scripts/plot_pole_zero.py
@@ -1,22 +1,51 @@
 #!/usr/bin/env python3
-"""Plot pole-zero diagrams from pole_positions.csv.
+"""Pole-zero displacement visualization.
 
-Unit circle with reference poles (filled) and displaced poles (open markers).
-One subplot per filter family. Displacement vectors drawn between positions.
+Reads `pole_positions.csv` and produces two figures:
+
+- `pole_zero.{png,pdf}` — unit-circle diagram with reference (double)
+  poles as large black × markers, quantized poles as smaller colored
+  circles, arrows drawn from reference to quantized location. Legend
+  annotates each non-reference arith_type with its maximum pole
+  displacement so readers can compare quantization sensitivity across
+  types without leaving the legend.
+
+- `pole_displacement.{png,pdf}` — grouped bar chart, max pole
+  displacement per (family, type), log-y. Only non-reference types.
+
+Expected input columns:
+    filter_family, arith_type, pole_index, real, imag, ref_real,
+    ref_imag, displacement
 
 Usage:
-    python scripts/plot_pole_zero.py /path/to/csv_directory
-    python scripts/plot_pole_zero.py /path/to/csv_directory --output figures/
+    python scripts/plot_pole_zero.py --input-dir results/ --output-dir figures/
+    python scripts/plot_pole_zero.py results/ --output-dir figures/     # legacy positional
+    python scripts/plot_pole_zero.py results/ --output figures/         # legacy --output
+    python scripts/plot_pole_zero.py results/                           # interactive
+
+Optional styling:
+    --publication    Serif fonts, tighter margins, larger labels
+    --latex          Use LaTeX for text (requires a working TeX install)
 """
 
+from __future__ import annotations
+
 import argparse
-from typing import Optional
 import os
 import sys
+from typing import Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
+
+REFERENCE_TYPE = "double"
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
 
 
 def load_poles(csv_dir: str) -> pd.DataFrame:
@@ -27,8 +56,53 @@ def load_poles(csv_dir: str) -> pd.DataFrame:
     return pd.read_csv(path)
 
 
-def draw_unit_circle(ax):
-    """Draw the unit circle and axes."""
+def save_figure(fig, output_dir: Optional[str], stem: str) -> None:
+    """Write `fig` to `{stem}.png` and `{stem}.pdf` in `output_dir`.
+
+    Mirrors the helper in scripts/plot_precision.py and
+    scripts/plot_heatmap.py so all three scripts produce consistent
+    PNG + PDF output.
+    """
+    if output_dir is None:
+        plt.show()
+        return
+    os.makedirs(output_dir, exist_ok=True)
+    for ext in ("png", "pdf"):
+        path = os.path.join(output_dir, f"{stem}.{ext}")
+        fig.savefig(path, dpi=150, bbox_inches="tight")
+        print(f"Saved: {path}")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Styling
+# ---------------------------------------------------------------------------
+
+
+def apply_publication_style(use_latex: bool = False) -> None:
+    plt.rcParams.update({
+        "font.family": "serif",
+        "font.size": 11,
+        "axes.titlesize": 12,
+        "axes.labelsize": 11,
+        "xtick.labelsize": 9,
+        "ytick.labelsize": 9,
+        "legend.fontsize": 8,
+        "figure.titlesize": 13,
+        "axes.grid": True,
+        "grid.alpha": 0.3,
+        "savefig.bbox": "tight",
+    })
+    if use_latex:
+        plt.rcParams["text.usetex"] = True
+
+
+# ---------------------------------------------------------------------------
+# Plot functions
+# ---------------------------------------------------------------------------
+
+
+def _draw_unit_circle(ax):
     theta = np.linspace(0, 2 * np.pi, 200)
     ax.plot(np.cos(theta), np.sin(theta), "k-", linewidth=0.8, alpha=0.4)
     ax.axhline(0, color="k", linewidth=0.5, alpha=0.3)
@@ -36,132 +110,180 @@ def draw_unit_circle(ax):
     ax.set_aspect("equal")
 
 
-def plot_pole_zero(df: pd.DataFrame, output_dir: Optional[str] = None):
-    """Pole-zero diagrams: one subplot per filter family."""
-    families = df["filter_family"].unique()
-    types = df["arith_type"].unique()
-    non_ref_types = [t for t in types if t != "double"]
+def _grid_shape(n_families: int) -> tuple[int, int]:
+    """Default to 2×3 (issue #14 spec); fall back to an adaptive grid when
+    the fixture or a custom sweep contains a different number of families
+    — a rigid 2×3 with only 1-2 filled subplots looks sparse.
+    """
+    if n_families == 6:
+        return 2, 3
+    ncols = min(3, max(n_families, 1))
+    nrows = (n_families + ncols - 1) // ncols
+    return nrows, ncols
 
-    colors = plt.cm.tab10(np.linspace(0, 1, len(non_ref_types)))
+
+def plot_pole_zero(df: pd.DataFrame, output_dir: Optional[str]):
+    families = sorted(df["filter_family"].unique())
+    types = sorted(df["arith_type"].unique())
+    non_ref_types = [t for t in types if t != REFERENCE_TYPE]
+
+    colors = plt.cm.tab10(np.linspace(0, 1, max(len(non_ref_types), 1)))
     type_colors = dict(zip(non_ref_types, colors))
 
-    ncols = min(3, len(families))
-    nrows = (len(families) + ncols - 1) // ncols
+    nrows, ncols = _grid_shape(len(families))
     fig, axes = plt.subplots(nrows, ncols, figsize=(5 * ncols, 5 * nrows))
-    if len(families) == 1:
-        axes = np.array([axes])
-    axes = axes.flatten()
+    # Normalize to a flat array regardless of rows/cols — handles the
+    # single-family test fixture and the 2×3 production case uniformly.
+    axes = np.atleast_1d(axes).flatten()
 
     for idx, family in enumerate(families):
         ax = axes[idx]
-        draw_unit_circle(ax)
-
+        _draw_unit_circle(ax)
         fam_df = df[df["filter_family"] == family]
 
-        # Plot reference poles (filled black 'x')
-        ref = fam_df[fam_df["arith_type"] == "double"]
+        # Reference poles — large black × markers per issue spec.
+        ref = fam_df[fam_df["arith_type"] == REFERENCE_TYPE]
         if not ref.empty:
             ax.plot(ref["ref_real"], ref["ref_imag"], "kx",
-                    markersize=10, markeredgewidth=2.5, label="double (ref)",
-                    zorder=10)
+                    markersize=10, markeredgewidth=2.5, zorder=10,
+                    label=f"{REFERENCE_TYPE} (ref)")
 
-        # Plot displaced poles for each type
+        # Non-reference types — colored circles + arrow from ref to quantized.
         for atype in non_ref_types:
             sub = fam_df[fam_df["arith_type"] == atype]
             if sub.empty:
                 continue
-
             color = type_colors[atype]
+
+            # Legend entry includes Δmax — the quantization-sensitivity
+            # number the issue asks to surface. Formatted in scientific
+            # notation because displacements span many orders of magnitude
+            # (1e-9 for posit<32,2>, 1e-3 for tiny_posit).
+            dmax = sub["displacement"].max()
+            label = f"{atype}  (Δmax={dmax:.1e})"
+
             ax.plot(sub["real"], sub["imag"], "o",
                     markersize=7, markerfacecolor="none",
                     markeredgecolor=color, markeredgewidth=1.5,
-                    label=atype)
+                    label=label)
 
-            # Draw displacement vectors (if displacement > threshold)
+            # Draw displacement vectors only where visible — sub-1e-10
+            # displacements produce arrow heads that overlap the markers.
             for _, row in sub.iterrows():
                 if row["displacement"] > 1e-10:
                     ax.annotate("", xy=(row["real"], row["imag"]),
-                                xytext=(row["ref_real"], row["ref_imag"]),
-                                arrowprops=dict(arrowstyle="->", color=color,
-                                                lw=0.8, alpha=0.6))
+                                 xytext=(row["ref_real"], row["ref_imag"]),
+                                 arrowprops=dict(arrowstyle="->", color=color,
+                                                  lw=0.8, alpha=0.6))
 
-        ax.set_title(family, fontsize=11, fontweight="bold")
-        ax.legend(fontsize=6, loc="lower left", ncol=2)
-        ax.set_xlabel("Real")
-        ax.set_ylabel("Imag")
+        ax.set_title(family, fontweight="bold")
+        ax.legend(loc="lower left", ncol=1, fontsize=7)
+        ax.set_xlabel("Re(z)")
+        ax.set_ylabel("Im(z)")
 
-        # Zoom to pole region
         all_real = fam_df["real"].tolist() + fam_df["ref_real"].tolist()
         all_imag = fam_df["imag"].tolist() + fam_df["ref_imag"].tolist()
         margin = 0.15
         ax.set_xlim(min(all_real) - margin, max(all_real) + margin)
         ax.set_ylim(min(all_imag) - margin, max(all_imag) + margin)
 
-    # Hide unused subplots
+    # Hide unused subplots in the 2×3 grid when <6 families were provided.
     for idx in range(len(families), len(axes)):
         axes[idx].set_visible(False)
 
-    fig.suptitle("Pole Positions: Reference vs Mixed-Precision",
-                 fontsize=14, fontweight="bold")
-    plt.tight_layout()
-
-    if output_dir:
-        os.makedirs(output_dir, exist_ok=True)
-        path = os.path.join(output_dir, "pole_zero.png")
-        fig.savefig(path, dpi=150, bbox_inches="tight")
-        print(f"Saved: {path}")
-    else:
-        plt.show()
+    fig.suptitle("Pole positions: reference vs mixed-precision",
+                 fontweight="bold")
+    fig.tight_layout()
+    save_figure(fig, output_dir, "pole_zero")
 
 
-def plot_displacement_summary(df: pd.DataFrame, output_dir: Optional[str] = None):
-    """Bar chart of maximum pole displacement per filter family × type."""
-    df_no_ref = df[df["arith_type"] != "double"]
-    summary = df_no_ref.groupby(["filter_family", "arith_type"])["displacement"].max()
-    summary = summary.reset_index()
-
-    # Only show types with non-zero displacement
+def plot_displacement_summary(df: pd.DataFrame, output_dir: Optional[str]):
+    """Max pole displacement per (family, type), log-y bar chart."""
+    df_no_ref = df[df["arith_type"] != REFERENCE_TYPE]
+    summary = (df_no_ref
+               .groupby(["filter_family", "arith_type"])["displacement"]
+               .max().reset_index())
+    # Only rows with visible displacement — a fixture with all CoeffScalar=double
+    # has no displacement anywhere, in which case we emit a hint and a blank
+    # figure rather than crashing downstream.
     summary = summary[summary["displacement"] > 1e-15]
 
     if summary.empty:
-        print("  No pole displacement detected (all CoeffScalar=double)")
-        print("  Displacement becomes visible when coefficients are projected")
-        print("  to narrower types via project_onto<T>()")
+        fig, ax = plt.subplots(figsize=(10, 4))
+        ax.text(0.5, 0.5,
+                 "No pole displacement detected.\n"
+                 "This happens when all arithmetic types share CoeffScalar=double;\n"
+                 "displacement becomes visible when coefficients are projected\n"
+                 "to narrower types via project_onto<T>().",
+                 ha="center", va="center", transform=ax.transAxes,
+                 fontsize=10)
+        ax.set_axis_off()
+        fig.tight_layout()
+        save_figure(fig, output_dir, "pole_displacement")
         return
 
-    pivot = summary.pivot_table(index="filter_family", columns="arith_type",
-                                values="displacement")
-    pivot.plot(kind="bar", figsize=(10, 5))
-    plt.ylabel("Max Pole Displacement")
-    plt.title("Pole Displacement from Reference (double)",
-              fontsize=13, fontweight="bold")
-    plt.yscale("log")
-    plt.legend(fontsize=8)
-    plt.tight_layout()
+    pivot = summary.pivot_table(index="filter_family",
+                                 columns="arith_type",
+                                 values="displacement")
+    fig, ax = plt.subplots(figsize=(10, 5))
+    pivot.plot(kind="bar", ax=ax)
+    ax.set_ylabel("Max pole displacement (unitless)")
+    ax.set_title("Pole displacement from reference (double)",
+                  fontweight="bold")
+    ax.set_yscale("log")
+    ax.grid(True, alpha=0.3, which="both", axis="y")
+    ax.legend(loc="upper right")
+    fig.tight_layout()
+    save_figure(fig, output_dir, "pole_displacement")
 
-    if output_dir:
-        os.makedirs(output_dir, exist_ok=True)
-        path = os.path.join(output_dir, "pole_displacement.png")
-        plt.savefig(path, dpi=150, bbox_inches="tight")
-        print(f"Saved: {path}")
-    else:
-        plt.show()
+
+# ---------------------------------------------------------------------------
+# CLI — same shape as scripts/plot_precision.py and scripts/plot_heatmap.py.
+# ---------------------------------------------------------------------------
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Pole-zero displacement visualization from CSV.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("csv_dir", nargs="?", default=None,
+                        help="Directory with pole_positions.csv "
+                             "(legacy positional; prefer --input-dir)")
+    parser.add_argument("--input-dir", "-i", default=None,
+                        help="Directory with pole_positions.csv")
+    parser.add_argument("--output-dir", "--output", "-o", default=None,
+                        dest="output_dir",
+                        help="Output directory for figures. Omit for "
+                             "interactive display.")
+    parser.add_argument("--publication", action="store_true",
+                        help="Apply publication rcParams (serif fonts, etc.)")
+    parser.add_argument("--latex", action="store_true",
+                        help="Use LaTeX to render text (requires TeX). "
+                             "Implies --publication.")
+    args = parser.parse_args()
+
+    if args.csv_dir and args.input_dir and args.csv_dir != args.input_dir:
+        parser.error("pass either the positional csv_dir OR --input-dir, not both")
+    args.input_dir = args.input_dir or args.csv_dir
+    if not args.input_dir:
+        parser.error("need an input directory: --input-dir DIR (or positional)")
+    return args
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Plot pole-zero diagrams from precision sweep CSV")
-    parser.add_argument("csv_dir", help="Directory containing pole_positions.csv")
-    parser.add_argument("--output", "-o", default=None,
-                        help="Output directory for PNG files (omit for interactive)")
-    args = parser.parse_args()
+    args = _parse_args()
+    if args.publication or args.latex:
+        apply_publication_style(use_latex=args.latex)
 
-    df = load_poles(args.csv_dir)
-    print(f"Loaded {len(df)} pole entries: {df['filter_family'].nunique()} families, "
+    df = load_poles(args.input_dir)
+    print(f"Loaded {len(df)} pole entries: "
+          f"{df['filter_family'].nunique()} families, "
           f"{df['arith_type'].nunique()} types")
 
-    plot_pole_zero(df, args.output)
-    plot_displacement_summary(df, args.output)
+    plot_pole_zero(df, args.output_dir)
+    plot_displacement_summary(df, args.output_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/plot_pole_zero.py
+++ b/scripts/plot_pole_zero.py
@@ -4,7 +4,7 @@
 Reads `pole_positions.csv` and produces two figures:
 
 - `pole_zero.{png,pdf}` — unit-circle diagram with reference (double)
-  poles as large black × markers, quantized poles as smaller colored
+  poles as large black cross markers, quantized poles as smaller colored
   circles, arrows drawn from reference to quantized location. Legend
   annotates each non-reference arith_type with its maximum pole
   displacement so readers can compare quantization sensitivity across
@@ -111,9 +111,9 @@ def _draw_unit_circle(ax):
 
 
 def _grid_shape(n_families: int) -> tuple[int, int]:
-    """Default to 2×3 (issue #14 spec); fall back to an adaptive grid when
+    """Default to 2x3 (issue #14 spec); fall back to an adaptive grid when
     the fixture or a custom sweep contains a different number of families
-    — a rigid 2×3 with only 1-2 filled subplots looks sparse.
+    — a rigid 2x3 with only 1-2 filled subplots looks sparse.
     """
     if n_families == 6:
         return 2, 3
@@ -133,7 +133,7 @@ def plot_pole_zero(df: pd.DataFrame, output_dir: Optional[str]):
     nrows, ncols = _grid_shape(len(families))
     fig, axes = plt.subplots(nrows, ncols, figsize=(5 * ncols, 5 * nrows))
     # Normalize to a flat array regardless of rows/cols — handles the
-    # single-family test fixture and the 2×3 production case uniformly.
+    # single-family test fixture and the 2x3 production case uniformly.
     axes = np.atleast_1d(axes).flatten()
 
     for idx, family in enumerate(families):
@@ -141,7 +141,7 @@ def plot_pole_zero(df: pd.DataFrame, output_dir: Optional[str]):
         _draw_unit_circle(ax)
         fam_df = df[df["filter_family"] == family]
 
-        # Reference poles — large black × markers per issue spec.
+        # Reference poles — large black cross markers per issue spec.
         ref = fam_df[fam_df["arith_type"] == REFERENCE_TYPE]
         if not ref.empty:
             ax.plot(ref["ref_real"], ref["ref_imag"], "kx",
@@ -181,13 +181,19 @@ def plot_pole_zero(df: pd.DataFrame, output_dir: Optional[str]):
         ax.set_xlabel("Re(z)")
         ax.set_ylabel("Im(z)")
 
+        # Axis limits must include the unit circle — it's the reference
+        # landmark of the plot. Deriving limits from pole coordinates alone
+        # crops the circle when poles cluster near a small region (e.g.
+        # high-order low-cutoff filters with poles all near one arc).
         all_real = fam_df["real"].tolist() + fam_df["ref_real"].tolist()
         all_imag = fam_df["imag"].tolist() + fam_df["ref_imag"].tolist()
         margin = 0.15
-        ax.set_xlim(min(all_real) - margin, max(all_real) + margin)
-        ax.set_ylim(min(all_imag) - margin, max(all_imag) + margin)
+        ax.set_xlim(min(-1.0, min(all_real)) - margin,
+                     max(1.0, max(all_real)) + margin)
+        ax.set_ylim(min(-1.0, min(all_imag)) - margin,
+                     max(1.0, max(all_imag)) + margin)
 
-    # Hide unused subplots in the 2×3 grid when <6 families were provided.
+    # Hide unused subplots in the 2x3 grid when <6 families were provided.
     for idx in range(len(families), len(axes)):
         axes[idx].set_visible(False)
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -166,7 +166,14 @@ def test_plot_pole_zero_generates_output(csv_dir):
 
 
 def test_plot_pole_zero_new_cli_flags(csv_dir):
-    """Issue #14 spec'd invocation: --input-dir / --output-dir."""
+    """Issue #14 spec'd invocation: --input-dir / --output-dir.
+
+    Mirrors the full artifact set asserted in
+    `test_plot_pole_zero_generates_output` — both figures, both formats —
+    so a regression that skips one of the two plots on the new CLI path
+    still fails this test. (Initial version only checked pole_zero.pdf,
+    which left pole_displacement.pdf unguarded.)
+    """
     script_path = Path(__file__).parent.parent / "scripts" / "plot_pole_zero.py"
     with tempfile.TemporaryDirectory() as outdir:
         result = subprocess.run(  # noqa: S603 - test-controlled script + tempdirs
@@ -174,4 +181,7 @@ def test_plot_pole_zero_new_cli_flags(csv_dir):
              "--input-dir", csv_dir, "--output-dir", outdir],
             capture_output=True, text=True, timeout=30)
         assert result.returncode == 0, f"Script failed: {result.stderr}"
-        assert os.path.exists(os.path.join(outdir, "pole_zero.pdf"))
+        for stem in ("pole_zero", "pole_displacement"):
+            for ext in ("png", "pdf"):
+                assert os.path.exists(os.path.join(outdir, f"{stem}.{ext}")), (
+                    f"Missing {stem}.{ext}")

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -155,7 +155,23 @@ def test_plot_heatmap_new_cli_flags(csv_dir):
 
 
 def test_plot_pole_zero_generates_output(csv_dir):
+    """Both pole-zero and displacement-summary figures in PNG and PDF."""
     with tempfile.TemporaryDirectory() as outdir:
         result = _run_script("plot_pole_zero.py", csv_dir, outdir)
         assert result.returncode == 0, f"Script failed: {result.stderr}"
-        assert os.path.exists(os.path.join(outdir, "pole_zero.png"))
+        for stem in ("pole_zero", "pole_displacement"):
+            for ext in ("png", "pdf"):
+                assert os.path.exists(os.path.join(outdir, f"{stem}.{ext}")), (
+                    f"Missing {stem}.{ext}")
+
+
+def test_plot_pole_zero_new_cli_flags(csv_dir):
+    """Issue #14 spec'd invocation: --input-dir / --output-dir."""
+    script_path = Path(__file__).parent.parent / "scripts" / "plot_pole_zero.py"
+    with tempfile.TemporaryDirectory() as outdir:
+        result = subprocess.run(  # noqa: S603 - test-controlled script + tempdirs
+            [sys.executable, str(script_path),
+             "--input-dir", csv_dir, "--output-dir", outdir],
+            capture_output=True, text=True, timeout=30)
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        assert os.path.exists(os.path.join(outdir, "pole_zero.pdf"))


### PR DESCRIPTION
Closes #14. The existing \`plot_pole_zero.py\` already ships most of the issue spec — unit circle, reference + quantized poles, displacement arrows, one subplot per family, type-colored legend. The one deliverable actually missing was the **quantization-sensitivity number in the legend**. This PR closes that gap and brings the script in line with the shared patterns landed in #43 and #44.

## What's new

### Displacement magnitude in the legend
Non-reference legend labels now read like \`posit<16,1>  (Δmax=1.8e-4)\`. Displacements span many orders of magnitude across types (1e-9 for posit<32,2>, 1e-3 for tiny_posit), so scientific notation makes the ordering legible at a glance — no more toggling back and forth between the pole-zero plot and the displacement bar chart.

### 2×3 grid per issue spec (with adaptive fallback)
Default grid is \`subplots(2, 3, ...)\`. When the CSV contains a number of families other than six (test fixture is 1; custom sweeps may vary), falls back to \`min(3, n)\` columns so you don't render a mostly-empty canvas. Unused cells are hidden when the 2×3 default runs with fewer families.

### Shared patterns (matching #43 and #44)
- \`save_figure()\` helper writes PNG + PDF and \`plt.close()\`s the figure.
- \`apply_publication_style()\` — serif fonts, larger labels, tighter ticks. Gated on \`--publication\`; \`--latex\` flips \`text.usetex\`.
- CLI accepts the spec'd \`--input-dir\` / \`--output-dir\` alongside the legacy positional + \`--output\` form. Non-breaking.

### \`plot_displacement_summary\` no longer crashes on all-double fixtures
When every arith_type in the CSV shares \`CoeffScalar=double\`, all displacements fall below the 1e-15 visibility threshold. The previous code returned early without emitting any figure at all, which failed the test's PDF-output assertion. Now it emits an explanatory blank figure — matching the pattern used elsewhere when a plot would otherwise be empty.

## Tests
- \`test_plot_pole_zero_generates_output\` expanded to assert \`pole_zero.{png,pdf}\` AND \`pole_displacement.{png,pdf}\`.
- New \`test_plot_pole_zero_new_cli_flags\` exercises \`--input-dir\` / \`--output-dir\`.

## Status
504/504 tests pass locally.

## Test plan
- [x] Fast CI passes (Linux gcc/clang, Windows MSVC, macOS)
- [x] Promote to ready when satisfied

Resolves #14

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pole-zero plotting script now generates displacement visualization outputs in addition to standard pole-zero plots.
  * Added `--input-dir` and `--output-dir` command-line flags for improved usability.
  * Added `--publication` and `--latex` flags for publication-ready plot styling.
  * Script now exports both PNG and PDF formats by default for all visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->