### PR TITLE
feat(dashboard): add group-delay pane

### DIFF
--- a/scripts/plot_dashboard.py
+++ b/scripts/plot_dashboard.py
@@ -221,6 +221,33 @@ def plot_magnitude_phase(filt, sample_rate: float, dtypes: list[str] | None,
     return fig
 
 
+def plot_group_delay(filt, sample_rate: float, num_points: int = 512):
+    """Group delay τ(f) = -d(phase)/d(omega), plotted across [0, fs/2].
+
+    Group delay quantifies per-frequency latency: a passband with flat
+    group delay preserves waveform shape (Bessel's signature property),
+    while sharp-rolloff IIR filters (elliptic, high-order Chebyshev) peak
+    hard at the transition band. Folds the IIR cascade into a single
+    TransferFunction via `to_transfer_function`, then calls upstream's
+    central-difference group_delay — the same path DSPFilters' classic
+    GUI used for its group-delay pane.
+    """
+    tf = mpdsp.to_transfer_function(filt)
+    gd = mpdsp.group_delay(tf, num_points)
+    freqs = np.linspace(0.0, 0.5, num_points, endpoint=False)
+
+    fig, ax = plt.subplots(figsize=(9, 4.5))
+    ax.plot(freqs * sample_rate, gd, linewidth=1.4, color="C2")
+    ax.set_xlabel("Frequency (Hz)")
+    ax.set_ylabel("Group delay (samples)")
+    ax.set_title(f"Group delay — mean {gd.mean():.2f} samples, "
+                 f"peak {gd.max():.2f} samples")
+    ax.grid(True, alpha=0.4)
+    ax.axhline(0.0, color="0.85", linewidth=0.5)
+    fig.tight_layout()
+    return fig
+
+
 def plot_pole_zero(filt):
     poles = np.asarray(filt.poles())
     theta = np.linspace(0.0, 2 * np.pi, 256)
@@ -644,10 +671,10 @@ def main():
         signal = mpdsp.white_noise(length=sig_length, amplitude=0.5, seed=1)
 
     # --- Tabs ---
-    (tab_freq, tab_pz, tab_time, tab_prec,
+    (tab_freq, tab_pz, tab_gd, tab_time, tab_prec,
      tab_two_type, tab_summary) = st.tabs(
-        ["Frequency response", "Pole / zero", "Time domain",
-         "Mixed-precision comparison",
+        ["Frequency response", "Pole / zero", "Group delay",
+         "Time domain", "Mixed-precision comparison",
          "Compare A vs B", "Summary"])
 
     # Build the shared descriptor used in export filenames so the same
@@ -697,6 +724,23 @@ def main():
                 csv_bytes = "\n".join(rows).encode()
             st.download_button("Download coefficients CSV", csv_bytes,
                                f"{tag}_coefficients.csv", "text/csv")
+
+    with tab_gd:
+        try:
+            fig = plot_group_delay(filt, sample_rate)
+            st.pyplot(fig)
+            st.download_button("Download PNG", figure_to_png_bytes(fig),
+                               f"{tag}_groupdelay.png", "image/png")
+            plt.close(fig)
+            st.caption(
+                "Group delay is the per-frequency latency τ(f) = "
+                "-d(phase)/d(ω). Bessel prototypes target a flat group "
+                "delay across the passband (waveform-preserving); "
+                "elliptic and high-order Chebyshev filters trade group "
+                "delay for sharper rolloff, producing a peak near the "
+                "transition band.")
+        except Exception as e:  # noqa: BLE001 - surface whatever upstream throws
+            st.warning(f"Group-delay computation failed: {e}", icon="⚠️")
 
     with tab_time:
         fig, time_failures = plot_impulse_step(filt, selected_dtypes)

--- a/scripts/plot_dashboard.py
+++ b/scripts/plot_dashboard.py
@@ -726,12 +726,12 @@ def main():
                                f"{tag}_coefficients.csv", "text/csv")
 
     with tab_gd:
+        fig = None
         try:
             fig = plot_group_delay(filt, sample_rate)
             st.pyplot(fig)
             st.download_button("Download PNG", figure_to_png_bytes(fig),
                                f"{tag}_groupdelay.png", "image/png")
-            plt.close(fig)
             st.caption(
                 "Group delay is the per-frequency latency τ(f) = "
                 "-d(phase)/d(ω). Bessel prototypes target a flat group "
@@ -741,6 +741,14 @@ def main():
                 "transition band.")
         except Exception as e:  # noqa: BLE001 - surface whatever upstream throws
             st.warning(f"Group-delay computation failed: {e}", icon="⚠️")
+        finally:
+            # Close the figure even if st.pyplot / figure_to_png_bytes /
+            # st.download_button throws after it was created — otherwise the
+            # pyplot registry accumulates figures across slider changes.
+            # plot_group_delay may have thrown before returning, in which
+            # case fig stays None and there's nothing to close.
+            if fig is not None:
+                plt.close(fig)
 
     with tab_time:
         fig, time_failures = plot_impulse_step(filt, selected_dtypes)


### PR DESCRIPTION
## Summary

Restore the group-delay visualization that Vinnie Falco's original DSPFilters GUI shipped with. The Streamlit dashboard had magnitude/phase, pole-zero, time-domain, and mixed-precision tabs — but no group-delay view, which is the tab users reach for when comparing filter families.

## Why

Group delay τ(f) = -d(phase)/d(ω) is *the* distinguishing feature between filter families in the passband. Bessel's signature is flat group delay (waveform-preserving); elliptic and high-order Chebyshev trade delay flatness for steep rolloff, producing a sharp peak near the transition. A dashboard that advertises filter-family comparison without a group-delay pane is missing the most informative view.

## Changes (one file, ~40 LOC)

- **`plot_group_delay(filt, sample_rate, num_points=512)`** — folds the IIR cascade into a single `TransferFunction` via `mpdsp.to_transfer_function`, then calls `mpdsp.group_delay` (wraps upstream `sw::dsp::spectral::group_delay` — central-difference `-d(phase)/d(omega)`). No C++ work needed; the binding was already in place at `types_bindings.cpp:445`.
- **New \"Group delay\" tab** inserted between \"Pole / zero\" and \"Time domain\". Standard PNG download + `plt.close`, matching the other panes.
- **Captioned** with a one-sentence reminder of the Bessel-vs-elliptic tradeoff.
- **Error guard** — `to_transfer_function`'s polynomial convolution can overflow on a malformed cascade; surface that via `st.warning` rather than taking down the whole dashboard.

## Smoke check

```
Bessel LP   order=8, cutoff=2 kHz:  passband var 0.000, peak  3.54 samples
Elliptic LP order=8, cutoff=2 kHz:  passband var 34.322, peak 48.07 samples
```

The canonical flat-vs-peaky signature — group-delay chain produces what users expect.

## Test plan
- Existing pytest suite unaffected (672/672 passing — plot_dashboard.py is a script, not covered by unit tests).
- [x] Fast CI passes
- [x] Manual: \`streamlit run scripts/plot_dashboard.py\` → pick Bessel vs. elliptic LP, verify the new tab renders and shows the expected flat-vs-peaky pattern.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Group delay" visualization tab to the dashboard.
  * Group delay plots show frequency-domain analysis with mean and peak summary statistics.
  * PNG export capability for group delay visualizations.

* **Bug Fixes**
  * Improved error handling to show warnings instead of crashing the app.
  * Ensured figures are closed after rendering to prevent resource accumulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->