### PR TITLE
docs(publishing): document two-path release flow (semver vs postN)

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -128,6 +128,14 @@ retry. TestPyPI allows unlimited retries with post-release suffixes.
 
 ### 6. Cut the real release
 
+There are **two paths** here — a plain semver tag (`vX.Y.Z`) and a
+post-release tag (`vX.Y.Z.postN`) — and they need different follow-up
+steps because `release.yml` only fires for one of them. See the table
+in "Ongoing release cadence" below for the quick version; the reasoning
+follows here.
+
+#### Path A — plain semver (`vX.Y.Z`)
+
 ```bash
 git tag vX.Y.Z
 git push origin vX.Y.Z
@@ -137,10 +145,9 @@ The tag triggers `release.yml`:
 
 1. Tests run on Linux / Windows / macOS.
 2. GitHub Release is created with auto-generated notes via
-   `softprops/action-gh-release`.
+   `softprops/action-gh-release` running under `GITHUB_TOKEN`.
 
-The release **does not auto-trigger `publish.yml`.** `release.yml`
-creates the GitHub Release under the default `GITHUB_TOKEN`, and GitHub
+That release **does not auto-trigger `publish.yml`.** GitHub
 deliberately suppresses workflow chaining when events originate from
 `GITHUB_TOKEN` — a loop-prevention safeguard. So the `release:
 published` event fires, but the listener in `publish.yml` skips it.
@@ -164,6 +171,44 @@ personal access token in `release.yml`'s `create-release` step — events
 from a PAT do chain). We chose the manual dispatch instead to avoid
 managing another secret.
 
+#### Path B — post-release (`vX.Y.Z.postN`)
+
+The flow is **inverted** compared to semver:
+
+```bash
+git tag vX.Y.Z.postN
+git push origin vX.Y.Z.postN
+```
+
+`release.yml` does **not** fire on this tag — its glob only matches
+`vX.Y.Z` and `vX.Y.Z-*` (see issue #73). So no automatic Release page
+and no automatic tests. Create the Release page manually:
+
+```bash
+gh release create vX.Y.Z.postN --title "vX.Y.Z.postN" --notes "..."
+```
+
+That command is authenticated as **you** (a user), not `GITHUB_TOKEN`,
+so the `release: published` event it emits **does** chain into
+`publish.yml` automatically. No manual dispatch required — in fact, a
+manual dispatch on top of this would start a second parallel publish
+run that races the release-event run, and whichever finishes uploading
+first wins while the other hits PyPI's file-name-reuse policy and fails
+(cosmetically — the files still land).
+
+So for the post-release path, just:
+
+```bash
+git tag vX.Y.Z.postN && git push origin vX.Y.Z.postN
+gh release create vX.Y.Z.postN --title "..." --notes "..."
+# publish.yml is already running — watch it:
+gh run watch
+```
+
+When #73 is resolved, the semver and post paths will converge back into
+a single "tag → release.yml creates Release under PAT → publish.yml
+chains automatically" flow.
+
 ## Considerations worth flagging
 
 | Concern | Reality |
@@ -177,33 +222,58 @@ managing another secret.
 
 ## Ongoing release cadence
 
-Once the machinery is proven, the flow for future releases is:
+The two paths at a glance:
+
+| Tag shape | `release.yml` fires? | GitHub Release page | `publish.yml` to PyPI |
+|-----------|---------------------|---------------------|-----------------------|
+| `vX.Y.Z` | Yes (glob matches) | Auto-created (under `GITHUB_TOKEN` → doesn't chain) | **Manual dispatch** |
+| `vX.Y.Z.postN` | No (glob doesn't match — #73) | **Manual `gh release create`** (user-auth → **does** chain) | Automatic, don't dispatch |
+
+### Path A — plain semver (`vX.Y.Z`)
+
+Wraps an upstream `mixed-precision-dsp X.Y.Z` tag in lockstep.
 
 1. Update `project(mp-dsp-python VERSION X.Y.Z ...)` in `CMakeLists.txt`
    to match the `mixed-precision-dsp` version being wrapped.
 2. Bump the peer `GIT_TAG` pins accordingly (`dsp` → `vX.Y.Z`, plus
    `universal` / `mtl5` if their versions changed).
-3. Merge to `main`.
-4. Tag and push:
+3. Reset `pyproject.toml`'s `[tool.scikit-build.metadata.version]
+   result` template back to `"{value}"` if it's currently on a
+   `.postN` suffix.
+4. Merge to `main`.
+5. Tag and push:
    ```bash
    git tag vX.Y.Z && git push origin vX.Y.Z
    ```
-5. After `release.yml` publishes the GitHub Release, manually dispatch
-   `publish.yml` — the auto-chain is disabled (see §6 above for why):
+6. After `release.yml` publishes the GitHub Release, manually dispatch
+   `publish.yml` — the auto-chain is disabled (see §6 Path A for why):
    ```bash
    gh workflow run publish.yml -f target=pypi --ref main
    gh run watch
    ```
 
-For a Python-only bindings fix (e.g. a wrapper-layer bug that doesn't
-correspond to any C++ change):
+### Path B — Python-only bindings fix (`vX.Y.Z.postN`)
+
+When the C++ library is unchanged (e.g. a wrapper-layer bug, a dashboard
+addition, a pure-Python accessor over data upstream already exposes).
 
 1. Bump `pyproject.toml`'s `[tool.scikit-build.metadata.version]
-   result` template from `"{value}"` to `"{value}.postN"` (PEP 440
-   post-release). `CMakeLists.txt` stays on `X.Y.Z` — CMake's
-   `project(VERSION)` doesn't accept `.postN`.
-2. Tag and push `vX.Y.Z.postN`, then manually dispatch `publish.yml`
-   as in the release flow above.
+   result` template to `"{value}.postN"` (PEP 440 post-release).
+   `CMakeLists.txt` stays on `X.Y.Z` — CMake's `project(VERSION)`
+   doesn't accept `.postN`.
+2. Regenerate `docs/api_reference.md` (picks up the new version string)
+   and merge to `main`.
+3. Tag, push, manually create the Release page — that's the whole
+   sequence:
+   ```bash
+   git tag vX.Y.Z.postN && git push origin vX.Y.Z.postN
+   gh release create vX.Y.Z.postN --title "..." --notes "..."
+   # publish.yml is already running from the release-event chain:
+   gh run watch
+   ```
+4. Do **not** also `gh workflow run publish.yml` — that starts a
+   second parallel run that races the release-event run and whichever
+   finishes second fails on file-name-reuse (harmless, but noisy).
 
 The `X.Y.Z` prefix still identifies the C++ version being wrapped. The
 `.postN` suffix tells users "same C++ underneath, Python bindings
@@ -215,7 +285,8 @@ repackaged".
 # Dry-run to TestPyPI (useful when validating a release candidate)
 gh workflow run publish.yml -f target=testpypi --ref main
 
-# Real release to PyPI (after tagging and release.yml completes)
+# Real release to PyPI — only needed on the semver path. On the postN
+# path, `gh release create` already chained publish.yml automatically.
 gh workflow run publish.yml -f target=pypi --ref main
 
 # Watch the most recent dispatch finish

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -110,7 +110,11 @@ Before cutting the real release:
    `testpypi`:
    ```bash
    gh workflow run publish.yml -f target=testpypi --ref main
-   gh run watch           # block until the matrix finishes (~20–40 min)
+   # Capture the run ID from the dispatch rather than relying on "most
+   # recent" — another run could race in between these commands.
+   RUN_ID=$(gh run list --workflow=publish.yml --limit 1 \
+       --json databaseId --jq '.[0].databaseId')
+   gh run watch "$RUN_ID"  # block until the matrix finishes (~20–40 min)
    ```
 4. In a clean virtualenv:
    ```bash
@@ -156,7 +160,9 @@ Dispatch `publish.yml` manually after the release is cut:
 
 ```bash
 gh workflow run publish.yml -f target=pypi --ref main
-gh run watch
+RUN_ID=$(gh run list --workflow=publish.yml --limit 1 \
+    --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID"
 ```
 
 That runs the sdist + cibuildwheel matrix and uploads to real PyPI via
@@ -182,7 +188,30 @@ git push origin vX.Y.Z.postN
 
 `release.yml` does **not** fire on this tag — its glob only matches
 `vX.Y.Z` and `vX.Y.Z-*` (see issue #73). So no automatic Release page
-and no automatic tests. Create the Release page manually:
+**and no automatic gated test matrix.** That's the same test-gate gap
+the semver path has, relocated — there, `release.yml`'s matrix runs
+*after* the tag and before the Release page appears; here, the tag
+shortcuts straight to the Release page without any matrix in between.
+
+Before creating the Release, manually confirm `ci.yml` on `main` is
+green. `ci.yml` runs the same Linux/Windows/macOS build+test matrix
+`release.yml` would have; it already ran when the release-bump PR
+(the one that flipped `result = "{value}.postN"`) was merged, so in
+practice this is a one-line verification rather than a new workflow
+invocation:
+
+```bash
+gh run list --branch main --workflow=ci.yml --limit 1 \
+    --json status,conclusion,headSha \
+    --jq '.[0] | "\(.status) \(.conclusion)  \(.headSha[:7])"'
+# Expect: "COMPLETED SUCCESS <sha of the merged release bump>"
+```
+
+If that doesn't show `SUCCESS`, re-run CI on `main` via the Actions UI
+or stop and diagnose before tagging. The tag-and-publish sequence
+itself has no test gate.
+
+With CI green, create the Release page:
 
 ```bash
 gh release create vX.Y.Z.postN --title "vX.Y.Z.postN" --notes "..."
@@ -196,18 +225,38 @@ run that races the release-event run, and whichever finishes uploading
 first wins while the other hits PyPI's file-name-reuse policy and fails
 (cosmetically — the files still land).
 
-So for the post-release path, just:
+Capture the run ID and attach to it explicitly rather than relying on
+bare `gh run watch`, which can attach to any "most recent" run
+(including unrelated ones if someone pushes to another workflow
+between your commands):
 
 ```bash
+RUN_ID=$(gh run list --workflow=publish.yml --limit 1 \
+    --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID"
+```
+
+So for the post-release path, the full sequence is:
+
+```bash
+# 1. Verify CI on main is green (no release.yml gate on postN, see #73):
+gh run list --branch main --workflow=ci.yml --limit 1 \
+    --json status,conclusion --jq '.[0] | "\(.status) \(.conclusion)"'
+
+# 2. Tag, push, create the Release page (user-auth → chains into publish.yml):
 git tag vX.Y.Z.postN && git push origin vX.Y.Z.postN
 gh release create vX.Y.Z.postN --title "..." --notes "..."
-# publish.yml is already running — watch it:
-gh run watch
+
+# 3. Watch the publish run that the release event just kicked off:
+RUN_ID=$(gh run list --workflow=publish.yml --limit 1 \
+    --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID"
 ```
 
 When #73 is resolved, the semver and post paths will converge back into
-a single "tag → release.yml creates Release under PAT → publish.yml
-chains automatically" flow.
+a single "tag → release.yml (gated test matrix) creates Release under
+PAT → publish.yml chains automatically" flow, and the manual CI-green
+pre-check collapses into the workflow.
 
 ## Considerations worth flagging
 
@@ -249,7 +298,9 @@ Wraps an upstream `mixed-precision-dsp X.Y.Z` tag in lockstep.
    `publish.yml` — the auto-chain is disabled (see §6 Path A for why):
    ```bash
    gh workflow run publish.yml -f target=pypi --ref main
-   gh run watch
+   RUN_ID=$(gh run list --workflow=publish.yml --limit 1 \
+       --json databaseId --jq '.[0].databaseId')
+   gh run watch "$RUN_ID"
    ```
 
 ### Path B — Python-only bindings fix (`vX.Y.Z.postN`)
@@ -263,15 +314,22 @@ addition, a pure-Python accessor over data upstream already exposes).
    doesn't accept `.postN`.
 2. Regenerate `docs/api_reference.md` (picks up the new version string)
    and merge to `main`.
-3. Tag, push, manually create the Release page — that's the whole
-   sequence:
+3. Verify `ci.yml` on `main` is green (no release.yml test gate on the
+   postN path — see §6 Path B):
+   ```bash
+   gh run list --branch main --workflow=ci.yml --limit 1 \
+       --json status,conclusion --jq '.[0] | "\(.status) \(.conclusion)"'
+   ```
+4. Tag, push, manually create the Release page:
    ```bash
    git tag vX.Y.Z.postN && git push origin vX.Y.Z.postN
    gh release create vX.Y.Z.postN --title "..." --notes "..."
    # publish.yml is already running from the release-event chain:
-   gh run watch
+   RUN_ID=$(gh run list --workflow=publish.yml --limit 1 \
+       --json databaseId --jq '.[0].databaseId')
+   gh run watch "$RUN_ID"
    ```
-4. Do **not** also `gh workflow run publish.yml` — that starts a
+5. Do **not** also `gh workflow run publish.yml` — that starts a
    second parallel run that races the release-event run and whichever
    finishes second fails on file-name-reuse (harmless, but noisy).
 
@@ -289,8 +347,12 @@ gh workflow run publish.yml -f target=testpypi --ref main
 # path, `gh release create` already chained publish.yml automatically.
 gh workflow run publish.yml -f target=pypi --ref main
 
-# Watch the most recent dispatch finish
-gh run watch
+# Watch a specific publish run finish — capture the ID first rather
+# than relying on "most recent", which can race with unrelated runs
+# (e.g. a CI run triggered by a concurrent push to another branch).
+RUN_ID=$(gh run list --workflow=publish.yml --limit 1 \
+    --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID"
 
 # List recent publish runs
 gh run list --workflow=publish.yml --limit 5


### PR DESCRIPTION
## Summary

Cutting three post-releases in a row (v0.5.0.post1 / .post2 / .post3) surfaced that the current doc's "always dispatch `publish.yml` after tagging" prescription is right for the semver path but **wrong for the postN path** — on postN it causes a parallel-upload race with the release-event chain that `gh release create` already fires.

Splitting the flow into two documented paths to match reality.

## Why the two paths diverge

| | Semver (`vX.Y.Z`) | Post (`vX.Y.Z.postN`) |
|---|---|---|
| `release.yml` fires? | Yes | No (glob miss, #73) |
| Release page | Auto-created under `GITHUB_TOKEN` | Manual `gh release create` |
| `release: published` event chains to `publish.yml`? | **No** (loop-prevention vs GITHUB_TOKEN) | **Yes** (user auth) |
| `publish.yml` dispatch needed? | **Yes**, manual | **No** — it's already running |

On the postN path, the manual dispatch I previously documented was creating a second parallel run. Whichever race-won the upload succeeded; the other hit PyPI's file-name-reuse policy and failed. Cosmetic (all 13 files always landed), but noisy, and the next maintainer shouldn't have to re-derive that.

## Changes (one file)

- `docs/publishing.md` §6: split into "Path A — plain semver" and "Path B — post-release" subsections. Path B explicitly warns against the duplicate dispatch.
- `docs/publishing.md` "Ongoing release cadence": opens with a two-row summary table, then the expanded flow under each path's own header.
- `docs/publishing.md` "gh CLI reference": comment on `gh workflow run publish.yml -f target=pypi` now notes the postN path doesn't need it.

## When does this go away?

When #73 is resolved (release.yml glob extended to match `.postN`), the two paths converge back into a single "tag → release.yml with a PAT creates Release → publish.yml chains automatically" flow. The split documented here is a workaround for the current state, not a permanent split.

## Test plan

Docs-only change; no tests. The next postN cut will exercise the documented Path B end to end — if the warning is correct, there will be exactly one publish.yml run instead of two, and no cosmetic failure.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release instructions to formalize two tag paths: semver (vX.Y.Z) and post-release (vX.Y.Z.postN).
  * Clarified semver path requires a manual publish dispatch; post-release can chain automatically from a published release.
  * Added steps to avoid duplicate/racing publishes, guidance to reset version template before semver tagging, and an expanded cadence comparison and PyPI guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->