### PR TITLE
chore(release): bump to 0.5.0.post1

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,7 +1,7 @@
 # `mpdsp` API reference
 
 Complete enumeration of every public name in the `mpdsp` package, grouped
-by subsystem. Generated from `0.5.0` (upstream `sw::dsp
+by subsystem. Generated from `0.5.0.post1` (upstream `sw::dsp
 0.5.0`) via `inspect` and the nanobind-attached
 `__doc__` strings. Keep this in sync by re-running the generator — see
 the note at the bottom.
@@ -79,7 +79,7 @@ ADC streams without re-architecting the downstream filter.
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `mpdsp.__version__` | `str` | The installed wheel version (PEP 440). Current: `"0.5.0"`. |
+| `mpdsp.__version__` | `str` | The installed wheel version (PEP 440). Current: `"0.5.0.post1"`. |
 | `mpdsp.__dsp_version__` | `str` | The upstream `sw::dsp` C++ library version the wheel was built against. Current: `"0.5.0"`. |
 | `mpdsp.__dsp_version_info__` | `tuple` | `(major, minor, patch)` tuple of ints for `__dsp_version__`. |
 | `mpdsp.HAS_CORE` | `bool` | `True` when the nanobind extension imported cleanly. `False` in unbuilt source checkouts, and (pre-0.4.1.post1) indicated a packaging bug before we hardened the import. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ wheel.install-dir = "mpdsp"
 provider = "scikit_build_core.metadata.regex"
 input = "CMakeLists.txt"
 regex = '(?i)project\s*\(\s*mp-dsp-python[^)]*VERSION\s+(?P<value>[0-9]+\.[0-9]+\.[0-9]+)'
-result = "{value}"
+result = "{value}.post1"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Post-release suffix for PR #70's `zeros()` accessor. Per `docs/publishing.md`, Python-only binding additions (no upstream C++ change) ship as `.postN` rather than bumping `X.Y.Z` — that preserves the lockstep invariant between the wheel version and the `sw::dsp` C++ library it links against.

## Changes

- **`pyproject.toml`** — scikit-build-core version template flips `"{value}"` → `"{value}.post1"`. Wheel now reports `mpdsp 0.5.0.post1`; `sw::dsp` still links 0.5.0.
- **`docs/api_reference.md`** — regenerated; header reads `0.5.0.post1 (upstream sw::dsp 0.5.0)`.
- `CMakeLists.txt` untouched (`project(VERSION 0.5.0)` and `MPDSP_DSP_PIN v0.5.0` both stay).

## What this ships

The `IIRFilter.zeros()` accessor landed in #70 and the matching open-circle markers in the dashboard's pole-zero pane.

## Lockstep invariant verified

```
import mpdsp
print(mpdsp.__version__)       # → "0.5.0.post1"
print(mpdsp.__dsp_version__)   # → "0.5.0"
```

Prefix matches — what the convention is for.

## Test Results

| Target | gcc build | gcc test |
|--------|-----------|----------|
| `_core` | OK | 674/674 |

## Post-merge

1. `git tag v0.5.0.post1` on main
2. `git push origin v0.5.0.post1`
3. After `release.yml` publishes the GitHub Release, manually dispatch:
   ```
   gh workflow run publish.yml -f target=pypi --ref main
   ```
   (Per §6 of `docs/publishing.md` — the auto-chain from `release` to `publish` stays broken without a PAT.)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.5.0.post1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->