### PR TITLE
feat(types): add sensor/FPGA configs + bits_of accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,13 @@ aren't part of a mixed-precision datapath).
 | `tiny_posit` | double | posit<8,2> | posit<8,2> | Ultra-low-power edge |
 | `cf24` | double | cfloat<24,5> | cfloat<24,5> | Custom 24-bit float research |
 | `half` | double | cfloat<16,5> | cfloat<16,5> | IEEE half throughout |
+| `sensor_8bit` | double | double | integer<8> | Standard 8-bit sensor ADC |
+| `sensor_6bit` | double | double | integer<6> | Noise-limited sensor |
+| `fpga_fixed` | double | fixpnt<32,24> | fixpnt<16,12> | FPGA fixed-point datapath |
 
-Query the live set at runtime with `mpdsp.available_dtypes()`. Fixed-point
-and integer configurations (sensor ADCs, FPGA datapaths) are planned for
-`0.5.0` alongside the remaining upstream bindings.
+Query the live set at runtime with `mpdsp.available_dtypes()`. Sample-scalar
+bit width per config is available via `mpdsp.bits_of(dtype)` — useful for
+labeling the x-axis of precision-vs-cost plots.
 
 Coefficients are always designed in `double` — design-time precision is
 non-negotiable for IIR filters (see the

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -322,6 +322,7 @@ Coefficient-level analysis that doesn't require a constructed IIRFilter — usef
 | Name | Signature | Description |
 |------|-----------|-------------|
 | `available_dtypes` | `() -> list[str]` | List available arithmetic configuration names. |
+| `bits_of` | `(dtype: str) -> int` | Return the sample-scalar bit width for `dtype`. Use this to label a precision-vs-cost axis instead of hardcoding the mapping. Raises ValueError for unknown dtype strings. |
 | `compare_filters` | `(filt, signal, dtypes=None)` | Process `signal` through `filt` at multiple dtypes and report error metrics. |
 
 ## CSV + image-pipeline helpers (pure Python)

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -65,10 +65,15 @@ these string keys. Query the live set at runtime with
 | `tiny_posit` | double | posit<8,2> | posit<8,2> | Ultra-low-power edge |
 | `cf24` | double | cfloat<24,5> | cfloat<24,5> | Custom 24-bit float |
 | `half` | double | cfloat<16,5> | cfloat<16,5> | IEEE half throughout |
+| `sensor_8bit` | double | double | integer<8> | Standard 8-bit sensor ADC |
+| `sensor_6bit` | double | double | integer<6> | Noise-limited sensor |
+| `fpga_fixed` | double | fixpnt<32,24> | fixpnt<16,12> | FPGA fixed-point datapath |
 
-Planned for `0.5.0` (issue #55): fixed-point / integer configs
-(`sensor_8bit`, `fpga_fixed`, ...) plus an `mpdsp.bits_of(dtype)`
-accessor. Dtype dispatch on the spectral transforms shipped in #54.
+Use `mpdsp.bits_of(dtype)` to query the sample-scalar bit width for any
+config (useful for precision-vs-cost plots). The sensor configs keep
+coefficient and state at double; only the ADC sample path quantizes
+through `integer<N>`, which is the common case for ingesting real-world
+ADC streams without re-architecting the downstream filter.
 
 ## Module attributes
 

--- a/python/mpdsp/__init__.py
+++ b/python/mpdsp/__init__.py
@@ -109,7 +109,7 @@ try:
         # Analysis — free-function primitives (method-form lives on IIRFilter)
         coefficient_sensitivity, biquad_condition_number,
         # Introspection
-        available_dtypes,
+        available_dtypes, bits_of,
     )
     # The underlying mixed-precision-dsp C++ library version the wheel
     # was built against, sourced from sw::dsp::version.hpp. Matches

--- a/scripts/build_api_ref.py
+++ b/scripts/build_api_ref.py
@@ -176,7 +176,7 @@ CATEGORIES = [
         "coefficient_sensitivity", "biquad_condition_number",
     ]),
     ("Mixed-precision helpers", [
-        "available_dtypes", "compare_filters",
+        "available_dtypes", "bits_of", "compare_filters",
     ]),
     ("CSV + image-pipeline helpers (pure Python)", [
         "load_sweep", "apply_per_channel", "collect_adaptive_weights",

--- a/scripts/build_api_ref.py
+++ b/scripts/build_api_ref.py
@@ -592,10 +592,15 @@ these string keys. Query the live set at runtime with
 | `tiny_posit` | double | posit<8,2> | posit<8,2> | Ultra-low-power edge |
 | `cf24` | double | cfloat<24,5> | cfloat<24,5> | Custom 24-bit float |
 | `half` | double | cfloat<16,5> | cfloat<16,5> | IEEE half throughout |
+| `sensor_8bit` | double | double | integer<8> | Standard 8-bit sensor ADC |
+| `sensor_6bit` | double | double | integer<6> | Noise-limited sensor |
+| `fpga_fixed` | double | fixpnt<32,24> | fixpnt<16,12> | FPGA fixed-point datapath |
 
-Planned for `0.5.0` (issue #55): fixed-point / integer configs
-(`sensor_8bit`, `fpga_fixed`, ...) plus an `mpdsp.bits_of(dtype)`
-accessor. Dtype dispatch on the spectral transforms shipped in #54.
+Use `mpdsp.bits_of(dtype)` to query the sample-scalar bit width for any
+config (useful for precision-vs-cost plots). The sensor configs keep
+coefficient and state at double; only the ADC sample path quantizes
+through `integer<N>`, which is the common case for ingesting real-world
+ADC streams without re-architecting the downstream filter.
 
 ## Module attributes
 

--- a/scripts/plot_dashboard.py
+++ b/scripts/plot_dashboard.py
@@ -487,20 +487,11 @@ def plot_summary_heatmap(filt, signal: np.ndarray):
 def plot_precision_cost_frontier(filt, signal: np.ndarray):
     """SQNR vs bits-per-sample scatter: identifies Pareto-optimal dtypes.
 
-    Uses the bit-width estimates below; mpdsp doesn't expose a formal
-    bits-per-sample accessor on the dtype name, so this dict lives here
-    as a documented constant the dashboard can use. It matches the
-    iir_precision_sweep CSV's `bits` column.
+    Bit widths come from `mpdsp.bits_of()` (issue #55) — the dashboard
+    used to duplicate this mapping as a local dict, which drifted every
+    time a new config was added. Now it queries the binding directly and
+    will automatically pick up any future sensor/FPGA configs.
     """
-    bits_by_dtype = {
-        "reference":    64,
-        "gpu_baseline": 32,
-        "ml_hw":        16,  # bfloat16 / half
-        "half":         16,
-        "cf24":         24,
-        "posit_full":   16,  # posit<16,1> is the dominant sample-path scalar
-        "tiny_posit":    8,
-    }
     ref_out = filt.process(signal, dtype="reference")
 
     rows = []
@@ -511,7 +502,7 @@ def plot_precision_cost_frontier(filt, signal: np.ndarray):
         except Exception:  # noqa: BLE001
             continue
         if np.isfinite(sqnr) and sqnr < 290:
-            rows.append({"dtype": dt, "bits": bits_by_dtype.get(dt, 0),
+            rows.append({"dtype": dt, "bits": mpdsp.bits_of(dt),
                           "sqnr_db": sqnr})
     df = pd.DataFrame(rows)
 

--- a/src/_binding_helpers.hpp
+++ b/src/_binding_helpers.hpp
@@ -273,6 +273,7 @@ inline auto dispatch_dtype_fn(mpdsp::ArithConfig config, const char* cls,
                                Callable&& f) {
 	using mpdsp::ArithConfig;
 	using mpdsp::cf24;
+	using mpdsp::fx3224_t;
 	using mpdsp::half_;
 	using mpdsp::p32;
 	using tiny_posit_t = sw::universal::posit<8, 2>;
@@ -284,6 +285,13 @@ inline auto dispatch_dtype_fn(mpdsp::ArithConfig config, const char* cls,
 	case ArithConfig::half_config:  return f.template operator()<half_>();
 	case ArithConfig::posit_full:   return f.template operator()<p32>();
 	case ArithConfig::tiny_posit:   return f.template operator()<tiny_posit_t>();
+	// Sensor configs dispatch to the STATE scalar (double). The quantization
+	// effect that distinguishes sensor_* from `reference` surfaces through
+	// the sample-path dispatchers (project_dispatch / adc_dispatch), not
+	// here. See issue #55 for the design rationale.
+	case ArithConfig::sensor_8bit:  return f.template operator()<double>();
+	case ArithConfig::sensor_6bit:  return f.template operator()<double>();
+	case ArithConfig::fpga_fixed:   return f.template operator()<fx3224_t>();
 	}
 	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
 }
@@ -293,6 +301,7 @@ inline std::unique_ptr<Base>
 make_impl_for_dtype(mpdsp::ArithConfig config, const char* cls, Args&&... args) {
 	using mpdsp::ArithConfig;
 	using mpdsp::cf24;
+	using mpdsp::fx3224_t;
 	using mpdsp::half_;
 	using mpdsp::p32;
 	using tiny_posit_t = sw::universal::posit<8, 2>;
@@ -311,6 +320,14 @@ make_impl_for_dtype(mpdsp::ArithConfig config, const char* cls, Args&&... args) 
 		return std::make_unique<Impl<p32>>(std::forward<Args>(args)...);
 	case ArithConfig::tiny_posit:
 		return std::make_unique<Impl<tiny_posit_t>>(std::forward<Args>(args)...);
+	case ArithConfig::sensor_8bit:
+	case ArithConfig::sensor_6bit:
+		// Sensor configs keep the state/compute scalar at double — the
+		// 8/6-bit path only shows up in ADC quantization, not in the
+		// filter/processor state. See types.hpp.
+		return std::make_unique<Impl<double>>(std::forward<Args>(args)...);
+	case ArithConfig::fpga_fixed:
+		return std::make_unique<Impl<fx3224_t>>(std::forward<Args>(args)...);
 	}
 	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
 }

--- a/src/estimation_bindings.cpp
+++ b/src/estimation_bindings.cpp
@@ -284,6 +284,7 @@ make_adaptive_impl(mpdsp::ArithConfig config, const char* cls,
                    std::size_t num_taps, DoubleArgs... args) {
 	using mpdsp::ArithConfig;
 	using mpdsp::cf24;
+	using mpdsp::fx3224_t;
 	using mpdsp::half_;
 	using mpdsp::p32;
 	using tiny_posit_t = sw::universal::posit<8, 2>;
@@ -309,6 +310,16 @@ make_adaptive_impl(mpdsp::ArithConfig config, const char* cls,
 	case ArithConfig::tiny_posit:
 		return std::make_unique<AdaptiveFilterImpl<Filter, tiny_posit_t>>(
 			num_taps, static_cast<tiny_posit_t>(args)...);
+	// Sensor configs keep the filter state at double; the sample-path
+	// quantization lives in project_dispatch / adc_dispatch rather than
+	// the adaptive update itself.
+	case ArithConfig::sensor_8bit:
+	case ArithConfig::sensor_6bit:
+		return std::make_unique<AdaptiveFilterImpl<Filter, double>>(
+			num_taps, static_cast<double>(args)...);
+	case ArithConfig::fpga_fixed:
+		return std::make_unique<AdaptiveFilterImpl<Filter, fx3224_t>>(
+			num_taps, static_cast<fx3224_t>(args)...);
 	}
 	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
 }

--- a/src/estimation_bindings.cpp
+++ b/src/estimation_bindings.cpp
@@ -310,16 +310,25 @@ make_adaptive_impl(mpdsp::ArithConfig config, const char* cls,
 	case ArithConfig::tiny_posit:
 		return std::make_unique<AdaptiveFilterImpl<Filter, tiny_posit_t>>(
 			num_taps, static_cast<tiny_posit_t>(args)...);
-	// Sensor configs keep the filter state at double; the sample-path
-	// quantization lives in project_dispatch / adc_dispatch rather than
-	// the adaptive update itself.
+	// Reject the Phase-6 sensor/FPGA configs here. Adaptive filters only
+	// accept a single scalar T, so we can't independently honour both a
+	// double state and an integer<N> / fixpnt<16,12> sample path — either
+	// the sensor_* configs would silently collapse to `reference` (with
+	// no quantization visible), or fpga_fixed would claim a 16-bit sample
+	// path while actually running the adaptive update at fixpnt<32,24>
+	// and breaking dtype-to-dtype comparisons. Surface the limitation
+	// instead of fabricating a misleading answer; a future wrapper can
+	// add explicit pre/post sample quantization around the update if a
+	// real use case appears.
 	case ArithConfig::sensor_8bit:
 	case ArithConfig::sensor_6bit:
-		return std::make_unique<AdaptiveFilterImpl<Filter, double>>(
-			num_taps, static_cast<double>(args)...);
 	case ArithConfig::fpga_fixed:
-		return std::make_unique<AdaptiveFilterImpl<Filter, fx3224_t>>(
-			num_taps, static_cast<fx3224_t>(args)...);
+		throw std::invalid_argument(
+			std::string(cls) +
+			": dtype not supported by adaptive filters — sensor_* and "
+			"fpga_fixed mix state and sample precisions, which the "
+			"single-T adaptive update can't honour. Use reference, "
+			"gpu_baseline, ml_hw, posit_full, tiny_posit, cf24, or half.");
 	}
 	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
 }

--- a/src/filter_bindings.cpp
+++ b/src/filter_bindings.cpp
@@ -77,7 +77,11 @@ static void process_dispatch(const CascadeD& cascade,
                              mpdsp::ArithConfig config) {
 	using mpdsp::ArithConfig;
 	using mpdsp::cf24;
+	using mpdsp::fx1612_t;
+	using mpdsp::fx3224_t;
 	using mpdsp::half_;
+	using mpdsp::int6_sample_t;
+	using mpdsp::int8_sample_t;
 	using mpdsp::p16;
 	using mpdsp::p32;
 	using tiny_posit_t = sw::universal::posit<8, 2>;
@@ -96,6 +100,16 @@ static void process_dispatch(const CascadeD& cascade,
 		process_typed<p32, p16>(cascade, in, out, n); break;
 	case ArithConfig::tiny_posit:
 		process_typed<tiny_posit_t, tiny_posit_t>(cascade, in, out, n); break;
+	// Sensor configs: coefficient/state in double, sample quantized through
+	// integer<N>. integer<N> is ADL-castable from double via static_cast, so
+	// process_typed<double, int8_sample_t> models "signal arrives on an 8-bit
+	// ADC, filter state stays wide" — matches issue #55's sensor semantics.
+	case ArithConfig::sensor_8bit:
+		process_typed<double, int8_sample_t>(cascade, in, out, n); break;
+	case ArithConfig::sensor_6bit:
+		process_typed<double, int6_sample_t>(cascade, in, out, n); break;
+	case ArithConfig::fpga_fixed:
+		process_typed<fx3224_t, fx1612_t>(cascade, in, out, n); break;
 	}
 }
 
@@ -331,7 +345,11 @@ static void fir_process_dispatch(const mtl::vec::dense_vector<double>& taps_d,
                                  mpdsp::ArithConfig config) {
 	using mpdsp::ArithConfig;
 	using mpdsp::cf24;
+	using mpdsp::fx1612_t;
+	using mpdsp::fx3224_t;
 	using mpdsp::half_;
+	using mpdsp::int6_sample_t;
+	using mpdsp::int8_sample_t;
 	using mpdsp::p16;
 	using mpdsp::p32;
 	using tiny_posit_t = sw::universal::posit<8, 2>;
@@ -350,6 +368,12 @@ static void fir_process_dispatch(const mtl::vec::dense_vector<double>& taps_d,
 		fir_process_typed<p32, p16>(taps_d, in, out, n); break;
 	case ArithConfig::tiny_posit:
 		fir_process_typed<tiny_posit_t, tiny_posit_t>(taps_d, in, out, n); break;
+	case ArithConfig::sensor_8bit:
+		fir_process_typed<double, int8_sample_t>(taps_d, in, out, n); break;
+	case ArithConfig::sensor_6bit:
+		fir_process_typed<double, int6_sample_t>(taps_d, in, out, n); break;
+	case ArithConfig::fpga_fixed:
+		fir_process_typed<fx3224_t, fx1612_t>(taps_d, in, out, n); break;
 	}
 }
 
@@ -419,6 +443,7 @@ static double pole_displacement_dispatch(const CascadeD& src,
                                          mpdsp::ArithConfig config) {
 	using mpdsp::ArithConfig;
 	using mpdsp::cf24;
+	using mpdsp::fx3224_t;
 	using mpdsp::half_;
 	using mpdsp::p16;
 	using mpdsp::p32;
@@ -432,6 +457,13 @@ static double pole_displacement_dispatch(const CascadeD& src,
 	case ArithConfig::half_config:  quantized = quantize_cascade<half_>(src); break;
 	case ArithConfig::posit_full:   quantized = quantize_cascade<p32>(src); break;
 	case ArithConfig::tiny_posit:   quantized = quantize_cascade<tiny_posit_t>(src); break;
+	// sensor_* keep coefficients at double (only the sample path quantizes),
+	// so coefficient-level pole displacement is zero for them.
+	case ArithConfig::sensor_8bit:
+	case ArithConfig::sensor_6bit:
+		return 0.0;
+	case ArithConfig::fpga_fixed:
+		quantized = quantize_cascade<fx3224_t>(src); break;
 	}
 	return sw::dsp::pole_displacement(src, quantized);
 }

--- a/src/filter_bindings.cpp
+++ b/src/filter_bindings.cpp
@@ -42,6 +42,10 @@
 #include <string>
 #include <vector>
 
+// sw::universal::is_integer trait used by the sample quantization helpers
+// below — #include <universal/traits/integer_traits.hpp> is pulled in
+// transitively via types.hpp's integer.hpp include.
+
 namespace nb = nanobind;
 
 // Max biquad stages exposed to Python. For Butterworth/Cheby/Bessel/Legendre:
@@ -57,6 +61,41 @@ using CascadeD = sw::dsp::Cascade<double, kMaxStages>;
 namespace {
 
 // ---------------------------------------------------------------------------
+// Sample quantization helpers.
+//
+// For float-like SampleScalar (float, posit, cfloat, fixpnt) a plain cast is
+// a faithful narrowing — the type represents fractional values natively.
+// For integer<N>, a plain static_cast truncates |x|<1 to zero, annihilating
+// any audio-range signal. Mirror the scale-quantize-unscale pipeline from
+// adc_typed / project_typed: map the full-scale [-1, 1] input range onto the
+// integer's representable range, quantize, then scale back. Keeps the
+// filter's sample-path quantization semantics consistent with what the ADC
+// binding exposes, so sensor_8bit FIR/IIR output isn't silently zero.
+// ---------------------------------------------------------------------------
+
+template <typename SampleScalar>
+static inline SampleScalar quantize_sample_in(double x) {
+	if constexpr (sw::universal::is_integer<SampleScalar>) {
+		constexpr double fs =
+			static_cast<double>((1LL << (SampleScalar::nbits - 1)) - 1);
+		return static_cast<SampleScalar>(x * fs);
+	} else {
+		return static_cast<SampleScalar>(x);
+	}
+}
+
+template <typename SampleScalar>
+static inline double quantize_sample_out(SampleScalar y) {
+	if constexpr (sw::universal::is_integer<SampleScalar>) {
+		constexpr double fs =
+			static_cast<double>((1LL << (SampleScalar::nbits - 1)) - 1);
+		return static_cast<double>(y) / fs;
+	} else {
+		return static_cast<double>(y);
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Type-dispatched per-sample processing.
 // ---------------------------------------------------------------------------
 
@@ -65,10 +104,10 @@ static void process_typed(const CascadeD& cascade,
                           const double* in, double* out, std::size_t n) {
 	std::array<sw::dsp::DirectFormI<StateScalar>, kMaxStages> state{};
 	for (std::size_t i = 0; i < n; ++i) {
-		SampleScalar x = static_cast<SampleScalar>(in[i]);
+		SampleScalar x = quantize_sample_in<SampleScalar>(in[i]);
 		SampleScalar y = cascade.template process<sw::dsp::DirectFormI<StateScalar>,
 		                                          SampleScalar>(x, state);
-		out[i] = static_cast<double>(y);
+		out[i] = quantize_sample_out<SampleScalar>(y);
 	}
 }
 
@@ -335,8 +374,8 @@ static void fir_process_typed(const mtl::vec::dense_vector<double>& taps_d,
 	}
 	sw::dsp::FIRFilter<StateScalar, StateScalar, SampleScalar> filt(taps);
 	for (std::size_t i = 0; i < n; ++i) {
-		SampleScalar x = static_cast<SampleScalar>(in[i]);
-		out[i] = static_cast<double>(filt.process(x));
+		SampleScalar x = quantize_sample_in<SampleScalar>(in[i]);
+		out[i] = quantize_sample_out<SampleScalar>(filt.process(x));
 	}
 }
 

--- a/src/quantization_bindings.cpp
+++ b/src/quantization_bindings.cpp
@@ -42,17 +42,44 @@ static np_array vec_to_numpy(const mtl::vec::dense_vector<double>& v) {
 	return np_array(data, 1, shape, owner);
 }
 
-// ADC: quantize a double signal through a target type and back
+// ADC: quantize a double signal through a target type and back.
+//
+// For float-like T (float, posit, cfloat, fixpnt), `static_cast<T>(x)` is a
+// faithful narrowing because those types can represent fractional values —
+// upstream sw::dsp::ADC handles this path directly.
+//
+// For integer<N>, `static_cast` truncates any |x| < 1 to zero — that's not a
+// quantization model, it's signal annihilation. Physical N-bit ADCs instead
+// map the full-scale analog range [-1, 1] onto the integer's representable
+// range [-(2^(N-1)-1), 2^(N-1)-1], quantize, then scale back to [-1, 1] for
+// downstream math. We detect integer<N> via a concept check and route through
+// a scale-quantize-unscale pipeline so sensor_* configs produce the
+// quantization noise users expect instead of all zeros.
 template <typename T>
 static mtl::vec::dense_vector<double>
 adc_typed(const mtl::vec::dense_vector<double>& signal) {
-	sw::dsp::ADC<double, T> adc;
-	auto quantized = adc.convert(signal);
-	mtl::vec::dense_vector<double> result(signal.size());
-	for (std::size_t i = 0; i < signal.size(); ++i) {
-		result[i] = static_cast<double>(quantized[i]);
+	if constexpr (sw::universal::is_integer<T>) {
+		// Full-scale magnitude for an N-bit signed integer (N = T::nbits).
+		// Subtract 1 so we don't hit the asymmetric -2^(N-1) value, keeping
+		// the mapping symmetric around zero. Reasonable for an audio-like
+		// signal normalized to [-1, 1]; asymmetric real-world ADCs are out
+		// of scope for this binding-layer ADC model.
+		constexpr double fs = static_cast<double>((1LL << (T::nbits - 1)) - 1);
+		mtl::vec::dense_vector<double> result(signal.size());
+		for (std::size_t i = 0; i < signal.size(); ++i) {
+			T q = static_cast<T>(signal[i] * fs);
+			result[i] = static_cast<double>(q) / fs;
+		}
+		return result;
+	} else {
+		sw::dsp::ADC<double, T> adc;
+		auto quantized = adc.convert(signal);
+		mtl::vec::dense_vector<double> result(signal.size());
+		for (std::size_t i = 0; i < signal.size(); ++i) {
+			result[i] = static_cast<double>(quantized[i]);
+		}
+		return result;
 	}
-	return result;
 }
 
 static mtl::vec::dense_vector<double>
@@ -65,6 +92,9 @@ adc_dispatch(const mtl::vec::dense_vector<double>& signal, mpdsp::ArithConfig co
 	case mpdsp::ArithConfig::ml_hw:         return adc_typed<mpdsp::half_>(signal);
 	case mpdsp::ArithConfig::posit_full:    return adc_typed<mpdsp::p16>(signal);
 	case mpdsp::ArithConfig::tiny_posit:    return adc_typed<sw::universal::posit<8,2>>(signal);
+	case mpdsp::ArithConfig::sensor_8bit:   return adc_typed<mpdsp::int8_sample_t>(signal);
+	case mpdsp::ArithConfig::sensor_6bit:   return adc_typed<mpdsp::int6_sample_t>(signal);
+	case mpdsp::ArithConfig::fpga_fixed:    return adc_typed<mpdsp::fx1612_t>(signal);
 	}
 	return signal;
 }
@@ -82,12 +112,26 @@ dac_typed(const mtl::vec::dense_vector<double>& quantized) {
 	// then use the vector-level convert() overload upstream provides.
 	// This keeps dac_typed / adc_typed structurally symmetric — important
 	// for a "companion" binding that readers will compare side by side.
-	mtl::vec::dense_vector<T> narrow(quantized.size());
-	for (std::size_t i = 0; i < quantized.size(); ++i) {
-		narrow[i] = static_cast<T>(quantized[i]);
+	//
+	// For integer<N> we apply the same scale-quantize-unscale loop as
+	// adc_typed so adc(signal, "sensor_8bit") -> dac stays an idempotent
+	// round-trip rather than collapsing to zero.
+	if constexpr (sw::universal::is_integer<T>) {
+		constexpr double fs = static_cast<double>((1LL << (T::nbits - 1)) - 1);
+		mtl::vec::dense_vector<double> result(quantized.size());
+		for (std::size_t i = 0; i < quantized.size(); ++i) {
+			T q = static_cast<T>(quantized[i] * fs);
+			result[i] = static_cast<double>(q) / fs;
+		}
+		return result;
+	} else {
+		mtl::vec::dense_vector<T> narrow(quantized.size());
+		for (std::size_t i = 0; i < quantized.size(); ++i) {
+			narrow[i] = static_cast<T>(quantized[i]);
+		}
+		sw::dsp::DAC<T, double> dac;
+		return dac.convert(narrow);
 	}
-	sw::dsp::DAC<T, double> dac;
-	return dac.convert(narrow);
 }
 
 static mtl::vec::dense_vector<double>
@@ -101,6 +145,9 @@ dac_dispatch(const mtl::vec::dense_vector<double>& quantized,
 	case mpdsp::ArithConfig::ml_hw:         return dac_typed<mpdsp::half_>(quantized);
 	case mpdsp::ArithConfig::posit_full:    return dac_typed<mpdsp::p16>(quantized);
 	case mpdsp::ArithConfig::tiny_posit:    return dac_typed<sw::universal::posit<8,2>>(quantized);
+	case mpdsp::ArithConfig::sensor_8bit:   return dac_typed<mpdsp::int8_sample_t>(quantized);
+	case mpdsp::ArithConfig::sensor_6bit:   return dac_typed<mpdsp::int6_sample_t>(quantized);
+	case mpdsp::ArithConfig::fpga_fixed:    return dac_typed<mpdsp::fx1612_t>(quantized);
 	}
 	// Unreachable: switch is exhaustive over mpdsp::ArithConfig.
 	return quantized;
@@ -370,6 +417,11 @@ void bind_quantization(nb::module_& m) {
 
 	m.def("available_dtypes", &mpdsp::available_configs,
 	   "List available arithmetic configuration names.");
+
+	m.def("bits_of", &mpdsp::bits_of, nb::arg("dtype"),
+	   "Return the sample-scalar bit width for `dtype`. Use this to label "
+	   "a precision-vs-cost axis instead of hardcoding the mapping. "
+	   "Raises ValueError for unknown dtype strings.");
 
 	// RPDFDither — uniform [-amplitude, +amplitude] additive noise.
 	nb::class_<PyRPDFDither>(m, "RPDFDither",

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -14,6 +14,8 @@
 
 // Universal number types
 #include <sw/universal/number/cfloat/cfloat.hpp>
+#include <sw/universal/number/fixpnt/fixpnt.hpp>
+#include <sw/universal/number/integer/integer.hpp>
 #include <sw/universal/number/posit/posit.hpp>
 
 namespace mpdsp {
@@ -23,6 +25,14 @@ using cf24  = sw::universal::cfloat<24, 5, uint32_t, true, false, false>;
 using half_ = sw::universal::cfloat<16, 5, uint16_t, true, false, false>;
 using p32   = sw::universal::posit<32, 2>;
 using p16   = sw::universal::posit<16, 1>;
+
+// Sensor / FPGA sample-path scalars (issue #55). integer<N> is the ADC
+// quantization target for sensor_* configs; fixpnt is the state/sample
+// scalar pair for a fixed-point FPGA datapath.
+using int8_sample_t  = sw::universal::integer<8>;
+using int6_sample_t  = sw::universal::integer<6>;
+using fx3224_t       = sw::universal::fixpnt<32, 24>;  // FPGA coefficient/state
+using fx1612_t       = sw::universal::fixpnt<16, 12>;  // FPGA sample path
 
 // The set of pre-instantiated arithmetic configurations.
 // Python passes these as string keys; C++ dispatches to the correct types.
@@ -34,6 +44,9 @@ enum class ArithConfig {
 	tiny_posit,     // double / posit<8,2> / posit<8,2>
 	cf24_config,    // double / cf24 / cf24
 	half_config,    // double / half / half
+	sensor_8bit,    // double / double / integer<8>
+	sensor_6bit,    // double / double / integer<6>
+	fpga_fixed,     // double / fixpnt<32,24> / fixpnt<16,12>
 };
 
 inline ArithConfig parse_config(const std::string& name) {
@@ -44,13 +57,39 @@ inline ArithConfig parse_config(const std::string& name) {
 	if (name == "tiny_posit") return ArithConfig::tiny_posit;
 	if (name == "cf24") return ArithConfig::cf24_config;
 	if (name == "half") return ArithConfig::half_config;
+	if (name == "sensor_8bit") return ArithConfig::sensor_8bit;
+	if (name == "sensor_6bit") return ArithConfig::sensor_6bit;
+	if (name == "fpga_fixed") return ArithConfig::fpga_fixed;
 	throw std::invalid_argument("Unknown arithmetic config: " + name);
 }
 
 // List of available config names (for Python introspection)
 inline std::vector<std::string> available_configs() {
 	return { "reference", "gpu_baseline", "ml_hw", "posit_full",
-	         "tiny_posit", "cf24", "half" };
+	         "tiny_posit", "cf24", "half",
+	         "sensor_8bit", "sensor_6bit", "fpga_fixed" };
+}
+
+// Sample-scalar bit width per config. Surfaces the table that was
+// previously hardcoded in scripts/plot_dashboard.py:plot_precision_cost_frontier
+// so the dashboard and any other consumer can query it rather than duplicate.
+// Returns the width of the narrowest (sample-path) scalar, which is what the
+// precision-vs-cost frontier is plotted against.
+inline int bits_of(const std::string& name) {
+	auto cfg = parse_config(name);
+	switch (cfg) {
+	case ArithConfig::reference:    return 64;
+	case ArithConfig::gpu_baseline: return 32;
+	case ArithConfig::ml_hw:        return 16;  // half
+	case ArithConfig::posit_full:   return 16;  // posit<16,1> sample path
+	case ArithConfig::tiny_posit:   return 8;   // posit<8,2>
+	case ArithConfig::cf24_config:  return 24;
+	case ArithConfig::half_config:  return 16;
+	case ArithConfig::sensor_8bit:  return 8;
+	case ArithConfig::sensor_6bit:  return 6;
+	case ArithConfig::fpga_fixed:   return 16;  // fixpnt<16,12> sample path
+	}
+	throw std::invalid_argument("bits_of: unsupported ArithConfig");
 }
 
 } // namespace mpdsp

--- a/src/types_bindings.cpp
+++ b/src/types_bindings.cpp
@@ -220,12 +220,28 @@ project_typed(const mtl::vec::dense_vector<double>& src) {
 	// each element back to double so the Python caller always sees
 	// float64 — matches the issue's signature
 	// `project_onto(ndarray, dtype: str) -> ndarray`.
-	auto narrowed = sw::dsp::project_onto<T>(src);
-	mtl::vec::dense_vector<double> out(narrowed.size());
-	for (std::size_t i = 0; i < narrowed.size(); ++i) {
-		out[i] = static_cast<double>(narrowed[i]);
+	//
+	// For integer<N> the direct cast collapses |x| < 1 to zero, so mirror
+	// the scale-quantize-unscale path used in adc_typed: map the
+	// full-scale [-1, 1] input range onto integer's representable range,
+	// quantize, then scale back. See quantization_bindings.cpp for the
+	// design rationale.
+	if constexpr (sw::universal::is_integer<T>) {
+		constexpr double fs = static_cast<double>((1LL << (T::nbits - 1)) - 1);
+		mtl::vec::dense_vector<double> out(src.size());
+		for (std::size_t i = 0; i < src.size(); ++i) {
+			T q = static_cast<T>(src[i] * fs);
+			out[i] = static_cast<double>(q) / fs;
+		}
+		return out;
+	} else {
+		auto narrowed = sw::dsp::project_onto<T>(src);
+		mtl::vec::dense_vector<double> out(narrowed.size());
+		for (std::size_t i = 0; i < narrowed.size(); ++i) {
+			out[i] = static_cast<double>(narrowed[i]);
+		}
+		return out;
 	}
-	return out;
 }
 
 static mtl::vec::dense_vector<double>
@@ -237,7 +253,10 @@ project_dispatch(const mtl::vec::dense_vector<double>& src,
 	// `measure_sqnr_db` already does. If a future request needs
 	// coefficient-path projection specifically, we add a second function.
 	using mpdsp::cf24;
+	using mpdsp::fx1612_t;
 	using mpdsp::half_;
+	using mpdsp::int6_sample_t;
+	using mpdsp::int8_sample_t;
 	using mpdsp::p16;
 	using tiny_posit_t = sw::universal::posit<8, 2>;
 
@@ -256,12 +275,14 @@ project_dispatch(const mtl::vec::dense_vector<double>& src,
 		return project_typed<cf24>(src);
 	case mpdsp::ArithConfig::half_config:
 		return project_typed<half_>(src);
+	case mpdsp::ArithConfig::sensor_8bit:
+		return project_typed<int8_sample_t>(src);
+	case mpdsp::ArithConfig::sensor_6bit:
+		return project_typed<int6_sample_t>(src);
+	case mpdsp::ArithConfig::fpga_fixed:
+		return project_typed<fx1612_t>(src);
 	}
 	// Unreachable: the switch above is exhaustive over mpdsp::ArithConfig.
-	// This return exists only to keep the compiler quiet without reaching for
-	// [[noreturn]] or a warning pragma. When a new ArithConfig enumerator
-	// lands (e.g. sensor_8bit in #55), add a case above and this line stays
-	// inert.
 	return src;
 }
 

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -284,6 +284,16 @@ class TestLMSFilter:
         with pytest.raises(ValueError):
             mpdsp.LMSFilter(num_taps=4, step_size=0.01, dtype="not_a_dtype")
 
+    @pytest.mark.parametrize("dtype", ["sensor_8bit", "sensor_6bit", "fpga_fixed"])
+    def test_sensor_and_fpga_configs_rejected(self, dtype):
+        # Adaptive filters have a single scalar T — there's no way to honour
+        # a mixed state/sample precision pair the way the IIR/FIR cascades
+        # can. The binding rejects the #55 configs rather than silently
+        # collapsing sensor_* to `reference` or routing fpga_fixed's sample
+        # path through the coefficient scalar. See estimation_bindings.cpp.
+        with pytest.raises(ValueError):
+            mpdsp.LMSFilter(num_taps=4, step_size=0.01, dtype=dtype)
+
     def test_process_returns_tuple(self):
         f = mpdsp.LMSFilter(num_taps=3, step_size=0.05)
         y, e = f.process(1.0, 0.5)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -124,6 +124,20 @@ class TestProcessing:
         with pytest.raises(Exception):
             filt.process(sig, dtype="not_a_real_dtype")
 
+    def test_sensor_8bit_output_stays_in_signal_range(self):
+        # Sensor dtypes route samples through integer<N> with the
+        # scale-quantize-unscale pipeline, so output of a unit-amplitude
+        # sine must stay in roughly [-1, 1] — not collapse to zero (the
+        # naive-cast failure mode) and not explode into integer units.
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        sig = _sine(300.0)  # amplitude 1.0
+        y = filt.process(sig, dtype="sensor_8bit")
+        assert np.max(np.abs(y)) > 0.1   # not annihilated
+        assert np.max(np.abs(y)) < 2.0   # not in integer units (would be ~127)
+        # 8-bit quantization should noticeably differ from reference.
+        ref = filt.process(sig, dtype="reference")
+        assert not np.array_equal(y, ref)
+
 
 # ---------------------------------------------------------------------------
 # Helpers reused across families.

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -99,10 +99,105 @@ class TestAvailableDtypes:
         assert "posit_full" in dtypes
         assert "half" in dtypes
 
+    def test_available_dtypes_includes_sensor_and_fpga(self):
+        # Phase 6 (#55) added the sensor/FPGA configs — guard against a
+        # future refactor silently dropping them from the registry.
+        dtypes = mpdsp.available_dtypes()
+        assert "sensor_8bit" in dtypes
+        assert "sensor_6bit" in dtypes
+        assert "fpga_fixed" in dtypes
+        assert len(dtypes) == 10
+
     def test_invalid_dtype_raises(self):
         sig = mpdsp.sine(100, frequency=440.0, sample_rate=44100.0)
         with pytest.raises(ValueError):
             mpdsp.adc(sig, dtype="nonexistent_type")
+
+
+class TestBitsOf:
+    """Regression guards for the bits_of() accessor (issue #55).
+
+    The sample-scalar bit width is the x-axis of the precision-cost
+    frontier; the dashboard used to hardcode this mapping. Pin the
+    numbers here so a future rename or reshape of ArithConfig can't
+    silently shift the frontier.
+    """
+
+    @pytest.mark.parametrize("dtype,expected", [
+        ("reference",    64),
+        ("gpu_baseline", 32),
+        ("ml_hw",        16),
+        ("half",         16),
+        ("cf24",         24),
+        ("posit_full",   16),
+        ("tiny_posit",    8),
+        ("sensor_8bit",   8),
+        ("sensor_6bit",   6),
+        ("fpga_fixed",   16),
+    ])
+    def test_bits_of_returns_expected_width(self, dtype, expected):
+        assert mpdsp.bits_of(dtype) == expected
+
+    def test_bits_of_covers_every_available_dtype(self):
+        # No dtype can be enumerated by available_dtypes() without also
+        # having a bits_of() answer — that's the invariant the dashboard
+        # relies on when iterating.
+        for dt in mpdsp.available_dtypes():
+            assert isinstance(mpdsp.bits_of(dt), int)
+
+    def test_bits_of_rejects_unknown_dtype(self):
+        with pytest.raises(ValueError):
+            mpdsp.bits_of("nonexistent_type")
+
+
+class TestSensorAndFpgaQuantization:
+    """End-to-end SQNR sweep through the three new (#55) configs.
+
+    Sensor configs quantize the sample path to integer<N>; the coarser the
+    N, the worse the SQNR. `fpga_fixed` keeps 12 fractional bits so SQNR
+    should land above the 8-bit sensor but well below `reference`. We
+    don't pin tight dB bounds — just the ordering that makes the frontier
+    plot meaningful.
+    """
+
+    def test_sensor_6bit_loses_more_sqnr_than_sensor_8bit(self):
+        sig = mpdsp.sine(4096, frequency=440.0, sample_rate=44100.0,
+                          amplitude=0.5)
+        sqnr_8 = mpdsp.measure_sqnr_db(sig, "sensor_8bit")
+        sqnr_6 = mpdsp.measure_sqnr_db(sig, "sensor_6bit")
+        # 6-bit quantization loses ~12 dB more than 8-bit per the 6 dB/bit
+        # rule of thumb — just assert direction, not magnitude.
+        assert sqnr_6 < sqnr_8
+
+    def test_fpga_fixed_beats_6bit_sensor(self):
+        sig = mpdsp.sine(4096, frequency=440.0, sample_rate=44100.0,
+                          amplitude=0.5)
+        sqnr_fpga = mpdsp.measure_sqnr_db(sig, "fpga_fixed")
+        sqnr_6    = mpdsp.measure_sqnr_db(sig, "sensor_6bit")
+        assert sqnr_fpga > sqnr_6
+
+    def test_adc_roundtrip_produces_different_output_per_new_dtype(self):
+        # Each new config should visibly quantize the signal — if two
+        # configs produce identical adc() output, dispatch is broken.
+        sig = mpdsp.sine(256, frequency=100.0, sample_rate=1024.0,
+                          amplitude=0.5)
+        q_8   = mpdsp.adc(sig, dtype="sensor_8bit")
+        q_6   = mpdsp.adc(sig, dtype="sensor_6bit")
+        q_fx  = mpdsp.adc(sig, dtype="fpga_fixed")
+        assert not np.array_equal(q_8, q_6)
+        assert not np.array_equal(q_8, q_fx)
+        assert not np.array_equal(q_6, q_fx)
+
+    def test_project_onto_sensor_8bit_quantizes(self):
+        # project_onto round-trips through the sample scalar. integer<8>
+        # has ~8 bits of precision so a mid-amplitude sine should show
+        # non-trivial quantization error.
+        sig = mpdsp.sine(512, frequency=10.0, sample_rate=512.0,
+                          amplitude=0.5)
+        projected = mpdsp.project_onto(sig, "sensor_8bit")
+        assert projected.shape == sig.shape
+        err = np.max(np.abs(sig - projected))
+        assert err > 1e-3  # integer<8> can't represent 0.5 exactly
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Phase 6 (final) of the 0.5.0 binding sweep. **Closes epic #40.**
- Adds three new `ArithConfig` enumerations targeting non-floating-point datapaths: `sensor_8bit` (integer<8> sample), `sensor_6bit` (integer<6> sample), and `fpga_fixed` (fixpnt<32,24> / fixpnt<16,12>).
- Introduces `mpdsp.bits_of(dtype) -> int` as the formal sample-scalar bit-width accessor; `scripts/plot_dashboard.py:plot_precision_cost_frontier` now queries it instead of duplicating the mapping.

## Changes

- `src/types.hpp` — three new enum values + type aliases + `parse_config` branches + `available_configs` entries + the new `bits_of()` function.
- `src/_binding_helpers.hpp` — `dispatch_dtype_fn` and `make_impl_for_dtype` extended: sensor_* dispatches to `double` (state); fpga_fixed dispatches to `fixpnt<32,24>`.
- `src/quantization_bindings.cpp` — `adc_typed`/`dac_typed` specialize on `sw::universal::is_integer<T>` to scale through the integer's full range instead of truncating to zero; `adc_dispatch`/`dac_dispatch` extended; `bits_of` exposed.
- `src/types_bindings.cpp` — `project_typed` applies the same integer-scaling specialization; `project_dispatch` extended to the new configs.
- `src/filter_bindings.cpp` / `src/estimation_bindings.cpp` — local dispatch switches extended so the previously-emitted `-Wswitch` warnings go away without silently taking the throw path.
- `python/mpdsp/__init__.py` — exports `bits_of`.
- `scripts/plot_dashboard.py` — drops the hardcoded `bits_by_dtype` dict; queries `mpdsp.bits_of()`.
- `scripts/build_api_ref.py` + `docs/api_reference.md` + `README.md` — arithmetic-configuration table grows from 7 to 10 rows; "planned for 0.5.0" footnote removed; `bits_of` documented.
- `tests/test_quantization.py` — 17 new test cases covering introspection + SQNR ordering through the new configs.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| `_core` | OK | 668/668 | OK | 668/668 |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #55
Closes #40

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three arithmetic configurations: sensor_8bit, sensor_6bit, and fpga_fixed.
  * Added mpdsp.bits_of(dtype) to query per-config sample-scalar bit width at runtime.

* **Behavior Changes**
  * ADC/DAC and sample-path operations now reflect integer/fixed-point quantization for the new configs.
  * Certain adaptive filter constructions now reject these configs with a clear error.

* **Documentation**
  * Updated configuration and API docs to describe new configs and bits_of.

* **Tests**
  * Added unit and end-to-end tests covering new configs and bits_of.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->