### PR TITLE
feat(analysis): free-function sensitivity + biquad/cascade condition (#53)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ nanobind_add_module(_core
   src/estimation_bindings.cpp
   src/image_bindings.cpp
   src/types_bindings.cpp
+  src/analysis_bindings.cpp
 )
 target_link_libraries(_core PRIVATE sw_dsp)
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -294,7 +294,7 @@ Thin layer over already-bound `IIRFilter` methods. `biquad_poles` is a standalon
 | `biquad_poles` | `(b0: 'float', b1: 'float', b2: 'float', a1: 'float', a2: 'float') -> 'list[complex]'` | Two poles of a single biquad section. |
 | `max_pole_radius` | `(filt) -> 'float'` | Largest ``\|pole\|`` in the filter's z-plane. |
 | `is_stable` | `(filt, tol: 'float' = 0.0) -> 'bool'` | True iff all poles are strictly inside the unit circle. |
-| `cascade_condition_number` | `(filt, num_freqs: 'int' = 256) -> 'float'` | Condition number of an entire IIR cascade. |
+| `cascade_condition_number` | `(filt, num_freqs: 'int' = 512) -> 'float'` | Condition number of an entire IIR cascade. |
 
 ## Numerical analysis — free-function primitives (bound)
 
@@ -303,7 +303,7 @@ Coefficient-level analysis that doesn't require a constructed IIRFilter — usef
 | Name | Signature | Description |
 |------|-----------|-------------|
 | `coefficient_sensitivity` | `(b0: float, b1: float, b2: float, a1: float, a2: float, epsilon: float = 1e-08) -> tuple` | Coefficient sensitivity of a biquad, as a (dp_da1, dp_da2) tuple of doubles. |
-| `biquad_condition_number` | `(b0: float, b1: float, b2: float, a1: float, a2: float, num_freqs: int = 256) -> float` | Condition number of a single biquad section. |
+| `biquad_condition_number` | `(b0: float, b1: float, b2: float, a1: float, a2: float, num_freqs: int = 512) -> float` | Condition number of a single biquad section. |
 
 ## Mixed-precision helpers
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -25,7 +25,8 @@ the note at the bottom.
 - [Image — file I/O](#image--file-io)
 - [Audio — WAV file I/O](#audio--wav-file-io)
 - [Types — transfer function and type projection](#types--transfer-function-and-type-projection)
-- [Numerical-analysis helpers (pure Python)](#numerical-analysis-helpers-pure-python)
+- [Numerical analysis — pure-Python helpers](#numerical-analysis--pure-python-helpers)
+- [Numerical analysis — free-function primitives (bound)](#numerical-analysis--free-function-primitives-bound)
 - [Mixed-precision helpers](#mixed-precision-helpers)
 - [CSV + image-pipeline helpers (pure Python)](#csv--image-pipeline-helpers-pure-python)
 - [Matplotlib plotting helpers](#matplotlib-plotting-helpers)
@@ -284,15 +285,25 @@ PGM (grayscale 8/16-bit), PPM (RGB 8-bit), and BMP (8-bit grayscale + RGB). Read
 | `projection_error` | `(data: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False], dtype: str) -> float` | Max absolute error between data and its round-trip through `dtype`. Equivalent to max(abs(data - project_onto(data, dtype))) but computed without allocating the intermediate ndarray. |
 | `to_transfer_function` | `(filt)` | Fold an `IIRFilter` cascade into a single `TransferFunction`. |
 
-## Numerical-analysis helpers (pure Python)
+## Numerical analysis — pure-Python helpers
 
-Thin layer over already-bound `IIRFilter` methods. `biquad_poles` is a standalone quadratic solver that takes a 5-tuple of coefficients. See `IIRFilter.stability_margin()`, `.condition_number()`, `.worst_case_sensitivity()`, and `.pole_displacement(dtype)` for the per-filter metrics.
+Thin layer over already-bound `IIRFilter` methods. `biquad_poles` is a standalone quadratic solver that takes a 5-tuple of coefficients. `cascade_condition_number(filt, num_freqs)` is the free-function companion to `filt.condition_number(num_freqs)` — identical upstream call, just different calling convention. See `IIRFilter.stability_margin()`, `.condition_number()`, `.worst_case_sensitivity()`, and `.pole_displacement(dtype)` for the per-filter metrics.
 
 | Name | Signature | Description |
 |------|-----------|-------------|
 | `biquad_poles` | `(b0: 'float', b1: 'float', b2: 'float', a1: 'float', a2: 'float') -> 'list[complex]'` | Two poles of a single biquad section. |
 | `max_pole_radius` | `(filt) -> 'float'` | Largest ``\|pole\|`` in the filter's z-plane. |
 | `is_stable` | `(filt, tol: 'float' = 0.0) -> 'bool'` | True iff all poles are strictly inside the unit circle. |
+| `cascade_condition_number` | `(filt, num_freqs: 'int' = 256) -> 'float'` | Condition number of an entire IIR cascade. |
+
+## Numerical analysis — free-function primitives (bound)
+
+Coefficient-level analysis that doesn't require a constructed IIRFilter — useful for design-time coefficient sweeps. `coefficient_sensitivity` returns the finite-difference pole-radius sensitivities `(dp_da1, dp_da2)`; `biquad_condition_number` returns the max relative response change per unit coefficient perturbation over a frequency sweep. Both bound on double only — mixed-precision analysis of the full filter lives on the IIRFilter methods, which dispatch through `ArithConfig`.
+
+| Name | Signature | Description |
+|------|-----------|-------------|
+| `coefficient_sensitivity` | `(b0: float, b1: float, b2: float, a1: float, a2: float, epsilon: float = 1e-08) -> tuple` | Coefficient sensitivity of a biquad, as a (dp_da1, dp_da2) tuple of doubles. |
+| `biquad_condition_number` | `(b0: float, b1: float, b2: float, a1: float, a2: float, num_freqs: int = 256) -> float` | Condition number of a single biquad section. |
 
 ## Mixed-precision helpers
 

--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -104,6 +104,8 @@ try:
         # Types — rational transfer function + type projection
         TransferFunction,
         project_onto, projection_error,
+        # Analysis — free-function primitives (method-form lives on IIRFilter)
+        coefficient_sensitivity, biquad_condition_number,
         # Introspection
         available_dtypes,
     )
@@ -148,7 +150,8 @@ if HAS_CORE:
                                  to_transfer_function)
 
 # Analysis helpers (pure Python; build only on stdlib + numpy + _core methods)
-from mpdsp.analysis import biquad_poles, is_stable, max_pole_radius
+from mpdsp.analysis import (biquad_poles, cascade_condition_number,
+                              is_stable, max_pole_radius)
 
 # Estimation helpers (pure Python; plotting needs matplotlib)
 if HAS_CORE:

--- a/python/mpdsp/analysis.py
+++ b/python/mpdsp/analysis.py
@@ -67,7 +67,7 @@ def is_stable(filt, tol: float = 0.0) -> bool:
     return max_pole_radius(filt) < (1.0 - tol)
 
 
-def cascade_condition_number(filt, num_freqs: int = 256) -> float:
+def cascade_condition_number(filt, num_freqs: int = 512) -> float:
     """Condition number of an entire IIR cascade.
 
     Free-function companion to the per-biquad ``biquad_condition_number``
@@ -78,6 +78,12 @@ def cascade_condition_number(filt, num_freqs: int = 256) -> float:
     writing design-time sweeps that accept a filter plus a custom
     ``num_freqs`` as separate arguments) without duplicating the C++
     side.
+
+    Note: ``num_freqs`` defaults to 512 here to match the 0.5.0 free-
+    function API contract in issue #53, while the existing
+    ``IIRFilter.condition_number`` method retains its 256 default from
+    #8 for backwards compatibility. Both accept an explicit
+    ``num_freqs`` if you want to override.
 
     Parameters
     ----------

--- a/python/mpdsp/analysis.py
+++ b/python/mpdsp/analysis.py
@@ -65,3 +65,26 @@ def is_stable(filt, tol: float = 0.0) -> bool:
     ``max|pole|`` can drift outward by a quantization-dependent amount.
     """
     return max_pole_radius(filt) < (1.0 - tol)
+
+
+def cascade_condition_number(filt, num_freqs: int = 256) -> float:
+    """Condition number of an entire IIR cascade.
+
+    Free-function companion to the per-biquad ``biquad_condition_number``
+    (bound in C++). Equivalent to ``filt.condition_number(num_freqs)`` —
+    the upstream ``sw::dsp::cascade_condition_number`` is exactly what the
+    ``IIRFilter.condition_number`` method already wraps. This Python
+    wrapper exists to surface the free-function spelling (useful when
+    writing design-time sweeps that accept a filter plus a custom
+    ``num_freqs`` as separate arguments) without duplicating the C++
+    side.
+
+    Parameters
+    ----------
+    filt : mpdsp.IIRFilter
+        A designed IIR filter.
+    num_freqs : int
+        Number of frequency points sampled on [0, 0.5]. Larger values give
+        a more accurate condition-number estimate at proportional cost.
+    """
+    return float(filt.condition_number(num_freqs))

--- a/scripts/build_api_ref.py
+++ b/scripts/build_api_ref.py
@@ -167,8 +167,12 @@ CATEGORIES = [
     ("Types — transfer function and type projection", [
         "project_onto", "projection_error", "to_transfer_function",
     ]),
-    ("Numerical-analysis helpers (pure Python)", [
+    ("Numerical analysis — pure-Python helpers", [
         "biquad_poles", "max_pole_radius", "is_stable",
+        "cascade_condition_number",
+    ]),
+    ("Numerical analysis — free-function primitives (bound)", [
+        "coefficient_sensitivity", "biquad_condition_number",
     ]),
     ("Mixed-precision helpers", [
         "available_dtypes", "compare_filters",
@@ -287,12 +291,26 @@ INTROS = {
         "the quantized samples or the raw error magnitude rather than the "
         "SQNR number."
     ),
-    "Numerical-analysis helpers (pure Python)": (
+    "Numerical analysis — pure-Python helpers": (
         "Thin layer over already-bound `IIRFilter` methods. "
         "`biquad_poles` is a standalone quadratic solver that takes a "
-        "5-tuple of coefficients. See `IIRFilter.stability_margin()`, "
+        "5-tuple of coefficients. `cascade_condition_number(filt, "
+        "num_freqs)` is the free-function companion to `filt.condition_"
+        "number(num_freqs)` — identical upstream call, just different "
+        "calling convention. See `IIRFilter.stability_margin()`, "
         "`.condition_number()`, `.worst_case_sensitivity()`, and "
         "`.pole_displacement(dtype)` for the per-filter metrics."
+    ),
+    "Numerical analysis — free-function primitives (bound)": (
+        "Coefficient-level analysis that doesn't require a constructed "
+        "IIRFilter — useful for design-time coefficient sweeps. "
+        "`coefficient_sensitivity` returns the finite-difference pole-"
+        "radius sensitivities `(dp_da1, dp_da2)`; `biquad_condition_"
+        "number` returns the max relative response change per unit "
+        "coefficient perturbation over a frequency sweep. Both bound "
+        "on double only — mixed-precision analysis of the full filter "
+        "lives on the IIRFilter methods, which dispatch through "
+        "`ArithConfig`."
     ),
     "Mixed-precision helpers": (
         "`available_dtypes()` is the runtime-queryable source of truth for "

--- a/src/analysis_bindings.cpp
+++ b/src/analysis_bindings.cpp
@@ -26,6 +26,7 @@
 #include <sw/dsp/analysis/sensitivity.hpp>
 #include <sw/dsp/types/biquad_coefficients.hpp>
 
+#include <cmath>
 #include <stdexcept>
 
 namespace nb = nanobind;
@@ -36,6 +37,14 @@ void bind_analysis(nb::module_& m) {
 	m.def("coefficient_sensitivity",
 		[](double b0, double b1, double b2, double a1, double a2,
 		   double epsilon) {
+			// Guard at the binding boundary: upstream forwards epsilon
+			// straight into finite-differencing, so 0 / negative / NaN /
+			// inf would silently produce meaningless derivatives.
+			if (!(epsilon > 0.0) || !std::isfinite(epsilon)) {
+				throw std::invalid_argument(
+					"coefficient_sensitivity: epsilon must be finite "
+					"and strictly positive");
+			}
 			BQ bq(b0, b1, b2, a1, a2);
 			auto s = sw::dsp::coefficient_sensitivity(bq, epsilon);
 			return nb::make_tuple(s.dp_da1, s.dp_da2);
@@ -68,7 +77,7 @@ void bind_analysis(nb::module_& m) {
 		},
 		nb::arg("b0"), nb::arg("b1"), nb::arg("b2"),
 		nb::arg("a1"), nb::arg("a2"),
-		nb::arg("num_freqs") = 256,
+		nb::arg("num_freqs") = 512,
 		"Condition number of a single biquad section.\n\n"
 		"Sweeps the unit circle at `num_freqs` points, measuring the "
 		"maximum relative change in |H(e^{j2*pi*f})| per unit "

--- a/src/analysis_bindings.cpp
+++ b/src/analysis_bindings.cpp
@@ -1,0 +1,83 @@
+// analysis_bindings.cpp: free-function analysis primitives.
+//
+// Phase 4 of the 0.5.0 binding sweep (#53). Surfaces the coefficient-
+// level analysis functions from upstream sw::dsp/analysis/ that operate
+// on raw biquad coefficients without needing a constructed IIRFilter.
+//
+// The method-form equivalents already live on PyIIRFilter in
+// filter_bindings.cpp (`filt.stability_margin()`, `.condition_number()`,
+// `.worst_case_sensitivity()`, `.pole_displacement()`). This file adds
+// the per-biquad free-function forms, which matter for design-time
+// coefficient sweeps — you can evaluate a candidate set of coefficients
+// without instantiating a full cascade.
+//
+// Bound on double only. Upstream templates on DspField T, but for
+// design-time analysis the meaningful arithmetic is double — the
+// interesting question is "what are the sensitivities of this
+// coefficient set before I quantize it". Mixed-precision analysis of a
+// constructed filter lives on the IIRFilter methods, which already
+// dispatch through ArithConfig.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/tuple.h>
+
+#include <sw/dsp/analysis/condition.hpp>
+#include <sw/dsp/analysis/sensitivity.hpp>
+#include <sw/dsp/types/biquad_coefficients.hpp>
+
+#include <stdexcept>
+
+namespace nb = nanobind;
+
+void bind_analysis(nb::module_& m) {
+	using BQ = sw::dsp::BiquadCoefficients<double>;
+
+	m.def("coefficient_sensitivity",
+		[](double b0, double b1, double b2, double a1, double a2,
+		   double epsilon) {
+			BQ bq(b0, b1, b2, a1, a2);
+			auto s = sw::dsp::coefficient_sensitivity(bq, epsilon);
+			return nb::make_tuple(s.dp_da1, s.dp_da2);
+		},
+		nb::arg("b0"), nb::arg("b1"), nb::arg("b2"),
+		nb::arg("a1"), nb::arg("a2"),
+		nb::arg("epsilon") = 1e-8,
+		"Coefficient sensitivity of a biquad, as a (dp_da1, dp_da2) "
+		"tuple of doubles.\n\n"
+		"Returns the finite-difference derivatives of the maximum pole "
+		"radius with respect to each denominator coefficient. Large "
+		"magnitudes indicate coefficients whose quantization will "
+		"meaningfully move the poles — a design-time signal for "
+		"numerical fragility under reduced precision.\n\n"
+		"Numerator coefficients (b0, b1, b2) are accepted for signature "
+		"symmetry with `biquad_condition_number` (and so callers can "
+		"unpack an `IIRFilter.coefficients()` tuple directly), but they "
+		"don't affect pole locations, so the returned sensitivities "
+		"depend only on (a1, a2).");
+
+	m.def("biquad_condition_number",
+		[](double b0, double b1, double b2, double a1, double a2,
+		   int num_freqs) {
+			if (num_freqs <= 0) {
+				throw std::invalid_argument(
+					"biquad_condition_number: num_freqs must be > 0");
+			}
+			BQ bq(b0, b1, b2, a1, a2);
+			return sw::dsp::biquad_condition_number(bq, num_freqs);
+		},
+		nb::arg("b0"), nb::arg("b1"), nb::arg("b2"),
+		nb::arg("a1"), nb::arg("a2"),
+		nb::arg("num_freqs") = 256,
+		"Condition number of a single biquad section.\n\n"
+		"Sweeps the unit circle at `num_freqs` points, measuring the "
+		"maximum relative change in |H(e^{j2*pi*f})| per unit "
+		"perturbation of each coefficient. The perturbation is chosen "
+		"to survive the round-trip through the coefficient type (no "
+		"silent no-ops for narrow arithmetic).\n\n"
+		"Large values mean small coefficient errors induce big frequency-"
+		"response changes — the numerical signature of designed-to-the-"
+		"edge biquads. For the cascade-level version use "
+		"`mpdsp.cascade_condition_number(filt, num_freqs)` or the "
+		"equivalent `filt.condition_number(num_freqs)` method.");
+}

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -18,6 +18,7 @@ void bind_conditioning(nb::module_& m);
 void bind_estimation(nb::module_& m);
 void bind_image(nb::module_& m);
 void bind_types(nb::module_& m);
+void bind_analysis(nb::module_& m);
 
 NB_MODULE(_core, m) {
 	m.doc() = "mpdsp C++ core: mixed-precision DSP bindings via nanobind";
@@ -40,4 +41,5 @@ NB_MODULE(_core, m) {
 	bind_estimation(m);
 	bind_image(m);
 	bind_types(m);
+	bind_analysis(m);
 }

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -121,3 +121,112 @@ def test_biquad_poles_agrees_with_iirfilter_poles():
     # sloppy about the math.
     for a, b in zip(manual_sorted, iir_sorted):
         assert a == pytest.approx(b, abs=1e-8)
+
+
+# ---- coefficient_sensitivity (C++ binding) -----------------------------
+
+
+class TestCoefficientSensitivity:
+    """Free-function `mpdsp.coefficient_sensitivity(b0, b1, b2, a1, a2)`
+    returns the finite-difference partial derivatives of the maximum
+    pole radius w.r.t. each denominator coefficient."""
+
+    def test_returns_two_doubles(self):
+        out = mpdsp.coefficient_sensitivity(1.0, 0.0, 0.0, -0.5, 0.1)
+        assert len(out) == 2
+        assert all(isinstance(v, float) for v in out)
+
+    def test_numerator_coefficients_inert(self):
+        # Sensitivity is a property of the denominator only. Changing b*
+        # must not change the result.
+        sens_a = mpdsp.coefficient_sensitivity(1.0, 2.0, 3.0, -0.5, 0.1)
+        sens_b = mpdsp.coefficient_sensitivity(0.0, 0.0, 0.0, -0.5, 0.1)
+        assert sens_a[0] == pytest.approx(sens_b[0], abs=1e-12)
+        assert sens_a[1] == pytest.approx(sens_b[1], abs=1e-12)
+
+    def test_complex_conjugate_a2_sensitivity_matches_analytic(self):
+        # For a biquad z^2 + a1*z + a2 with complex-conjugate poles,
+        # |p| = sqrt(a2). So d|p|/da2 = 1/(2*sqrt(a2)) = 1/(2r)
+        # where r is the pole radius. Pin the relationship against the
+        # analytic formula at three pole radii.
+        import math
+        for r in (0.2, 0.5, 0.8):
+            theta = 0.6  # any theta giving complex poles
+            a1 = -2.0 * r * math.cos(theta)
+            a2 = r * r
+            s = mpdsp.coefficient_sensitivity(1.0, 0.0, 0.0, a1, a2)
+            expected_dp_da2 = 1.0 / (2.0 * r)
+            # 1% relative tolerance — finite differences at epsilon=1e-8
+            # on max_pole_radius are noisy at this level.
+            assert s[1] == pytest.approx(expected_dp_da2, rel=1e-2)
+
+    def test_complex_conjugate_a1_sensitivity_near_zero(self):
+        # Still for complex-conjugate poles: |p| depends only on a2, so
+        # d|p|/da1 should be ~0.
+        import math
+        for r in (0.2, 0.5, 0.8):
+            theta = 0.6
+            a1 = -2.0 * r * math.cos(theta)
+            a2 = r * r
+            s = mpdsp.coefficient_sensitivity(1.0, 0.0, 0.0, a1, a2)
+            assert abs(s[0]) < 1e-6
+
+
+# ---- biquad_condition_number (C++ binding) -----------------------------
+
+
+class TestBiquadConditionNumber:
+    """Free-function `mpdsp.biquad_condition_number(b0, b1, b2, a1, a2)`
+    measures frequency-response sensitivity to coefficient perturbation."""
+
+    def test_returns_finite_positive_float(self):
+        cn = mpdsp.biquad_condition_number(1.0, 0.0, 0.0, -0.5, 0.1)
+        assert isinstance(cn, float)
+        assert cn > 0.0
+        import math
+        assert math.isfinite(cn)
+
+    def test_grows_with_pole_radius(self):
+        # High-Q biquads are numerically fragile: small coefficient
+        # errors produce large response changes.
+        def coeffs(r, theta=0.6):
+            import math
+            return (-2.0 * r * math.cos(theta), r * r)
+
+        a1_low, a2_low = coeffs(0.10)
+        a1_high, a2_high = coeffs(0.99)
+        cn_low = mpdsp.biquad_condition_number(1.0, 0.0, 0.0, a1_low, a2_low)
+        cn_high = mpdsp.biquad_condition_number(1.0, 0.0, 0.0, a1_high, a2_high)
+        assert cn_high > cn_low
+
+    def test_num_freqs_validated(self):
+        with pytest.raises(ValueError):
+            mpdsp.biquad_condition_number(1.0, 0.0, 0.0, -0.5, 0.1,
+                                           num_freqs=0)
+        with pytest.raises(ValueError):
+            mpdsp.biquad_condition_number(1.0, 0.0, 0.0, -0.5, 0.1,
+                                           num_freqs=-1)
+
+
+# ---- cascade_condition_number (Python wrapper) -------------------------
+
+
+class TestCascadeConditionNumber:
+    """`mpdsp.cascade_condition_number(filt, num_freqs)` is the free-
+    function companion to the existing `filt.condition_number(num_freqs)`
+    method. They wrap the same upstream primitive, so agreement is exact."""
+
+    def test_agrees_with_method_form(self):
+        filt = mpdsp.butterworth_lowpass(order=6, sample_rate=44100.0,
+                                           cutoff=1000.0)
+        for nf in (128, 256, 512):
+            assert (mpdsp.cascade_condition_number(filt, nf)
+                    == pytest.approx(filt.condition_number(nf), abs=0.0))
+
+    def test_high_order_exceeds_low_order(self):
+        filt_lo = mpdsp.butterworth_lowpass(order=2, sample_rate=44100.0,
+                                              cutoff=1000.0)
+        filt_hi = mpdsp.butterworth_lowpass(order=8, sample_rate=44100.0,
+                                              cutoff=1000.0)
+        assert (mpdsp.cascade_condition_number(filt_hi)
+                > mpdsp.cascade_condition_number(filt_lo))

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -207,6 +207,39 @@ class TestBiquadConditionNumber:
             mpdsp.biquad_condition_number(1.0, 0.0, 0.0, -0.5, 0.1,
                                            num_freqs=-1)
 
+    def test_default_num_freqs_is_512(self):
+        # Issue #53 contract pins the default at 512. Agreement between
+        # default-arg call and explicit num_freqs=512 catches a silent
+        # default-value regression.
+        default = mpdsp.biquad_condition_number(1.0, 0.0, 0.0, -0.5, 0.1)
+        explicit = mpdsp.biquad_condition_number(1.0, 0.0, 0.0, -0.5, 0.1,
+                                                   num_freqs=512)
+        assert default == pytest.approx(explicit, rel=0.0, abs=0.0)
+
+
+class TestCoefficientSensitivityEpsilonValidation:
+    """Guard at the binding boundary: epsilon must be finite and > 0."""
+
+    def test_rejects_zero_epsilon(self):
+        with pytest.raises(ValueError):
+            mpdsp.coefficient_sensitivity(1.0, 0.0, 0.0, -0.5, 0.1,
+                                            epsilon=0.0)
+
+    def test_rejects_negative_epsilon(self):
+        with pytest.raises(ValueError):
+            mpdsp.coefficient_sensitivity(1.0, 0.0, 0.0, -0.5, 0.1,
+                                            epsilon=-1e-6)
+
+    def test_rejects_nan_epsilon(self):
+        with pytest.raises(ValueError):
+            mpdsp.coefficient_sensitivity(1.0, 0.0, 0.0, -0.5, 0.1,
+                                            epsilon=float("nan"))
+
+    def test_rejects_inf_epsilon(self):
+        with pytest.raises(ValueError):
+            mpdsp.coefficient_sensitivity(1.0, 0.0, 0.0, -0.5, 0.1,
+                                            epsilon=float("inf"))
+
 
 # ---- cascade_condition_number (Python wrapper) -------------------------
 
@@ -230,3 +263,14 @@ class TestCascadeConditionNumber:
                                               cutoff=1000.0)
         assert (mpdsp.cascade_condition_number(filt_hi)
                 > mpdsp.cascade_condition_number(filt_lo))
+
+    def test_default_num_freqs_is_512(self):
+        # Per issue #53 the default is 512. The existing
+        # IIRFilter.condition_number method keeps 256 for backwards
+        # compatibility, so the wrapper default must differ from the
+        # underlying method default at call-through time.
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=44100.0,
+                                          cutoff=1000.0)
+        default = mpdsp.cascade_condition_number(filt)
+        explicit_512 = mpdsp.cascade_condition_number(filt, num_freqs=512)
+        assert default == pytest.approx(explicit_512, rel=0.0, abs=0.0)


### PR DESCRIPTION
Phase 4 of the 0.5.0 binding sweep (#40). Surfaces the three analysis free functions the issue identified — coefficient-level design-time analysis that doesn't require a constructed \`IIRFilter\`.

## New bindings — \`src/analysis_bindings.cpp\`

### \`coefficient_sensitivity(b0, b1, b2, a1, a2, epsilon=1e-8) → (dp_da1, dp_da2)\`
Finite-difference pole-radius sensitivities from upstream. Numerator coefficients accepted for signature symmetry (so callers can unpack \`IIRFilter.coefficients()\` tuples); they don't affect pole locations so the result depends only on the denominator.

### \`biquad_condition_number(b0, b1, b2, a1, a2, num_freqs=256) → float\`
Max relative frequency-response change per coefficient perturbation, swept across \`num_freqs\` points on \`[0, 0.5]\`. Large values indicate designed-to-the-edge biquads whose response is fragile under quantization.

Both bound on **double only**. Mixed-precision analysis of a constructed filter continues to live on the \`IIRFilter\` methods which dispatch through \`ArithConfig\`.

## Python wrapper — \`python/mpdsp/analysis.py\`

### \`cascade_condition_number(filt, num_freqs=256) → float\`
Thin Python wrapper over \`filt.condition_number(num_freqs)\`. Same upstream primitive; adds the free-function spelling without needing to expose \`PyIIRFilter\` in a shared header. Kept in Python because C++ cross-TU access to \`PyIIRFilter::cascade\` would require restructuring \`filter_bindings.cpp\` (already 1029 lines) for no functional gain.

## Tests — \`tests/test_analysis.py\`, +9 cases

| Group | Coverage |
|-------|----------|
| \`TestCoefficientSensitivity\` (4) | Shape; numerator-inert; complex-conjugate pole analytic formula \`d\\|p\\|/da2 = 1/(2r)\` pinned at 3 radii; \`d\\|p\\|/da1 ≈ 0\` |
| \`TestBiquadConditionNumber\` (3) | Shape + sign + finiteness; low-Q (r=0.1) < high-Q (r=0.99); num_freqs validation |
| \`TestCascadeConditionNumber\` (2) | Wrapper agrees with method form exactly; order-8 > order-2 at same cutoff |

Analytic pinning: for complex-conjugate biquad poles \`|p| = sqrt(a2)\`, so \`d|p|/da2 = 1/(2|p|)\`. The test verifies this against the binding's output across three pole radii with 1% relative tolerance — catches regressions in the finite-difference step size and the scalar-wrapping path.

## Docs

- \`scripts/build_api_ref.py\`: per issue #53's acceptance criteria, split the Numerical Analysis category into two subsections: \"pure-Python helpers\" (now includes \`cascade_condition_number\`) and \"free-function primitives (bound)\" (the two new C++ bindings).
- \`docs/api_reference.md\`: regenerated.
- \`README.md\`: unchanged. The analysis row already reads \"✓ via filter methods\" which remains accurate; the free functions are an addition, not a replacement of that story.

## Status
561/561 tests pass locally (552 before + 9 new).

## Test plan
- [x] Fast CI passes (Linux gcc/clang, Windows MSVC, macOS)
- [x] Promote to ready when satisfied

Resolves #53

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cascade_condition_number(), coefficient_sensitivity(), and biquad_condition_number(); these analysis helpers are now available from the package root.

* **Documentation**
  * Updated API reference and reorganized the numerical analysis sections to document the new functions.

* **Tests**
  * Added comprehensive tests validating behavior, input checks, and defaults for the new analysis helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->