### PR TITLE
chore(release): bump to 0.5.0.post3

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,7 +1,7 @@
 # `mpdsp` API reference
 
 Complete enumeration of every public name in the `mpdsp` package, grouped
-by subsystem. Generated from `0.5.0.post2` (upstream `sw::dsp
+by subsystem. Generated from `0.5.0.post3` (upstream `sw::dsp
 0.5.0`) via `inspect` and the nanobind-attached
 `__doc__` strings. Keep this in sync by re-running the generator — see
 the note at the bottom.
@@ -79,7 +79,7 @@ ADC streams without re-architecting the downstream filter.
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `mpdsp.__version__` | `str` | The installed wheel version (PEP 440). Current: `"0.5.0.post2"`. |
+| `mpdsp.__version__` | `str` | The installed wheel version (PEP 440). Current: `"0.5.0.post3"`. |
 | `mpdsp.__dsp_version__` | `str` | The upstream `sw::dsp` C++ library version the wheel was built against. Current: `"0.5.0"`. |
 | `mpdsp.__dsp_version_info__` | `tuple` | `(major, minor, patch)` tuple of ints for `__dsp_version__`. |
 | `mpdsp.HAS_CORE` | `bool` | `True` when the nanobind extension imported cleanly. `False` in unbuilt source checkouts, and (pre-0.4.1.post1) indicated a packaging bug before we hardened the import. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ wheel.install-dir = "mpdsp"
 provider = "scikit_build_core.metadata.regex"
 input = "CMakeLists.txt"
 regex = '(?i)project\s*\(\s*mp-dsp-python[^)]*VERSION\s+(?P<value>[0-9]+\.[0-9]+\.[0-9]+)'
-result = "{value}.post2"
+result = "{value}.post3"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Post-release for PR #76's log-x and normalized-frequency toggles on the dashboard's frequency-response pane (resolves #75). Pure-Python change — `scripts/plot_dashboard.py` only. Following the `.postN` convention in `docs/publishing.md` keeps lockstep with upstream `sw::dsp 0.5.0`.

## Changes

- **`pyproject.toml`** — scikit-build-core `result` template `"{value}.post2"` → `"{value}.post3"`.
- **`docs/api_reference.md`** — regenerated; header reads `0.5.0.post3 (upstream sw::dsp 0.5.0)`.
- `CMakeLists.txt` untouched.

## Cumulative `.postN` deltas since 0.5.0

| Version | Adds |
|---------|------|
| `.post1` | `IIRFilter.zeros()` accessor; pole-zero pane renders zeros |
| `.post2` | Dashboard group-delay pane |
| `.post3` | Dashboard freq-response axis toggles (log-x + normalized f/f_c) |

With `.post3` the dashboard reaches feature parity with Vinnie Falco's classic DSPFilters GUI across pole-zero, group-delay, and Bode-style frequency response — plus the mixed-precision tabs that are this library's distinctive angle.

## Lockstep invariant

```
>>> import mpdsp
>>> mpdsp.__version__       # "0.5.0.post3"
>>> mpdsp.__dsp_version__   # "0.5.0"
```

## Test Results

| Target | gcc build | gcc test |
|--------|-----------|----------|
| `_core` | OK | 674/674 |

## Post-merge choreography

Same as post1 / post2 — `release.yml`'s tag glob still doesn't match `.postN` (tracked in #73), so:

1. `git tag v0.5.0.post3 && git push origin v0.5.0.post3`
2. Create the GitHub Release page manually: `gh release create v0.5.0.post3 ...`
3. Dispatch publish: `gh workflow run publish.yml -f target=pypi --ref main`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference documentation.

* **Chores**
  * Updated package version to 0.5.0.post3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->