### PR TITLE
chore(release): bump to 0.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.22)
 # the regex provider configured in pyproject.toml — do not hardcode
 # it anywhere else.
 project(mp-dsp-python
-	VERSION 0.4.1
+	VERSION 0.5.0
 	LANGUAGES CXX)
 
 # ---------------------------------------------------------------------------
@@ -25,7 +25,7 @@ project(mp-dsp-python
 # Override at configure time with `-DMPDSP_DSP_PIN=main` (etc.) to build
 # against an unreleased upstream without editing this file.
 # ---------------------------------------------------------------------------
-set(MPDSP_DSP_PIN       "v0.4.1" CACHE STRING
+set(MPDSP_DSP_PIN       "v0.5.0" CACHE STRING
 	"mixed-precision-dsp git tag / branch / SHA to fetch")
 set(MPDSP_UNIVERSAL_PIN "v4.6.9" CACHE STRING
 	"universal git tag / branch / SHA to fetch")

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,8 +1,8 @@
 # `mpdsp` API reference
 
 Complete enumeration of every public name in the `mpdsp` package, grouped
-by subsystem. Generated from `0.4.1.post2` (upstream `sw::dsp
-0.4.1`) via `inspect` and the nanobind-attached
+by subsystem. Generated from `0.5.0` (upstream `sw::dsp
+0.5.0`) via `inspect` and the nanobind-attached
 `__doc__` strings. Keep this in sync by re-running the generator — see
 the note at the bottom.
 
@@ -79,8 +79,8 @@ ADC streams without re-architecting the downstream filter.
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `mpdsp.__version__` | `str` | The installed wheel version (PEP 440). Current: `"0.4.1.post2"`. |
-| `mpdsp.__dsp_version__` | `str` | The upstream `sw::dsp` C++ library version the wheel was built against. Current: `"0.4.1"`. |
+| `mpdsp.__version__` | `str` | The installed wheel version (PEP 440). Current: `"0.5.0"`. |
+| `mpdsp.__dsp_version__` | `str` | The upstream `sw::dsp` C++ library version the wheel was built against. Current: `"0.5.0"`. |
 | `mpdsp.__dsp_version_info__` | `tuple` | `(major, minor, patch)` tuple of ints for `__dsp_version__`. |
 | `mpdsp.HAS_CORE` | `bool` | `True` when the nanobind extension imported cleanly. `False` in unbuilt source checkouts, and (pre-0.4.1.post1) indicated a packaging bug before we hardened the import. |
 | `mpdsp.HAS_PLOT` | `bool` | `True` when matplotlib is importable — gates the `plot_*` helpers. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ wheel.install-dir = "mpdsp"
 provider = "scikit_build_core.metadata.regex"
 input = "CMakeLists.txt"
 regex = '(?i)project\s*\(\s*mp-dsp-python[^)]*VERSION\s+(?P<value>[0-9]+\.[0-9]+\.[0-9]+)'
-result = "{value}.post2"
+result = "{value}"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -372,13 +372,18 @@ class TestNoiseShaper:
             assert s.dtype == dt
 
     def test_reference_process_is_near_identity(self):
-        # At `reference` dtype, there's no quantization — error feedback
-        # stays zero and output equals input.
+        # At `reference` dtype the (double -> double) cast is lossless, so
+        # the pure quantization error is zero. Upstream 0.5.0 adds a
+        # denormal-prevention AC term (±1e-8) to the error-feedback path
+        # to keep IEEE doubles out of the flush-to-zero hole, so output
+        # is "near-identity" to within that denormal bound rather than
+        # bit-exact. See sw::dsp::DenormalPrevention in
+        # mixed-precision-dsp's math/denormal.hpp.
         shaper = mpdsp.FirstOrderNoiseShaper(dtype="reference")
         rng = np.random.default_rng(3)
         signal = rng.normal(0.0, 0.3, size=256)
         out = shaper.process_block(signal)
-        np.testing.assert_allclose(out, signal, atol=1e-12)
+        np.testing.assert_allclose(out, signal, atol=1e-7)
 
     def test_process_block_and_process_agree(self):
         signal = np.linspace(-0.4, 0.4, 64)


### PR DESCRIPTION
## Summary

Cut the 0.5.0 release — lockstep with the upstream `mixed-precision-dsp` v0.5.0 tag cut today. Closes out epic #40 (the 0.5.0 binding sweep).

## Changes

- `CMakeLists.txt` — `project(VERSION)` bumped `0.4.1 → 0.5.0`; `MPDSP_DSP_PIN` bumped `v0.4.1 → v0.5.0`. Wheel builds under cibuildwheel will now pull upstream v0.5.0.
- `pyproject.toml` — reset the scikit-build-core version template from `"{value}.post2"` back to `"{value}"`, as the file's own comment directs. Wheel version reports `0.5.0`, not `0.5.0.post2`.
- `docs/api_reference.md` — regenerated (header now reads `0.5.0 / sw::dsp 0.5.0`).
- `tests/test_quantization.py` — loosened the noise-shaper reference-dtype tolerance from `1e-12` to `1e-7`. Upstream 0.5.0's `FirstOrderNoiseShaper` added a ±1e-8 denormal-prevention AC term to the error-feedback path; reference is no longer bit-exact identity but stays within the denormal bound. Comment captures the rationale.

## What ships in 0.5.0 (epic #40)

Six phases across issues #50–#55, all merged:

| Phase | What |
|-------|------|
| #50 | TransferFunction.from/to_biquad conversion |
| #51 | Coefficient sensitivity + biquad condition number |
| #52 | TransferFunction class + projection primitives |
| #53 | Analysis free functions + ContinuousTransferFunction |
| #54 | Spectral dtype dispatch (fft/ifft/psd/periodogram/spectrogram) |
| #55 | sensor_*/fpga_fixed ArithConfig + bits_of accessor |

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| `_core` | OK | 672/672 | OK | 672/672 |

## Post-merge

1. `git tag v0.5.0` on main
2. `git push origin v0.5.0`
3. Tag triggers `release.yml` (tests + GitHub Release) → `publish.yml` (cibuildwheel → PyPI via trusted publisher)

Closes #40

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented project version from 0.4.1 to 0.5.0
  * Updated version extraction mechanism to directly use semantic version without post-release suffix
  * Synchronized upstream C++ library version reference to match project version

* **Tests**
  * Updated test tolerance parameters for numerical computation validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->