### PR TITLE
chore(release): bump to 0.5.0.post2

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,7 +1,7 @@
 # `mpdsp` API reference
 
 Complete enumeration of every public name in the `mpdsp` package, grouped
-by subsystem. Generated from `0.5.0.post1` (upstream `sw::dsp
+by subsystem. Generated from `0.5.0.post2` (upstream `sw::dsp
 0.5.0`) via `inspect` and the nanobind-attached
 `__doc__` strings. Keep this in sync by re-running the generator — see
 the note at the bottom.
@@ -79,7 +79,7 @@ ADC streams without re-architecting the downstream filter.
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `mpdsp.__version__` | `str` | The installed wheel version (PEP 440). Current: `"0.5.0.post1"`. |
+| `mpdsp.__version__` | `str` | The installed wheel version (PEP 440). Current: `"0.5.0.post2"`. |
 | `mpdsp.__dsp_version__` | `str` | The upstream `sw::dsp` C++ library version the wheel was built against. Current: `"0.5.0"`. |
 | `mpdsp.__dsp_version_info__` | `tuple` | `(major, minor, patch)` tuple of ints for `__dsp_version__`. |
 | `mpdsp.HAS_CORE` | `bool` | `True` when the nanobind extension imported cleanly. `False` in unbuilt source checkouts, and (pre-0.4.1.post1) indicated a packaging bug before we hardened the import. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ wheel.install-dir = "mpdsp"
 provider = "scikit_build_core.metadata.regex"
 input = "CMakeLists.txt"
 regex = '(?i)project\s*\(\s*mp-dsp-python[^)]*VERSION\s+(?P<value>[0-9]+\.[0-9]+\.[0-9]+)'
-result = "{value}.post1"
+result = "{value}.post2"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Post-release for PR #71's group-delay dashboard pane. Pure-Python change — `scripts/plot_dashboard.py` only, no C++ touched — so per `docs/publishing.md`'s `.postN` convention, increment the suffix rather than bumping the patch triple. Lockstep prefix (`0.5.0`) stays aligned with the linked `sw::dsp` C++ library.

## Changes

- **`pyproject.toml`** — scikit-build-core `result` template `"{value}.post1"` → `"{value}.post2"`. Wheel now reports `mpdsp 0.5.0.post2`.
- **`docs/api_reference.md`** — regenerated; header reads `0.5.0.post2 (upstream sw::dsp 0.5.0)`.
- `CMakeLists.txt` untouched (`project(VERSION 0.5.0)` and `MPDSP_DSP_PIN v0.5.0`).

## What ships cumulatively since 0.5.0

- `0.5.0.post1` — `IIRFilter.zeros()` accessor + dashboard now renders zeros
- `0.5.0.post2` — dashboard group-delay pane (this PR)

Together: the Streamlit dashboard matches Vinnie Falco's classic DSPFilters GUI for pole/zero + group-delay views, plus the mixed-precision tabs.

## Lockstep invariant

```
>>> import mpdsp
>>> mpdsp.__version__      # "0.5.0.post2"
>>> mpdsp.__dsp_version__  # "0.5.0"
```

## Test Results

| Target | gcc build | gcc test |
|--------|-----------|----------|
| `_core` | OK | 674/674 |

## Post-merge choreography

Same as v0.5.0.post1 — `release.yml`'s tag glob still doesn't match `.postN` (tracked in #73), so:

1. `git tag v0.5.0.post2 && git push origin v0.5.0.post2`
2. Create the GitHub Release page manually: `gh release create v0.5.0.post2 ...`
3. Dispatch publish: `gh workflow run publish.yml -f target=pypi --ref main`

Once #73 lands, steps 2–3 simplify back to a single dispatch after the auto-created Release page.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.5.0.post2
  * Updated documentation and build metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->