### PR TITLE
fix(filters): expose zeros() on IIRFilter; render them in dashboard

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -376,6 +376,7 @@ Returned by every `*_lowpass` / `*_highpass` / `*_bandpass` / `*_bandstop` / `rb
 | `.process` | `(self, signal: numpy.ndarray[dtype=float64, shape=(*), writable=False], dtype: str = 'reference') -> numpy.ndarray[dtype=float64]` — Filter a signal. dtype selects arithmetic for state and samples (see available_dtypes()). Returns NumPy float64. |
 | `.stability_margin` | `(self) -> float` — 1 - max(\|pole\|). Positive = stable, 0 = marginal, < 0 = unstable. |
 | `.worst_case_sensitivity` | `(self, epsilon: float = 1e-08) -> float` — Worst-case \|d(max_pole_radius)/d(coeff)\| across stages, computed by finite differences. |
+| `.zeros` | `(self) -> list[complex]` — List of complex zero locations in the z-plane. For all-pole families (Butterworth / Chebyshev I / Bessel / Legendre), all finite zeros map t |
 
 ### `FIRFilter`
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -376,7 +376,7 @@ Returned by every `*_lowpass` / `*_highpass` / `*_bandpass` / `*_bandstop` / `rb
 | `.process` | `(self, signal: numpy.ndarray[dtype=float64, shape=(*), writable=False], dtype: str = 'reference') -> numpy.ndarray[dtype=float64]` — Filter a signal. dtype selects arithmetic for state and samples (see available_dtypes()). Returns NumPy float64. |
 | `.stability_margin` | `(self) -> float` — 1 - max(\|pole\|). Positive = stable, 0 = marginal, < 0 = unstable. |
 | `.worst_case_sensitivity` | `(self, epsilon: float = 1e-08) -> float` — Worst-case \|d(max_pole_radius)/d(coeff)\| across stages, computed by finite differences. |
-| `.zeros` | `(self) -> list[complex]` — List of complex zero locations in the z-plane. For all-pole families (Butterworth / Chebyshev I / Bessel / Legendre), all finite zeros map t |
+| `.zeros` | `(self) -> list[complex]` — List of complex zero locations in the z-plane. For all-pole families (Butterworth / Chebyshev I / Bessel / Legendre), all finite zeros map to z = -1, so expect an N-fold cluster there. Chebyshev II and Elliptic distribute zeros on the unit circle. |
 
 ### `FIRFilter`
 
@@ -441,7 +441,7 @@ Peak envelope follower with configurable attack/release. The `.value` property e
 |--------|-------------------------|
 | `.dtype` | The arithmetic configuration selected at construction. |
 | `.process` | `(self, input: float) -> float` — Process a single sample. Returns the updated envelope value. |
-| `.process_block` | `(self, signal: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False]) -> numpy.ndarray[dtype=float64]` — Process a 1D NumPy float64 signal. Returns the envelope trace (same length as the input). The per-sample loop releases the GIL internally so |
+| `.process_block` | `(self, signal: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False]) -> numpy.ndarray[dtype=float64]` — Process a 1D NumPy float64 signal. Returns the envelope trace (same length as the input). The per-sample loop releases the GIL internally so other Python threads can run. |
 | `.reset` | `(self) -> None` — Clear the internal envelope state to zero. |
 | `.value` | `(self) -> float` — Current envelope value without consuming a sample. |
 
@@ -519,7 +519,7 @@ Least-mean-squares adaptive filter. Coefficients adapt online via the LMS update
 | `.last_error` | Error residual from the most recent process() call. |
 | `.num_taps` | (self) -> int |
 | `.process` | `(self, input: float, desired: float) -> tuple[float, float]` — Process one sample with adaptation. Returns a (output, error) tuple where output is y[n] = w^T x[n] and error is d[n] - y[n]. |
-| `.process_block` | `(self, inputs: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False], desireds: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False]) -> tuple[numpy.ndarray[dtype=float64], numpy.ndarray[dtype=float64]]` — Process two equal-length NumPy float64 signals (input, desired) and return a (outputs, errors) tuple of float64 arrays. The per-sample loop  |
+| `.process_block` | `(self, inputs: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False], desireds: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False]) -> tuple[numpy.ndarray[dtype=float64], numpy.ndarray[dtype=float64]]` — Process two equal-length NumPy float64 signals (input, desired) and return a (outputs, errors) tuple of float64 arrays. The per-sample loop releases the GIL. |
 | `.reset` | `(self) -> None` — Zero the weights and delay line. |
 | `.weights` | Current tap weights as a 1D NumPy float64 array (read-only copy). |
 
@@ -535,7 +535,7 @@ Normalized LMS — divides the step size by the input power for tunability that'
 | `.last_error` | Error residual from the most recent process() call. |
 | `.num_taps` | (self) -> int |
 | `.process` | `(self, input: float, desired: float) -> tuple[float, float]` — Process one sample with adaptation. Returns a (output, error) tuple where output is y[n] = w^T x[n] and error is d[n] - y[n]. |
-| `.process_block` | `(self, inputs: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False], desireds: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False]) -> tuple[numpy.ndarray[dtype=float64], numpy.ndarray[dtype=float64]]` — Process two equal-length NumPy float64 signals (input, desired) and return a (outputs, errors) tuple of float64 arrays. The per-sample loop  |
+| `.process_block` | `(self, inputs: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False], desireds: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False]) -> tuple[numpy.ndarray[dtype=float64], numpy.ndarray[dtype=float64]]` — Process two equal-length NumPy float64 signals (input, desired) and return a (outputs, errors) tuple of float64 arrays. The per-sample loop releases the GIL. |
 | `.reset` | `(self) -> None` — Zero the weights and delay line. |
 | `.weights` | Current tap weights as a 1D NumPy float64 array (read-only copy). |
 
@@ -551,7 +551,7 @@ Recursive least-squares adaptive filter. Faster convergence than LMS/NLMS at the
 | `.last_error` | Error residual from the most recent process() call. |
 | `.num_taps` | (self) -> int |
 | `.process` | `(self, input: float, desired: float) -> tuple[float, float]` — Process one sample with adaptation. Returns a (output, error) tuple where output is y[n] = w^T x[n] and error is d[n] - y[n]. |
-| `.process_block` | `(self, inputs: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False], desireds: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False]) -> tuple[numpy.ndarray[dtype=float64], numpy.ndarray[dtype=float64]]` — Process two equal-length NumPy float64 signals (input, desired) and return a (outputs, errors) tuple of float64 arrays. The per-sample loop  |
+| `.process_block` | `(self, inputs: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False], desireds: numpy.ndarray[dtype=float64, shape=(*), order='C', writable=False]) -> tuple[numpy.ndarray[dtype=float64], numpy.ndarray[dtype=float64]]` — Process two equal-length NumPy float64 signals (input, desired) and return a (outputs, errors) tuple of float64 arrays. The per-sample loop releases the GIL. |
 | `.reset` | `(self) -> None` — Zero the weights, delay line, and reset P to delta*I. |
 | `.weights` | Current tap weights as a 1D NumPy float64 array (read-only copy). |
 

--- a/scripts/build_api_ref.py
+++ b/scripts/build_api_ref.py
@@ -76,6 +76,24 @@ def sig_and_blurb(name: str, obj) -> tuple[str, str]:
     return sig, blurb
 
 
+def _truncate_at_word(text: str, limit: int) -> str:
+    """Trim `text` to at most `limit` characters on a word boundary, appending
+    an ellipsis when truncation actually happens. The previous generator did a
+    raw ``[:140]`` slice that chopped mid-word (visible in the `.zeros` row as
+    a dangling "map t" — CodeRabbit flagged it on PR #70). Table cells can
+    absorb long descriptions fine, so the new 280-char limit rarely trims at
+    all; the word-boundary-plus-ellipsis only matters for docstrings that
+    genuinely overflow.
+    """
+    if len(text) <= limit:
+        return text
+    cut = text[:limit].rstrip()
+    sp = cut.rfind(" ")
+    if sp > limit // 2:
+        cut = cut[:sp]
+    return cut.rstrip(" ,.;:") + "…"
+
+
 def class_methods(cls) -> list[tuple[str, str, str]]:
     """List (method_name, signature, blurb) for public methods of a class.
 
@@ -510,12 +528,12 @@ def render_class(name: str) -> str:
                     continue
                 if p.startswith(("1.", "2.")) or p.startswith(f"{mname}("):
                     continue
-                rest = " ".join(p.split())[:140]
+                rest = _truncate_at_word(" ".join(p.split()), 280)
                 break
             cell = f"`{sig_args}`" + (f" — {rest}" if rest else "")
         else:
             cell = first if first else "*(property)*"
-            cell = cell[:160]
+            cell = _truncate_at_word(cell, 280)
         lines.append(f"| `.{mname}` | {cell.replace('|', '\\|')} |")
     return "\n".join(lines)
 

--- a/scripts/plot_dashboard.py
+++ b/scripts/plot_dashboard.py
@@ -229,7 +229,7 @@ def plot_pole_zero(filt):
     ax.plot(np.cos(theta), np.sin(theta), color="0.6", linewidth=0.8)
     ax.axhline(0.0, color="0.85", linewidth=0.5)
     ax.axvline(0.0, color="0.85", linewidth=0.5)
-    # Conventional markers: × for poles, ○ for zeros. All-pole families
+    # Conventional markers: 'x' for poles, 'o' for zeros. All-pole families
     # (Butterworth / Chebyshev I / Bessel / Legendre) place every zero at
     # z = -1, so they render as a visible N-fold cluster on the negative
     # real axis rather than disappearing from the plot.

--- a/scripts/plot_dashboard.py
+++ b/scripts/plot_dashboard.py
@@ -223,19 +223,27 @@ def plot_magnitude_phase(filt, sample_rate: float, dtypes: list[str] | None,
 
 def plot_pole_zero(filt):
     poles = np.asarray(filt.poles())
+    zeros = np.asarray(filt.zeros())
     theta = np.linspace(0.0, 2 * np.pi, 256)
     fig, ax = plt.subplots(figsize=(6, 6))
     ax.plot(np.cos(theta), np.sin(theta), color="0.6", linewidth=0.8)
     ax.axhline(0.0, color="0.85", linewidth=0.5)
     ax.axvline(0.0, color="0.85", linewidth=0.5)
+    # Conventional markers: × for poles, ○ for zeros. All-pole families
+    # (Butterworth / Chebyshev I / Bessel / Legendre) place every zero at
+    # z = -1, so they render as a visible N-fold cluster on the negative
+    # real axis rather than disappearing from the plot.
     ax.scatter(poles.real, poles.imag, marker="x", s=90, color="C3",
                linewidths=2, label=f"poles (n={len(poles)})")
+    ax.scatter(zeros.real, zeros.imag, marker="o", s=90,
+               facecolors="none", edgecolors="C0", linewidths=1.5,
+               label=f"zeros (n={len(zeros)})")
     ax.set_aspect("equal")
     ax.set_xlim(-1.2, 1.2)
     ax.set_ylim(-1.2, 1.2)
     ax.set_xlabel("Re(z)")
     ax.set_ylabel("Im(z)")
-    ax.set_title(f"Pole locations — stability margin = "
+    ax.set_title(f"Pole / zero locations — stability margin = "
                  f"{filt.stability_margin():.4f}")
     ax.grid(True, alpha=0.3)
     ax.legend(loc="upper right")

--- a/src/filter_bindings.cpp
+++ b/src/filter_bindings.cpp
@@ -261,6 +261,27 @@ public:
 		return out;
 	}
 
+	// Extract zeros from the numerator of each biquad stage. `BiquadPoleState`
+	// solves the numerator quadratic upstream (see biquad/biquad.hpp); we were
+	// throwing that data away when building `poles()`, so the dashboard's
+	// pole-zero plot was missing half its content. Mirrors `poles()` exactly,
+	// including the second-slot guard — for first-order sections (b2 = 0)
+	// BiquadPoleState leaves `zeros.second` default-constructed, same pattern
+	// as the pole path.
+	std::vector<std::complex<double>> zeros() const {
+		std::vector<std::complex<double>> out;
+		out.reserve(static_cast<std::size_t>(cascade.num_stages()) * 2);
+		for (int i = 0; i < cascade.num_stages(); ++i) {
+			sw::dsp::BiquadPoleState<double> pz(cascade.stage(i));
+			out.push_back(pz.zeros.first);
+			const auto& second = pz.zeros.second;
+			if (second != std::complex<double>{}) {
+				out.push_back(second);
+			}
+		}
+		return out;
+	}
+
 	np_f64 process(np_f64_ro signal, const std::string& dtype) const {
 		std::size_t n = signal.shape(0);
 		double* out_ptr = nullptr;
@@ -558,6 +579,11 @@ void bind_filters(nb::module_& m) {
 		     "List of (b0, b1, b2, a1, a2) tuples, one per stage.")
 		.def("poles", &PyIIRFilter::poles,
 		     "List of complex pole locations in the z-plane.")
+		.def("zeros", &PyIIRFilter::zeros,
+		     "List of complex zero locations in the z-plane. For all-pole "
+		     "families (Butterworth / Chebyshev I / Bessel / Legendre), all "
+		     "finite zeros map to z = -1, so expect an N-fold cluster there. "
+		     "Chebyshev II and Elliptic distribute zeros on the unit circle.")
 		.def("process", &PyIIRFilter::process,
 		     nb::arg("signal"), nb::arg("dtype") = "reference",
 		     "Filter a signal. dtype selects arithmetic for state and samples "

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -47,9 +47,13 @@ class TestButterworthDesign:
         filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
         zeros = filt.zeros()
         assert len(zeros) == 4
-        # All should be at or near z = -1 for Butterworth LP.
+        # All should be at or near z = -1 for Butterworth LP. Tolerance is
+        # looser than bit-exact: Apple Silicon's Clang generates different
+        # FMA sequences than x86_64 GCC/Clang, so the bilinear-transform
+        # output can differ by ~1e-8 between platforms. 1e-6 is comfortably
+        # above that platform noise while still pinning "clustered at -1".
         for z in zeros:
-            assert abs(z - (-1 + 0j)) < 1e-9
+            assert abs(z - (-1 + 0j)) < 1e-6
 
     def test_zeros_chebyshev2_on_unit_circle(self):
         # Chebyshev II has finite stopband zeros distributed on the unit

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -40,6 +40,31 @@ class TestButterworthDesign:
         for p in poles:
             assert abs(p) < 1.0
 
+    def test_zeros_count_matches_order(self):
+        # Butterworth LP is all-pole in the analog prototype; after bilinear
+        # transform every zero maps to z = -1. The binding still reports all
+        # N of them (as an N-fold cluster), matching the number of poles.
+        filt = mpdsp.butterworth_lowpass(order=4, sample_rate=SAMPLE_RATE, cutoff=1000.0)
+        zeros = filt.zeros()
+        assert len(zeros) == 4
+        # All should be at or near z = -1 for Butterworth LP.
+        for z in zeros:
+            assert abs(z - (-1 + 0j)) < 1e-9
+
+    def test_zeros_chebyshev2_on_unit_circle(self):
+        # Chebyshev II has finite stopband zeros distributed on the unit
+        # circle — the canonical case where zeros are visually informative
+        # (unlike Butterworth's pile-at-minus-one). Guards against a future
+        # regression that throws the zeros away again.
+        filt = mpdsp.chebyshev2_lowpass(order=6, sample_rate=SAMPLE_RATE,
+                                         cutoff=1000.0, stopband_db=40.0)
+        zeros = filt.zeros()
+        # At least some zeros should be strictly off z = -1 and on the unit
+        # circle (|z| ≈ 1, not clustered at the real axis).
+        off_axis = [z for z in zeros
+                    if abs(abs(z) - 1.0) < 1e-6 and abs(z.imag) > 1e-3]
+        assert len(off_axis) > 0
+
     def test_invalid_order_raises(self):
         with pytest.raises(ValueError):
             mpdsp.butterworth_lowpass(order=0, sample_rate=SAMPLE_RATE, cutoff=1000.0)


### PR DESCRIPTION
## Summary

Fix a long-standing gap: the dashboard's pole-zero plot never displayed any zeros. Root cause was **not** a plot bug — the Python `IIRFilter` class had no `zeros()` method at all. Upstream's `BiquadPoleState` already computes both poles and zeros (derives from `PoleZeroPair<T>` and solves the numerator quadratic), but `filter_bindings.cpp`'s accessor walked `pz.poles.*` and threw `pz.zeros.*` away.

## Changes

- **`src/filter_bindings.cpp`** — new `PyIIRFilter::zeros()` accessor mirroring `poles()` (same second-slot guard for first-order sections); registered on the class with a docstring that flags the all-pole-family quirk (Butterworth / Chebyshev I / Bessel / Legendre cluster every zero at `z = -1`).
- **`scripts/plot_dashboard.py:plot_pole_zero`** — scatters zeros with the conventional open-circle marker alongside the `×` for poles; title updated.
- **`tests/test_filters.py`** — 2 new cases:
  - `test_zeros_count_matches_order` — Butterworth LP order 4 produces 4 zeros, all at `z = -1`
  - `test_zeros_chebyshev2_on_unit_circle` — Chebyshev II produces zeros strictly on the unit circle with non-negligible imaginary parts. Guards the canonical "zeros are visually informative" case.
- **`docs/api_reference.md`** — regenerated (now lists `.zeros`).

## Verification

Sanity check on the freshly built module:

```
Butterworth LP order=4:
  poles: [0.939+0.124j, 0.939-0.124j, 0.875+0.048j, 0.875-0.048j]
  zeros: [-1+0j, -1+0j, -1+0j, -1+0j]          # pile-at-minus-one as expected

Chebyshev II LP order=6:
  zero 0: 0.989+0.147j  |z|=1.0000             # distributed on unit circle
  zero 1: 0.989-0.147j  |z|=1.0000
  zero 2: 0.980+0.200j  |z|=1.0000
  zero 3: 0.980-0.200j  |z|=1.0000
  zero 4: 0.859+0.513j  |z|=1.0000
  zero 5: 0.859-0.513j  |z|=1.0000
```

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| `_core` | OK | 674/674 | OK | 674/674 |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready\`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IIR filters now expose a zeros() method to report zeros in the z-plane.
  * Pole/zero dashboard now plots zeros alongside poles with updated title and legend.

* **Documentation**
  * API reference updated with zeros() docs and clearer per-sample loop wording about releasing the GIL.

* **Tests**
  * New tests validate zeros count and expected placement for Butterworth and Chebyshev II designs.

* **Chores**
  * API rendering now truncates descriptions at word boundaries for cleaner summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->