### PR TITLE
feat(types): ContinuousTransferFunction + z-transform / laplace fns (#54 PR-A)

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -45,6 +45,7 @@ the note at the bottom.
   - [`NLMSFilter`](#nlmsfilter)
   - [`RLSFilter`](#rlsfilter)
   - [`TransferFunction`](#transferfunction)
+  - [`ContinuousTransferFunction`](#continuoustransferfunction)
 
 ---
 
@@ -277,13 +278,17 @@ PGM (grayscale 8/16-bit), PPM (RGB 8-bit), and BMP (8-bit grayscale + RGB). Read
 
 ## Types — transfer function and type projection
 
-`TransferFunction` is bound on double in 0.5.0 and represents the rational H(z) = B(z)/A(z) directly (as opposed to `IIRFilter`'s cascade-of-biquads form). Use `to_transfer_function(filt)` to fold an IIR cascade into a single TF for evaluation, cascade composition, or handing to the upcoming `ztransform` (Phase 5 / #54). `project_onto` / `projection_error` are the round-trip primitives underlying `measure_sqnr_db` — use them when you want the quantized samples or the raw error magnitude rather than the SQNR number.
+`TransferFunction` (discrete-time H(z)) and `ContinuousTransferFunction` (analog H(s)) are the rational-function classes, bound on double. `to_transfer_function(filt)` folds an IIRFilter cascade into a single TF; the spectral-analysis free functions (`ztransform`, `freqz`, `group_delay`, `laplace_freqs`) operate on those classes. `project_onto` / `projection_error` are the round-trip primitives underlying `measure_sqnr_db` — use them when you want the quantized samples or the raw error magnitude rather than the SQNR number.
 
 | Name | Signature | Description |
 |------|-----------|-------------|
 | `project_onto` | `(data: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False], dtype: str) -> ndarray` | Project data through the sample scalar of `dtype` and back to float64. The round-trip surfaces the quantization error you'd see feeding a signal through an ADC at that precision — it's the underlying mechanic of `measure_sqnr_db`, exposed directly for when you want the quantized samples rather than just the SQNR. |
 | `projection_error` | `(data: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False], dtype: str) -> float` | Max absolute error between data and its round-trip through `dtype`. Equivalent to max(abs(data - project_onto(data, dtype))) but computed without allocating the intermediate ndarray. |
 | `to_transfer_function` | `(filt)` | Fold an `IIRFilter` cascade into a single `TransferFunction`. |
+| `ztransform` | `(tf: mpdsp._core.TransferFunction, z: numpy.ndarray[dtype=complex128, shape=(*), order='C', writable=False]) -> ndarray[complex]` | Evaluate H(z) at each z-plane point. Free-function spelling of `tf.evaluate_many(z)`. Returns complex128 ndarray. |
+| `freqz` | `(tf: mpdsp._core.TransferFunction, num_points: int = 512) -> ndarray[complex]` | Evaluate H(e^{j 2*pi*f}) at `num_points` uniformly spaced normalized frequencies in [0, 0.5). Returns complex128 ndarray. |
+| `group_delay` | `(tf: mpdsp._core.TransferFunction, num_points: int = 512) -> ndarray` | Group delay at `num_points` uniformly spaced normalized frequencies in [0, 0.5). Returns float64 ndarray (samples of -d(phase)/d(omega)). |
+| `laplace_freqs` | `(tf: mpdsp._core.ContinuousTransferFunction, omega_max: float, num_points: int = 512) -> ndarray[complex]` | Evaluate H(j*omega) at `num_points` uniformly spaced angular frequencies in [0, omega_max). Returns complex128 ndarray. |
 
 ## Numerical analysis — pure-Python helpers
 
@@ -558,6 +563,21 @@ Rational H(z) = B(z)/A(z) with double-precision coefficients. Construct from num
 | `.frequency_response_many` | `(self, freqs: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False]) -> numpy.ndarray[dtype=complex128]` — Vectorized frequency_response(...) over a float64 ndarray of normalized frequencies. Returns complex128. |
 | `.is_stable` | `(self) -> bool` — Check stability via a 360-angle sampling of the denominator on the unit circle. False if any sample is within 1e-6 of zero. |
 | `.numerator` | Numerator coefficients b0, b1, b2, ... as a float64 ndarray. |
+
+### `ContinuousTransferFunction`
+
+Analog (continuous-time) rational H(s) = N(s)/D(s) with coefficients in ascending powers of s. Use with `laplace_freqs(tf, omega_max, N)` to evaluate frequency response at uniformly spaced angular frequencies — the natural path for analyzing analog prototype filters before bilinear transformation to the digital domain.
+
+> Continuous-time (analog) rational transfer function H(s) = N(s) / D(s).
+
+| Member | Signature / description |
+|--------|-------------------------|
+| `.denominator` | Denominator coefficients in ascending powers of s. |
+| `.evaluate` | `(self, s: complex) -> complex` — Evaluate H(s) at a single complex s-plane point. |
+| `.evaluate_many` | `(self, s: numpy.ndarray[dtype=complex128, shape=(*), order='C', writable=False]) -> numpy.ndarray[dtype=complex128]` — Evaluate H(s) at each point in a complex128 ndarray. Returns a complex128 ndarray of the same length. |
+| `.frequency_response` | `(self, omega: float) -> complex` — Evaluate H(j*omega) at angular frequency omega (rad/s). |
+| `.frequency_response_many` | `(self, omegas: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False]) -> numpy.ndarray[dtype=complex128]` — Vectorized frequency_response(...) over a float64 ndarray of angular frequencies. Returns complex128. |
+| `.numerator` | Numerator coefficients in ascending powers of s. |
 
 ---
 

--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -102,8 +102,10 @@ try:
         # Audio — file I/O
         read_wav, write_wav,
         # Types — rational transfer function + type projection
-        TransferFunction,
+        TransferFunction, ContinuousTransferFunction,
         project_onto, projection_error,
+        # Types — spectral-analysis free functions over transfer functions
+        ztransform, freqz, group_delay, laplace_freqs,
         # Analysis — free-function primitives (method-form lives on IIRFilter)
         coefficient_sensitivity, biquad_condition_number,
         # Introspection

--- a/scripts/build_api_ref.py
+++ b/scripts/build_api_ref.py
@@ -166,6 +166,7 @@ CATEGORIES = [
     ]),
     ("Types — transfer function and type projection", [
         "project_onto", "projection_error", "to_transfer_function",
+        "ztransform", "freqz", "group_delay", "laplace_freqs",
     ]),
     ("Numerical analysis — pure-Python helpers", [
         "biquad_poles", "max_pole_radius", "is_stable",
@@ -196,7 +197,7 @@ CLASSES = [
     "RPDFDither", "TPDFDither", "FirstOrderNoiseShaper",
     "PeakEnvelope", "RMSEnvelope", "Compressor", "AGC",
     "KalmanFilter", "LMSFilter", "NLMSFilter", "RLSFilter",
-    "TransferFunction",
+    "TransferFunction", "ContinuousTransferFunction",
 ]
 
 
@@ -281,15 +282,15 @@ INTROS = {
         "convention as `scipy.io.wavfile`."
     ),
     "Types — transfer function and type projection": (
-        "`TransferFunction` is bound on double in 0.5.0 and represents the "
-        "rational H(z) = B(z)/A(z) directly (as opposed to `IIRFilter`'s "
-        "cascade-of-biquads form). Use `to_transfer_function(filt)` to "
-        "fold an IIR cascade into a single TF for evaluation, cascade "
-        "composition, or handing to the upcoming `ztransform` (Phase 5 / "
-        "#54). `project_onto` / `projection_error` are the round-trip "
-        "primitives underlying `measure_sqnr_db` — use them when you want "
-        "the quantized samples or the raw error magnitude rather than the "
-        "SQNR number."
+        "`TransferFunction` (discrete-time H(z)) and "
+        "`ContinuousTransferFunction` (analog H(s)) are the rational-"
+        "function classes, bound on double. `to_transfer_function(filt)` "
+        "folds an IIRFilter cascade into a single TF; the spectral-"
+        "analysis free functions (`ztransform`, `freqz`, `group_delay`, "
+        "`laplace_freqs`) operate on those classes. `project_onto` / "
+        "`projection_error` are the round-trip primitives underlying "
+        "`measure_sqnr_db` — use them when you want the quantized samples "
+        "or the raw error magnitude rather than the SQNR number."
     ),
     "Numerical analysis — pure-Python helpers": (
         "Thin layer over already-bound `IIRFilter` methods. "
@@ -409,6 +410,14 @@ CLASS_INTROS = {
         "`*`. The `to_transfer_function(filt)` helper folds an IIRFilter "
         "cascade into one of these, useful when evaluating the full "
         "filter's H(z) directly rather than staging by stage."
+    ),
+    "ContinuousTransferFunction": (
+        "Analog (continuous-time) rational H(s) = N(s)/D(s) with "
+        "coefficients in ascending powers of s. Use with "
+        "`laplace_freqs(tf, omega_max, N)` to evaluate frequency "
+        "response at uniformly spaced angular frequencies — the natural "
+        "path for analyzing analog prototype filters before bilinear "
+        "transformation to the digital domain."
     ),
 }
 

--- a/src/types_bindings.cpp
+++ b/src/types_bindings.cpp
@@ -142,7 +142,7 @@ public:
 //
 // Same shape as PyTransferFunction but polynomials are in ascending powers
 // of s (the natural form for Laplace-plane analysis). Used by
-// `mpdsp.laplace_freqs` (bound in spectral_bindings.cpp) for frequency-
+// `mpdsp.laplace_freqs` (registered later in this same file) for frequency-
 // response evaluation of analog prototype filters.
 //
 // Like the discrete TransferFunction, bound on double only — multi-

--- a/src/types_bindings.cpp
+++ b/src/types_bindings.cpp
@@ -27,6 +27,8 @@
 #include <string>
 
 #include <mtl/vec/dense_vector.hpp>
+#include <sw/dsp/spectral/laplace.hpp>
+#include <sw/dsp/spectral/ztransform.hpp>
 #include <sw/dsp/types/projection.hpp>
 #include <sw/dsp/types/transfer_function.hpp>
 
@@ -132,6 +134,75 @@ public:
 	// Python side expects from `*`.
 	PyTransferFunction cascade(const PyTransferFunction& other) const {
 		return PyTransferFunction(inner * other.inner);
+	}
+};
+
+// ---------------------------------------------------------------------------
+// PyContinuousTransferFunction — analog-domain H(s) = N(s)/D(s).
+//
+// Same shape as PyTransferFunction but polynomials are in ascending powers
+// of s (the natural form for Laplace-plane analysis). Used by
+// `mpdsp.laplace_freqs` (bound in spectral_bindings.cpp) for frequency-
+// response evaluation of analog prototype filters.
+//
+// Like the discrete TransferFunction, bound on double only — multi-
+// precision continuous-time analysis isn't a real-world use case today
+// and would need infrastructure we don't have.
+// ---------------------------------------------------------------------------
+
+using CTF = sw::dsp::spectral::ContinuousTransferFunction<double>;
+
+class PyContinuousTransferFunction {
+public:
+	CTF inner;
+
+	PyContinuousTransferFunction() = default;
+
+	PyContinuousTransferFunction(np_f64_ro numerator, np_f64_ro denominator) {
+		inner.numerator = numpy_to_vec_fresh<double>(numerator);
+		inner.denominator = numpy_to_vec_fresh<double>(denominator);
+	}
+
+	explicit PyContinuousTransferFunction(CTF ctf) : inner(std::move(ctf)) {}
+
+	np_f64 get_numerator() const { return vec_to_numpy(inner.numerator); }
+	np_f64 get_denominator() const { return vec_to_numpy(inner.denominator); }
+
+	void set_numerator(np_f64_ro a) {
+		inner.numerator = numpy_to_vec_fresh<double>(a);
+	}
+	void set_denominator(np_f64_ro a) {
+		inner.denominator = numpy_to_vec_fresh<double>(a);
+	}
+
+	std::complex<double> evaluate(std::complex<double> s) const {
+		return inner.evaluate(s);
+	}
+
+	np_complex evaluate_many(np_complex_ro s_points) const {
+		std::size_t n = s_points.shape(0);
+		std::complex<double>* out_ptr = nullptr;
+		auto arr = make_complex_array(n, out_ptr);
+		const auto* sp = s_points.data();
+		for (std::size_t i = 0; i < n; ++i) {
+			out_ptr[i] = inner.evaluate(sp[i]);
+		}
+		return arr;
+	}
+
+	std::complex<double> frequency_response(double omega) const {
+		return inner.frequency_response(omega);
+	}
+
+	np_complex frequency_response_many(np_f64_ro omegas) const {
+		std::size_t n = omegas.shape(0);
+		std::complex<double>* out_ptr = nullptr;
+		auto arr = make_complex_array(n, out_ptr);
+		const auto* wp = omegas.data();
+		for (std::size_t i = 0; i < n; ++i) {
+			out_ptr[i] = inner.frequency_response(wp[i]);
+		}
+		return arr;
 	}
 };
 
@@ -246,6 +317,48 @@ void bind_types(nb::module_& m) {
 		      "Cascade: H_self(z) * H_other(z). Returns a new "
 		      "TransferFunction; self is not modified.");
 
+	// -- ContinuousTransferFunction (analog H(s)) --------------------------
+
+	nb::class_<PyContinuousTransferFunction>(m, "ContinuousTransferFunction",
+			"Continuous-time (analog) rational transfer function "
+			"H(s) = N(s) / D(s).\n\n"
+			"Numerator and denominator store ascending powers of s "
+			"(coeffs[0] + coeffs[1]*s + coeffs[2]*s^2 + ...) — the natural "
+			"form for Laplace-plane analysis of analog prototype filters.\n\n"
+			"Bound on double only; mixed-precision continuous-time analysis "
+			"isn't a real-world use case today.")
+		.def(nb::init<np_f64_ro, np_f64_ro>(),
+		     nb::arg("numerator"), nb::arg("denominator"),
+		     "Construct from numerator and denominator coefficient arrays "
+		     "in ascending powers of s.")
+		.def_prop_rw("numerator",
+		              &PyContinuousTransferFunction::get_numerator,
+		              &PyContinuousTransferFunction::set_numerator,
+		              nb::rv_policy::take_ownership,
+		              "Numerator coefficients in ascending powers of s.")
+		.def_prop_rw("denominator",
+		              &PyContinuousTransferFunction::get_denominator,
+		              &PyContinuousTransferFunction::set_denominator,
+		              nb::rv_policy::take_ownership,
+		              "Denominator coefficients in ascending powers of s.")
+		.def("evaluate", &PyContinuousTransferFunction::evaluate,
+		      nb::arg("s"),
+		      "Evaluate H(s) at a single complex s-plane point.")
+		.def("evaluate_many",
+		      &PyContinuousTransferFunction::evaluate_many,
+		      nb::arg("s"),
+		      "Evaluate H(s) at each point in a complex128 ndarray. "
+		      "Returns a complex128 ndarray of the same length.")
+		.def("frequency_response",
+		      &PyContinuousTransferFunction::frequency_response,
+		      nb::arg("omega"),
+		      "Evaluate H(j*omega) at angular frequency omega (rad/s).")
+		.def("frequency_response_many",
+		      &PyContinuousTransferFunction::frequency_response_many,
+		      nb::arg("omegas"),
+		      "Vectorized frequency_response(...) over a float64 ndarray "
+		      "of angular frequencies. Returns complex128.");
+
 	// -- Projection round-trip free functions ------------------------------
 
 	m.def("project_onto",
@@ -277,4 +390,78 @@ void bind_types(nb::module_& m) {
 		"Max absolute error between data and its round-trip through "
 		"`dtype`. Equivalent to max(abs(data - project_onto(data, dtype))) "
 		"but computed without allocating the intermediate ndarray.");
+
+	// -- Z-transform free functions over TransferFunction ------------------
+
+	m.def("ztransform",
+		[](const PyTransferFunction& tf, np_complex_ro z_points) {
+			// Free-function spelling of tf.evaluate_many — matches upstream
+			// `sw::dsp::spectral::evaluate_at` naming for callers who
+			// prefer a free-function style. Functionally identical.
+			return tf.evaluate_many(z_points);
+		},
+		nb::arg("tf"), nb::arg("z"),
+		"Evaluate H(z) at each z-plane point. Free-function spelling of "
+		"`tf.evaluate_many(z)`. Returns complex128 ndarray.");
+
+	m.def("freqz",
+		[](const PyTransferFunction& tf, std::size_t num_points) {
+			// Uniform sweep of [0, 0.5) at num_points frequencies. Matches
+			// the shape of MATLAB/scipy's freqz.
+			std::complex<double>* out_ptr = nullptr;
+			auto arr = make_complex_array(num_points, out_ptr);
+			for (std::size_t k = 0; k < num_points; ++k) {
+				double f = static_cast<double>(k) /
+				            static_cast<double>(num_points) * 0.5;
+				out_ptr[k] = tf.inner.frequency_response(f);
+			}
+			return arr;
+		},
+		nb::arg("tf"), nb::arg("num_points") = 512,
+		"Evaluate H(e^{j 2*pi*f}) at `num_points` uniformly spaced "
+		"normalized frequencies in [0, 0.5). Returns complex128 ndarray.");
+
+	m.def("group_delay",
+		[](const PyTransferFunction& tf, std::size_t num_points) {
+			// Group delay at uniform frequency sweep. Computed as
+			// -d(phase)/d(omega) via central finite differences with a
+			// small step. Wraps upstream sw::dsp::spectral::group_delay,
+			// but call it explicitly so we can surface the result as a
+			// float64 ndarray with take_ownership semantics.
+			double* out_ptr = nullptr;
+			auto arr = make_f64_array(num_points, out_ptr);
+			auto gd = sw::dsp::spectral::group_delay(tf.inner, num_points);
+			for (std::size_t k = 0; k < num_points; ++k) {
+				out_ptr[k] = gd[k];
+			}
+			return arr;
+		},
+		nb::arg("tf"), nb::arg("num_points") = 512,
+		"Group delay at `num_points` uniformly spaced normalized "
+		"frequencies in [0, 0.5). Returns float64 ndarray (samples of "
+		"-d(phase)/d(omega)).");
+
+	// -- Laplace free function over ContinuousTransferFunction -------------
+
+	m.def("laplace_freqs",
+		[](const PyContinuousTransferFunction& tf, double omega_max,
+		   std::size_t num_points) {
+			// Uniform sweep of angular frequencies in [0, omega_max).
+			// Companion to `freqz` but in the s-plane rather than z-plane.
+			if (!(omega_max > 0.0)) {
+				throw std::invalid_argument(
+					"laplace_freqs: omega_max must be positive");
+			}
+			std::complex<double>* out_ptr = nullptr;
+			auto arr = make_complex_array(num_points, out_ptr);
+			for (std::size_t k = 0; k < num_points; ++k) {
+				double omega = static_cast<double>(k) /
+				                static_cast<double>(num_points) * omega_max;
+				out_ptr[k] = tf.inner.frequency_response(omega);
+			}
+			return arr;
+		},
+		nb::arg("tf"), nb::arg("omega_max"), nb::arg("num_points") = 512,
+		"Evaluate H(j*omega) at `num_points` uniformly spaced angular "
+		"frequencies in [0, omega_max). Returns complex128 ndarray.");
 }

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -189,3 +189,128 @@ def test_projection_error_narrower_worse_than_wider():
     assert err_gpu <= err_half <= err_tiny
     # Sanity: the spread should be material.
     assert err_tiny > err_gpu * 10
+
+
+# ---------------------------------------------------------------------------
+# ContinuousTransferFunction (analog H(s)) — #54 Phase 5 PR-A
+# ---------------------------------------------------------------------------
+
+
+class TestContinuousTransferFunction:
+    def test_constructor_stores_coefficients(self):
+        ctf = mpdsp.ContinuousTransferFunction(
+            numerator=np.array([1.0, 1.0]),
+            denominator=np.array([1.0, 0.5, 1.0]),
+        )
+        np.testing.assert_allclose(ctf.numerator, [1.0, 1.0], atol=1e-15)
+        np.testing.assert_allclose(ctf.denominator, [1.0, 0.5, 1.0], atol=1e-15)
+
+    def test_evaluate_pure_gain_at_any_s_is_the_gain(self):
+        ctf = mpdsp.ContinuousTransferFunction(
+            np.array([2.0]), np.array([1.0]))
+        for s in (1.0 + 0j, 1j, -0.3 + 0.4j):
+            assert ctf.evaluate(s) == pytest.approx(2.0 + 0j, abs=1e-12)
+
+    def test_frequency_response_matches_evaluate_on_imag_axis(self):
+        # First-order lowpass H(s) = 1 / (s + 1).
+        ctf = mpdsp.ContinuousTransferFunction(
+            np.array([1.0]), np.array([1.0, 1.0]))
+        for omega in (0.0, 0.5, 1.0, 2.0, 5.0):
+            direct = ctf.evaluate(1j * omega)
+            via_fr = ctf.frequency_response(omega)
+            assert via_fr == pytest.approx(direct, abs=1e-12)
+
+    def test_first_order_lowpass_magnitude_3db_at_omega_1(self):
+        # |H(j*1)| = 1/sqrt(2) for H(s) = 1 / (s + 1).
+        ctf = mpdsp.ContinuousTransferFunction(
+            np.array([1.0]), np.array([1.0, 1.0]))
+        H = ctf.frequency_response(1.0)
+        assert abs(H) == pytest.approx(1.0 / np.sqrt(2), abs=1e-12)
+
+    def test_evaluate_many_matches_loop(self):
+        ctf = mpdsp.ContinuousTransferFunction(
+            np.array([1.0, 0.5]), np.array([1.0, 0.3, 1.0]))
+        ss = np.array([0 + 0.5j, 1j, -0.2 + 0.3j], dtype=complex)
+        batch = ctf.evaluate_many(ss)
+        one_by_one = np.array([ctf.evaluate(s) for s in ss])
+        np.testing.assert_allclose(batch, one_by_one, atol=1e-12)
+
+    def test_property_access_is_fresh_buffer_per_call(self):
+        # Regression guard against the rv_policy pitfall in BINDING_PATTERNS.md.
+        ctf = mpdsp.ContinuousTransferFunction(
+            np.array([1.0, 2.0, 3.0]), np.array([1.0]))
+        a = ctf.numerator
+        b = ctf.numerator
+        assert a.ctypes.data != b.ctypes.data
+        np.testing.assert_array_equal(a, b)
+
+
+# ---------------------------------------------------------------------------
+# ztransform, freqz, group_delay (#54 Phase 5 PR-A)
+# ---------------------------------------------------------------------------
+
+
+class TestZTransformFreeFunctions:
+    def test_ztransform_matches_evaluate_many(self):
+        tf = mpdsp.TransferFunction(np.array([1.0, 0.5, 0.25]),
+                                      np.array([-0.8, 0.3]))
+        zs = np.exp(2j * np.pi * np.array([0.0, 0.1, 0.25, 0.4, 0.5]))
+        via_free = mpdsp.ztransform(tf, zs)
+        via_method = tf.evaluate_many(zs)
+        np.testing.assert_array_equal(via_free, via_method)
+
+    def test_freqz_matches_frequency_response_at_matching_points(self):
+        tf = mpdsp.TransferFunction(np.array([1.0, 0.5]),
+                                      np.array([-0.5, 0.1]))
+        N = 64
+        from_free = mpdsp.freqz(tf, num_points=N)
+        freqs = np.linspace(0.0, 0.5, N, endpoint=False)
+        from_method = tf.frequency_response_many(freqs)
+        np.testing.assert_allclose(from_free, from_method, atol=1e-12)
+
+    def test_freqz_default_num_points_is_512(self):
+        tf = mpdsp.TransferFunction(np.array([1.0]), np.array([-0.5]))
+        assert mpdsp.freqz(tf).shape == (512,)
+
+    def test_group_delay_shape_and_type(self):
+        tf = mpdsp.TransferFunction(np.array([1.0, 0.5]),
+                                      np.array([-0.5, 0.1]))
+        gd = mpdsp.group_delay(tf, 64)
+        assert gd.shape == (64,)
+        assert gd.dtype == np.float64
+
+    def test_group_delay_zero_for_pure_gain(self):
+        # A pure-gain TF has zero phase everywhere → group delay is 0.
+        tf = mpdsp.TransferFunction(np.array([0.5]), np.array([]))
+        gd = mpdsp.group_delay(tf, 32)
+        np.testing.assert_allclose(gd, 0.0, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# laplace_freqs (#54 Phase 5 PR-A)
+# ---------------------------------------------------------------------------
+
+
+class TestLaplaceFreqs:
+    def test_matches_frequency_response_at_matching_omega(self):
+        ctf = mpdsp.ContinuousTransferFunction(
+            np.array([1.0]), np.array([1.0, 1.0]))  # 1/(s+1)
+        N = 32
+        omega_max = 5.0
+        from_free = mpdsp.laplace_freqs(ctf, omega_max, N)
+        omegas = np.linspace(0.0, omega_max, N, endpoint=False)
+        from_method = ctf.frequency_response_many(omegas)
+        np.testing.assert_allclose(from_free, from_method, atol=1e-12)
+
+    def test_omega_max_validated(self):
+        ctf = mpdsp.ContinuousTransferFunction(
+            np.array([1.0]), np.array([1.0, 1.0]))
+        with pytest.raises(ValueError):
+            mpdsp.laplace_freqs(ctf, 0.0, 16)
+        with pytest.raises(ValueError):
+            mpdsp.laplace_freqs(ctf, -1.0, 16)
+
+    def test_default_num_points_is_512(self):
+        ctf = mpdsp.ContinuousTransferFunction(
+            np.array([1.0]), np.array([1.0, 1.0]))
+        assert mpdsp.laplace_freqs(ctf, 10.0).shape == (512,)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -205,6 +205,24 @@ class TestContinuousTransferFunction:
         np.testing.assert_allclose(ctf.numerator, [1.0, 1.0], atol=1e-15)
         np.testing.assert_allclose(ctf.denominator, [1.0, 0.5, 1.0], atol=1e-15)
 
+    def test_setter_round_trip(self):
+        # Pin the writable property contract: assign new arrays, read them
+        # back. A broken def_prop_rw binding or ndarray-to-vector conversion
+        # would slip past the constructor + getter-only tests otherwise.
+        ctf = mpdsp.ContinuousTransferFunction(
+            np.array([1.0]), np.array([1.0]))
+        ctf.numerator = np.array([1.0, 0.5, 0.25])
+        ctf.denominator = np.array([1.0, 0.3, 1.0, 0.5])
+        np.testing.assert_allclose(ctf.numerator,
+                                    [1.0, 0.5, 0.25], atol=1e-15)
+        np.testing.assert_allclose(ctf.denominator,
+                                    [1.0, 0.3, 1.0, 0.5], atol=1e-15)
+        # After a setter round-trip, evaluate should reflect the new
+        # coefficients, not the constructor's.
+        # H(s) = (1 + 0.5s + 0.25s^2) / (1 + 0.3s + s^2 + 0.5s^3) at s=0
+        # is just 1/1 = 1.
+        assert ctf.evaluate(0.0 + 0j) == pytest.approx(1.0 + 0j, abs=1e-12)
+
     def test_evaluate_pure_gain_at_any_s_is_the_gain(self):
         ctf = mpdsp.ContinuousTransferFunction(
             np.array([2.0]), np.array([1.0]))


### PR DESCRIPTION
Phase 5 PR-A of the 0.5.0 binding sweep (#54). First of two PRs; the dtype-dispatch refactor of existing spectral primitives lands in PR-B.

Per the option-B decomposition: this PR is purely **additive** (new class + new free functions, no refactor of existing code). PR-B will be the cross-cutting dispatch work on \`fft\` / \`ifft\` / \`psd\` / \`periodogram\` / \`spectrogram\`.

## New class — \`mpdsp.ContinuousTransferFunction\`

Analog \`H(s) = N(s) / D(s)\`. Coefficients in ascending powers of s. Same shape as \`TransferFunction\` from #52:
- Constructor from \`(numerator, denominator)\` float64 ndarrays
- \`numerator\` / \`denominator\` read/write properties with \`nb::rv_policy::take_ownership\` (per \`src/BINDING_PATTERNS.md\`)
- \`evaluate(s)\`, \`evaluate_many(s_array)\`, \`frequency_response(omega)\`, \`frequency_response_many(omegas)\`

Bound on double only — mixed-precision continuous-time analysis isn't a real-world use case today.

## New free functions

| Function | Role |
|----------|------|
| \`mpdsp.ztransform(tf, z)\` | Free-function spelling of \`tf.evaluate_many\` at arbitrary z points |
| \`mpdsp.freqz(tf, num_points=512)\` | Uniform sweep of \`[0, 0.5)\` — MATLAB/scipy naming |
| \`mpdsp.group_delay(tf, num_points=512)\` | Group delay via \`-d(phase)/d(omega)\` |
| \`mpdsp.laplace_freqs(tf, omega_max, num_points=512)\` | Uniform analog-domain sweep through \`[0, omega_max)\` |

### Binding location
All four free functions + the new class live in \`src/types_bindings.cpp\` rather than \`src/spectral_bindings.cpp\` because they need access to \`PyTransferFunction\` / \`PyContinuousTransferFunction\` (both defined in that TU). Moving them to spectral bindings would require a shared header for the class declarations, which we don't need for zero functional gain.

## Tests — \`tests/test_types.py\`, +14 cases

| Group | Coverage |
|-------|----------|
| TestContinuousTransferFunction (6) | Coefficient round-trip; pure-gain evaluate; imaginary-axis evaluate vs. frequency_response; canonical 1/(s+1) is −3 dB at ω=1; batch vs. loop; fresh-buffer-per-property-access (rv_policy pin) |
| TestZTransformFreeFunctions (5) | \`ztransform\` == \`evaluate_many\` exactly; \`freqz\` matches \`frequency_response_many\` on \`linspace(0, 0.5, N, endpoint=False)\`; default \`num_points=512\`; \`group_delay\` shape/dtype; \`group_delay=0\` for pure-gain TF |
| TestLaplaceFreqs (3) | Agreement with \`frequency_response_many\`; \`omega_max > 0\` validation; default \`num_points=512\` |

## Status
581/581 tests pass locally (567 before + 14 new).

## Docs
- \`scripts/build_api_ref.py\`: Types category picks up the four new free functions; new \`ContinuousTransferFunction\` class added to \`CLASSES\` with intro.
- \`docs/api_reference.md\`: regenerated.

## Test plan
- [x] Fast CI passes (Linux gcc/clang, Windows MSVC, macOS)
- [x] Promote to ready when satisfied

Relates to #54 — the dtype-dispatch refactor of \`fft\` / \`ifft\` / \`psd\` / \`periodogram\` / \`spectrogram\` lands in a separate PR to keep review surface manageable.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ContinuousTransferFunction for analog H(s) with evaluation and frequency-response helpers.
  * Added spectral-analysis helpers: ztransform, freqz, group_delay, laplace_freqs — sampling helpers with sensible defaults and input validation.

* **Documentation**
  * API reference updated to include the new class and functions and usage notes.

* **Tests**
  * New unit tests covering construction, evaluation, frequency sampling, defaults, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->