### PR TITLE
feat(types): expose the full posit<N, es> grid for N ∈ {8,16,32}, es ∈ {0,1,2}

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,17 +131,30 @@ aren't part of a mixed-precision datapath).
 | `reference` | double | double | double | Ground truth |
 | `gpu_baseline` | double | float | float | GPU / embedded CPU |
 | `ml_hw` | double | float | cfloat<16,5> (IEEE half) | ML accelerator |
-| `posit_full` | double | posit<32,2> | posit<16,1> | Posit arithmetic research |
-| `tiny_posit` | double | posit<8,2> | posit<8,2> | Ultra-low-power edge |
+| `posit_full` | double | posit<32,2> | posit<16,1> | Mixed-precision posit pipeline |
 | `cf24` | double | cfloat<24,5> | cfloat<24,5> | Custom 24-bit float research |
 | `half` | double | cfloat<16,5> | cfloat<16,5> | IEEE half throughout |
 | `sensor_8bit` | double | double | integer<8> | Standard 8-bit sensor ADC |
 | `sensor_6bit` | double | double | integer<6> | Noise-limited sensor |
 | `fpga_fixed` | double | fixpnt<32,24> | fixpnt<16,12> | FPGA fixed-point datapath |
 
-Query the live set at runtime with `mpdsp.available_dtypes()`. Sample-scalar
-bit width per config is available via `mpdsp.bits_of(dtype)` — useful for
-labeling the x-axis of precision-vs-cost plots.
+**Posit taxonomy grid** — `posit<N, es>` single-type configs for N ∈ {8, 16, 32},
+es ∈ {0, 1, 2}. All three scalars (coefficient, state, sample) use the same
+posit type, so these cells cleanly compare ES-vs-precision tradeoff at fixed
+bit width:
+
+| Config | Posit type | Notes |
+|--------|-----------|-------|
+| `posit_8_0` / `posit_8_1` / `posit_8_2` | `posit<8, 0/1/2>` | `posit_8_2` is canonical for 8-bit; `tiny_posit` is a legacy alias |
+| `posit_16_0` / `posit_16_1` / `posit_16_2` | `posit<16, 0/1/2>` | `posit_16_1` is the standard 16-bit posit (also used as posit_full's sample) |
+| `posit_32_0` / `posit_32_1` / `posit_32_2` | `posit<32, 0/1/2>` | `posit_32_2` is the standard 32-bit posit (also used as posit_full's state) |
+
+Query the live set at runtime with `mpdsp.available_dtypes()` (18 entries).
+Sample-scalar bit width per config is available via `mpdsp.bits_of(dtype)` —
+useful for labeling the x-axis of precision-vs-cost plots. For posit grid
+cells the ES dimension doesn't affect bit width, so every `posit_N_*` reports
+N; plotting a full sweep gives 3 points stacked vertically at each width
+showing ES's effect on SQNR.
 
 Coefficients are always designed in `double` — design-time precision is
 non-negotiable for IIR filters (see the

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -61,19 +61,36 @@ these string keys. Query the live set at runtime with
 | `reference` | double | double | double | Ground truth |
 | `gpu_baseline` | double | float | float | GPU / embedded CPU |
 | `ml_hw` | double | float | cfloat<16,5> (half) | ML accelerator |
-| `posit_full` | double | posit<32,2> | posit<16,1> | Posit research |
-| `tiny_posit` | double | posit<8,2> | posit<8,2> | Ultra-low-power edge |
+| `posit_full` | double | posit<32,2> | posit<16,1> | Mixed-precision posit pipeline |
 | `cf24` | double | cfloat<24,5> | cfloat<24,5> | Custom 24-bit float |
 | `half` | double | cfloat<16,5> | cfloat<16,5> | IEEE half throughout |
 | `sensor_8bit` | double | double | integer<8> | Standard 8-bit sensor ADC |
 | `sensor_6bit` | double | double | integer<6> | Noise-limited sensor |
 | `fpga_fixed` | double | fixpnt<32,24> | fixpnt<16,12> | FPGA fixed-point datapath |
 
+**Posit taxonomy grid** — single-type `posit<N, es>` configs for every
+combination of N ∈ {8, 16, 32} and es ∈ {0, 1, 2}. Coefficient = state =
+sample, so ES-vs-precision tradeoff is readable directly from a fixed-N
+sweep:
+
+| Key | Posit type |
+|-----|-----------|
+| `posit_8_0`, `posit_8_1`, `posit_8_2` | `posit<8, 0/1/2>` |
+| `posit_16_0`, `posit_16_1`, `posit_16_2` | `posit<16, 0/1/2>` |
+| `posit_32_0`, `posit_32_1`, `posit_32_2` | `posit<32, 0/1/2>` |
+
+`posit_8_2` is the canonical 8-bit posit (accepts the legacy `tiny_posit`
+alias via `parse_config`); `posit_16_1` and `posit_32_2` are the
+single-type standalones for the types `posit_full` mixes together.
+
 Use `mpdsp.bits_of(dtype)` to query the sample-scalar bit width for any
 config (useful for precision-vs-cost plots). The sensor configs keep
 coefficient and state at double; only the ADC sample path quantizes
 through `integer<N>`, which is the common case for ingesting real-world
-ADC streams without re-architecting the downstream filter.
+ADC streams without re-architecting the downstream filter. For posit
+grid cells the ES dimension doesn't affect bit width — every `posit_N_*`
+reports N, so a sweep produces 3 stacked points per width on the
+precision-cost frontier.
 
 ## Module attributes
 

--- a/scripts/build_api_ref.py
+++ b/scripts/build_api_ref.py
@@ -606,19 +606,36 @@ these string keys. Query the live set at runtime with
 | `reference` | double | double | double | Ground truth |
 | `gpu_baseline` | double | float | float | GPU / embedded CPU |
 | `ml_hw` | double | float | cfloat<16,5> (half) | ML accelerator |
-| `posit_full` | double | posit<32,2> | posit<16,1> | Posit research |
-| `tiny_posit` | double | posit<8,2> | posit<8,2> | Ultra-low-power edge |
+| `posit_full` | double | posit<32,2> | posit<16,1> | Mixed-precision posit pipeline |
 | `cf24` | double | cfloat<24,5> | cfloat<24,5> | Custom 24-bit float |
 | `half` | double | cfloat<16,5> | cfloat<16,5> | IEEE half throughout |
 | `sensor_8bit` | double | double | integer<8> | Standard 8-bit sensor ADC |
 | `sensor_6bit` | double | double | integer<6> | Noise-limited sensor |
 | `fpga_fixed` | double | fixpnt<32,24> | fixpnt<16,12> | FPGA fixed-point datapath |
 
+**Posit taxonomy grid** — single-type `posit<N, es>` configs for every
+combination of N ∈ {8, 16, 32} and es ∈ {0, 1, 2}. Coefficient = state =
+sample, so ES-vs-precision tradeoff is readable directly from a fixed-N
+sweep:
+
+| Key | Posit type |
+|-----|-----------|
+| `posit_8_0`, `posit_8_1`, `posit_8_2` | `posit<8, 0/1/2>` |
+| `posit_16_0`, `posit_16_1`, `posit_16_2` | `posit<16, 0/1/2>` |
+| `posit_32_0`, `posit_32_1`, `posit_32_2` | `posit<32, 0/1/2>` |
+
+`posit_8_2` is the canonical 8-bit posit (accepts the legacy `tiny_posit`
+alias via `parse_config`); `posit_16_1` and `posit_32_2` are the
+single-type standalones for the types `posit_full` mixes together.
+
 Use `mpdsp.bits_of(dtype)` to query the sample-scalar bit width for any
 config (useful for precision-vs-cost plots). The sensor configs keep
 coefficient and state at double; only the ADC sample path quantizes
 through `integer<N>`, which is the common case for ingesting real-world
-ADC streams without re-architecting the downstream filter.
+ADC streams without re-architecting the downstream filter. For posit
+grid cells the ES dimension doesn't affect bit width — every `posit_N_*`
+reports N, so a sweep produces 3 stacked points per width on the
+precision-cost frontier.
 
 ## Module attributes
 

--- a/src/_binding_helpers.hpp
+++ b/src/_binding_helpers.hpp
@@ -276,7 +276,15 @@ inline auto dispatch_dtype_fn(mpdsp::ArithConfig config, const char* cls,
 	using mpdsp::fx3224_t;
 	using mpdsp::half_;
 	using mpdsp::p32;
-	using tiny_posit_t = sw::universal::posit<8, 2>;
+	using mpdsp::p8_0;
+	using mpdsp::p8_1;
+	using mpdsp::p8_2;
+	using mpdsp::p16_0;
+	using mpdsp::p16_1;
+	using mpdsp::p16_2;
+	using mpdsp::p32_0;
+	using mpdsp::p32_1;
+	using mpdsp::p32_2;
 	switch (config) {
 	case ArithConfig::reference:    return f.template operator()<double>();
 	case ArithConfig::gpu_baseline: return f.template operator()<float>();
@@ -284,7 +292,6 @@ inline auto dispatch_dtype_fn(mpdsp::ArithConfig config, const char* cls,
 	case ArithConfig::cf24_config:  return f.template operator()<cf24>();
 	case ArithConfig::half_config:  return f.template operator()<half_>();
 	case ArithConfig::posit_full:   return f.template operator()<p32>();
-	case ArithConfig::tiny_posit:   return f.template operator()<tiny_posit_t>();
 	// Sensor configs dispatch to the STATE scalar (double). The quantization
 	// effect that distinguishes sensor_* from `reference` surfaces through
 	// the sample-path dispatchers (project_dispatch / adc_dispatch), not
@@ -292,6 +299,18 @@ inline auto dispatch_dtype_fn(mpdsp::ArithConfig config, const char* cls,
 	case ArithConfig::sensor_8bit:  return f.template operator()<double>();
 	case ArithConfig::sensor_6bit:  return f.template operator()<double>();
 	case ArithConfig::fpga_fixed:   return f.template operator()<fx3224_t>();
+	// Posit taxonomy grid (#81) — every cell uses the posit<N,es> scalar
+	// throughout (coefficient = state = sample). posit_8_2 also serves the
+	// tiny_posit alias (same enum value).
+	case ArithConfig::posit_8_0:    return f.template operator()<p8_0>();
+	case ArithConfig::posit_8_1:    return f.template operator()<p8_1>();
+	case ArithConfig::posit_8_2:    return f.template operator()<p8_2>();
+	case ArithConfig::posit_16_0:   return f.template operator()<p16_0>();
+	case ArithConfig::posit_16_1:   return f.template operator()<p16_1>();
+	case ArithConfig::posit_16_2:   return f.template operator()<p16_2>();
+	case ArithConfig::posit_32_0:   return f.template operator()<p32_0>();
+	case ArithConfig::posit_32_1:   return f.template operator()<p32_1>();
+	case ArithConfig::posit_32_2:   return f.template operator()<p32_2>();
 	}
 	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
 }
@@ -304,7 +323,15 @@ make_impl_for_dtype(mpdsp::ArithConfig config, const char* cls, Args&&... args) 
 	using mpdsp::fx3224_t;
 	using mpdsp::half_;
 	using mpdsp::p32;
-	using tiny_posit_t = sw::universal::posit<8, 2>;
+	using mpdsp::p8_0;
+	using mpdsp::p8_1;
+	using mpdsp::p8_2;
+	using mpdsp::p16_0;
+	using mpdsp::p16_1;
+	using mpdsp::p16_2;
+	using mpdsp::p32_0;
+	using mpdsp::p32_1;
+	using mpdsp::p32_2;
 	switch (config) {
 	case ArithConfig::reference:
 		return std::make_unique<Impl<double>>(std::forward<Args>(args)...);
@@ -318,8 +345,6 @@ make_impl_for_dtype(mpdsp::ArithConfig config, const char* cls, Args&&... args) 
 		return std::make_unique<Impl<half_>>(std::forward<Args>(args)...);
 	case ArithConfig::posit_full:
 		return std::make_unique<Impl<p32>>(std::forward<Args>(args)...);
-	case ArithConfig::tiny_posit:
-		return std::make_unique<Impl<tiny_posit_t>>(std::forward<Args>(args)...);
 	case ArithConfig::sensor_8bit:
 	case ArithConfig::sensor_6bit:
 		// Sensor configs keep the state/compute scalar at double — the
@@ -328,6 +353,25 @@ make_impl_for_dtype(mpdsp::ArithConfig config, const char* cls, Args&&... args) 
 		return std::make_unique<Impl<double>>(std::forward<Args>(args)...);
 	case ArithConfig::fpga_fixed:
 		return std::make_unique<Impl<fx3224_t>>(std::forward<Args>(args)...);
+	// Posit taxonomy grid (#81).
+	case ArithConfig::posit_8_0:
+		return std::make_unique<Impl<p8_0>>(std::forward<Args>(args)...);
+	case ArithConfig::posit_8_1:
+		return std::make_unique<Impl<p8_1>>(std::forward<Args>(args)...);
+	case ArithConfig::posit_8_2:
+		return std::make_unique<Impl<p8_2>>(std::forward<Args>(args)...);
+	case ArithConfig::posit_16_0:
+		return std::make_unique<Impl<p16_0>>(std::forward<Args>(args)...);
+	case ArithConfig::posit_16_1:
+		return std::make_unique<Impl<p16_1>>(std::forward<Args>(args)...);
+	case ArithConfig::posit_16_2:
+		return std::make_unique<Impl<p16_2>>(std::forward<Args>(args)...);
+	case ArithConfig::posit_32_0:
+		return std::make_unique<Impl<p32_0>>(std::forward<Args>(args)...);
+	case ArithConfig::posit_32_1:
+		return std::make_unique<Impl<p32_1>>(std::forward<Args>(args)...);
+	case ArithConfig::posit_32_2:
+		return std::make_unique<Impl<p32_2>>(std::forward<Args>(args)...);
 	}
 	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
 }

--- a/src/estimation_bindings.cpp
+++ b/src/estimation_bindings.cpp
@@ -287,7 +287,15 @@ make_adaptive_impl(mpdsp::ArithConfig config, const char* cls,
 	using mpdsp::fx3224_t;
 	using mpdsp::half_;
 	using mpdsp::p32;
-	using tiny_posit_t = sw::universal::posit<8, 2>;
+	using mpdsp::p8_0;
+	using mpdsp::p8_1;
+	using mpdsp::p8_2;
+	using mpdsp::p16_0;
+	using mpdsp::p16_1;
+	using mpdsp::p16_2;
+	using mpdsp::p32_0;
+	using mpdsp::p32_1;
+	using mpdsp::p32_2;
 	switch (config) {
 	case ArithConfig::reference:
 		return std::make_unique<AdaptiveFilterImpl<Filter, double>>(
@@ -307,14 +315,42 @@ make_adaptive_impl(mpdsp::ArithConfig config, const char* cls,
 	case ArithConfig::posit_full:
 		return std::make_unique<AdaptiveFilterImpl<Filter, p32>>(
 			num_taps, static_cast<p32>(args)...);
-	case ArithConfig::tiny_posit:
-		return std::make_unique<AdaptiveFilterImpl<Filter, tiny_posit_t>>(
-			num_taps, static_cast<tiny_posit_t>(args)...);
-	// Reject the Phase-6 sensor/FPGA configs here. Adaptive filters only
-	// accept a single scalar T, so we can't independently honour both a
-	// double state and an integer<N> / fixpnt<16,12> sample path — either
-	// the sensor_* configs would silently collapse to `reference` (with
-	// no quantization visible), or fpga_fixed would claim a 16-bit sample
+	// Posit taxonomy grid (#81) — single-type, so the adaptive update runs
+	// entirely at posit<N,es>. No state-vs-sample split to worry about;
+	// none of the "reject these" reasoning for sensor_*/fpga_fixed applies.
+	// posit_8_2 also covers the tiny_posit alias.
+	case ArithConfig::posit_8_0:
+		return std::make_unique<AdaptiveFilterImpl<Filter, p8_0>>(
+			num_taps, static_cast<p8_0>(args)...);
+	case ArithConfig::posit_8_1:
+		return std::make_unique<AdaptiveFilterImpl<Filter, p8_1>>(
+			num_taps, static_cast<p8_1>(args)...);
+	case ArithConfig::posit_8_2:
+		return std::make_unique<AdaptiveFilterImpl<Filter, p8_2>>(
+			num_taps, static_cast<p8_2>(args)...);
+	case ArithConfig::posit_16_0:
+		return std::make_unique<AdaptiveFilterImpl<Filter, p16_0>>(
+			num_taps, static_cast<p16_0>(args)...);
+	case ArithConfig::posit_16_1:
+		return std::make_unique<AdaptiveFilterImpl<Filter, p16_1>>(
+			num_taps, static_cast<p16_1>(args)...);
+	case ArithConfig::posit_16_2:
+		return std::make_unique<AdaptiveFilterImpl<Filter, p16_2>>(
+			num_taps, static_cast<p16_2>(args)...);
+	case ArithConfig::posit_32_0:
+		return std::make_unique<AdaptiveFilterImpl<Filter, p32_0>>(
+			num_taps, static_cast<p32_0>(args)...);
+	case ArithConfig::posit_32_1:
+		return std::make_unique<AdaptiveFilterImpl<Filter, p32_1>>(
+			num_taps, static_cast<p32_1>(args)...);
+	case ArithConfig::posit_32_2:
+		return std::make_unique<AdaptiveFilterImpl<Filter, p32_2>>(
+			num_taps, static_cast<p32_2>(args)...);
+	// Reject the sensor/FPGA configs here. Adaptive filters only accept a
+	// single scalar T, so we can't independently honour both a double
+	// state and an integer<N> / fixpnt<16,12> sample path — either the
+	// sensor_* configs would silently collapse to `reference` (with no
+	// quantization visible), or fpga_fixed would claim a 16-bit sample
 	// path while actually running the adaptive update at fixpnt<32,24>
 	// and breaking dtype-to-dtype comparisons. Surface the limitation
 	// instead of fabricating a misleading answer; a future wrapper can
@@ -328,7 +364,8 @@ make_adaptive_impl(mpdsp::ArithConfig config, const char* cls,
 			": dtype not supported by adaptive filters — sensor_* and "
 			"fpga_fixed mix state and sample precisions, which the "
 			"single-T adaptive update can't honour. Use reference, "
-			"gpu_baseline, ml_hw, posit_full, tiny_posit, cf24, or half.");
+			"gpu_baseline, ml_hw, posit_full, cf24, half, or any "
+			"posit_N_es grid cell.");
 	}
 	throw std::invalid_argument(std::string(cls) + ": unsupported ArithConfig");
 }

--- a/src/filter_bindings.cpp
+++ b/src/filter_bindings.cpp
@@ -123,7 +123,15 @@ static void process_dispatch(const CascadeD& cascade,
 	using mpdsp::int8_sample_t;
 	using mpdsp::p16;
 	using mpdsp::p32;
-	using tiny_posit_t = sw::universal::posit<8, 2>;
+	using mpdsp::p8_0;
+	using mpdsp::p8_1;
+	using mpdsp::p8_2;
+	using mpdsp::p16_0;
+	using mpdsp::p16_1;
+	using mpdsp::p16_2;
+	using mpdsp::p32_0;
+	using mpdsp::p32_1;
+	using mpdsp::p32_2;
 	switch (config) {
 	case ArithConfig::reference:
 		process_typed<double, double>(cascade, in, out, n); break;
@@ -137,8 +145,6 @@ static void process_dispatch(const CascadeD& cascade,
 		process_typed<half_, half_>(cascade, in, out, n); break;
 	case ArithConfig::posit_full:
 		process_typed<p32, p16>(cascade, in, out, n); break;
-	case ArithConfig::tiny_posit:
-		process_typed<tiny_posit_t, tiny_posit_t>(cascade, in, out, n); break;
 	// Sensor configs: coefficient/state in double, sample quantized through
 	// integer<N>. integer<N> is ADL-castable from double via static_cast, so
 	// process_typed<double, int8_sample_t> models "signal arrives on an 8-bit
@@ -149,6 +155,26 @@ static void process_dispatch(const CascadeD& cascade,
 		process_typed<double, int6_sample_t>(cascade, in, out, n); break;
 	case ArithConfig::fpga_fixed:
 		process_typed<fx3224_t, fx1612_t>(cascade, in, out, n); break;
+	// Posit taxonomy grid (#81) — every cell uses a single posit type for
+	// both state and sample. posit_8_2 also covers the tiny_posit alias.
+	case ArithConfig::posit_8_0:
+		process_typed<p8_0, p8_0>(cascade, in, out, n); break;
+	case ArithConfig::posit_8_1:
+		process_typed<p8_1, p8_1>(cascade, in, out, n); break;
+	case ArithConfig::posit_8_2:
+		process_typed<p8_2, p8_2>(cascade, in, out, n); break;
+	case ArithConfig::posit_16_0:
+		process_typed<p16_0, p16_0>(cascade, in, out, n); break;
+	case ArithConfig::posit_16_1:
+		process_typed<p16_1, p16_1>(cascade, in, out, n); break;
+	case ArithConfig::posit_16_2:
+		process_typed<p16_2, p16_2>(cascade, in, out, n); break;
+	case ArithConfig::posit_32_0:
+		process_typed<p32_0, p32_0>(cascade, in, out, n); break;
+	case ArithConfig::posit_32_1:
+		process_typed<p32_1, p32_1>(cascade, in, out, n); break;
+	case ArithConfig::posit_32_2:
+		process_typed<p32_2, p32_2>(cascade, in, out, n); break;
 	}
 }
 
@@ -412,7 +438,15 @@ static void fir_process_dispatch(const mtl::vec::dense_vector<double>& taps_d,
 	using mpdsp::int8_sample_t;
 	using mpdsp::p16;
 	using mpdsp::p32;
-	using tiny_posit_t = sw::universal::posit<8, 2>;
+	using mpdsp::p8_0;
+	using mpdsp::p8_1;
+	using mpdsp::p8_2;
+	using mpdsp::p16_0;
+	using mpdsp::p16_1;
+	using mpdsp::p16_2;
+	using mpdsp::p32_0;
+	using mpdsp::p32_1;
+	using mpdsp::p32_2;
 	switch (config) {
 	case ArithConfig::reference:
 		fir_process_typed<double, double>(taps_d, in, out, n); break;
@@ -426,14 +460,31 @@ static void fir_process_dispatch(const mtl::vec::dense_vector<double>& taps_d,
 		fir_process_typed<half_, half_>(taps_d, in, out, n); break;
 	case ArithConfig::posit_full:
 		fir_process_typed<p32, p16>(taps_d, in, out, n); break;
-	case ArithConfig::tiny_posit:
-		fir_process_typed<tiny_posit_t, tiny_posit_t>(taps_d, in, out, n); break;
 	case ArithConfig::sensor_8bit:
 		fir_process_typed<double, int8_sample_t>(taps_d, in, out, n); break;
 	case ArithConfig::sensor_6bit:
 		fir_process_typed<double, int6_sample_t>(taps_d, in, out, n); break;
 	case ArithConfig::fpga_fixed:
 		fir_process_typed<fx3224_t, fx1612_t>(taps_d, in, out, n); break;
+	// Posit taxonomy grid (#81).
+	case ArithConfig::posit_8_0:
+		fir_process_typed<p8_0, p8_0>(taps_d, in, out, n); break;
+	case ArithConfig::posit_8_1:
+		fir_process_typed<p8_1, p8_1>(taps_d, in, out, n); break;
+	case ArithConfig::posit_8_2:
+		fir_process_typed<p8_2, p8_2>(taps_d, in, out, n); break;
+	case ArithConfig::posit_16_0:
+		fir_process_typed<p16_0, p16_0>(taps_d, in, out, n); break;
+	case ArithConfig::posit_16_1:
+		fir_process_typed<p16_1, p16_1>(taps_d, in, out, n); break;
+	case ArithConfig::posit_16_2:
+		fir_process_typed<p16_2, p16_2>(taps_d, in, out, n); break;
+	case ArithConfig::posit_32_0:
+		fir_process_typed<p32_0, p32_0>(taps_d, in, out, n); break;
+	case ArithConfig::posit_32_1:
+		fir_process_typed<p32_1, p32_1>(taps_d, in, out, n); break;
+	case ArithConfig::posit_32_2:
+		fir_process_typed<p32_2, p32_2>(taps_d, in, out, n); break;
 	}
 }
 
@@ -507,7 +558,15 @@ static double pole_displacement_dispatch(const CascadeD& src,
 	using mpdsp::half_;
 	using mpdsp::p16;
 	using mpdsp::p32;
-	using tiny_posit_t = sw::universal::posit<8, 2>;
+	using mpdsp::p8_0;
+	using mpdsp::p8_1;
+	using mpdsp::p8_2;
+	using mpdsp::p16_0;
+	using mpdsp::p16_1;
+	using mpdsp::p16_2;
+	using mpdsp::p32_0;
+	using mpdsp::p32_1;
+	using mpdsp::p32_2;
 	CascadeD quantized;
 	switch (config) {
 	case ArithConfig::reference:    return 0.0;  // no quantization
@@ -516,7 +575,6 @@ static double pole_displacement_dispatch(const CascadeD& src,
 	case ArithConfig::cf24_config:  quantized = quantize_cascade<cf24>(src); break;
 	case ArithConfig::half_config:  quantized = quantize_cascade<half_>(src); break;
 	case ArithConfig::posit_full:   quantized = quantize_cascade<p32>(src); break;
-	case ArithConfig::tiny_posit:   quantized = quantize_cascade<tiny_posit_t>(src); break;
 	// sensor_* keep coefficients at double (only the sample path quantizes),
 	// so coefficient-level pole displacement is zero for them.
 	case ArithConfig::sensor_8bit:
@@ -524,6 +582,17 @@ static double pole_displacement_dispatch(const CascadeD& src,
 		return 0.0;
 	case ArithConfig::fpga_fixed:
 		quantized = quantize_cascade<fx3224_t>(src); break;
+	// Posit taxonomy grid (#81) — coefficient-level quantization through
+	// the grid's posit type. posit_8_2 also covers the tiny_posit alias.
+	case ArithConfig::posit_8_0:  quantized = quantize_cascade<p8_0>(src); break;
+	case ArithConfig::posit_8_1:  quantized = quantize_cascade<p8_1>(src); break;
+	case ArithConfig::posit_8_2:  quantized = quantize_cascade<p8_2>(src); break;
+	case ArithConfig::posit_16_0: quantized = quantize_cascade<p16_0>(src); break;
+	case ArithConfig::posit_16_1: quantized = quantize_cascade<p16_1>(src); break;
+	case ArithConfig::posit_16_2: quantized = quantize_cascade<p16_2>(src); break;
+	case ArithConfig::posit_32_0: quantized = quantize_cascade<p32_0>(src); break;
+	case ArithConfig::posit_32_1: quantized = quantize_cascade<p32_1>(src); break;
+	case ArithConfig::posit_32_2: quantized = quantize_cascade<p32_2>(src); break;
 	}
 	return sw::dsp::pole_displacement(src, quantized);
 }

--- a/src/quantization_bindings.cpp
+++ b/src/quantization_bindings.cpp
@@ -91,10 +91,20 @@ adc_dispatch(const mtl::vec::dense_vector<double>& signal, mpdsp::ArithConfig co
 	case mpdsp::ArithConfig::half_config:   return adc_typed<mpdsp::half_>(signal);
 	case mpdsp::ArithConfig::ml_hw:         return adc_typed<mpdsp::half_>(signal);
 	case mpdsp::ArithConfig::posit_full:    return adc_typed<mpdsp::p16>(signal);
-	case mpdsp::ArithConfig::tiny_posit:    return adc_typed<sw::universal::posit<8,2>>(signal);
 	case mpdsp::ArithConfig::sensor_8bit:   return adc_typed<mpdsp::int8_sample_t>(signal);
 	case mpdsp::ArithConfig::sensor_6bit:   return adc_typed<mpdsp::int6_sample_t>(signal);
 	case mpdsp::ArithConfig::fpga_fixed:    return adc_typed<mpdsp::fx1612_t>(signal);
+	// Posit taxonomy grid (#81) — posit<N,es> as the sample scalar. posit_8_2
+	// also covers the tiny_posit alias (same enum value).
+	case mpdsp::ArithConfig::posit_8_0:     return adc_typed<mpdsp::p8_0>(signal);
+	case mpdsp::ArithConfig::posit_8_1:     return adc_typed<mpdsp::p8_1>(signal);
+	case mpdsp::ArithConfig::posit_8_2:     return adc_typed<mpdsp::p8_2>(signal);
+	case mpdsp::ArithConfig::posit_16_0:    return adc_typed<mpdsp::p16_0>(signal);
+	case mpdsp::ArithConfig::posit_16_1:    return adc_typed<mpdsp::p16_1>(signal);
+	case mpdsp::ArithConfig::posit_16_2:    return adc_typed<mpdsp::p16_2>(signal);
+	case mpdsp::ArithConfig::posit_32_0:    return adc_typed<mpdsp::p32_0>(signal);
+	case mpdsp::ArithConfig::posit_32_1:    return adc_typed<mpdsp::p32_1>(signal);
+	case mpdsp::ArithConfig::posit_32_2:    return adc_typed<mpdsp::p32_2>(signal);
 	}
 	return signal;
 }
@@ -144,10 +154,19 @@ dac_dispatch(const mtl::vec::dense_vector<double>& quantized,
 	case mpdsp::ArithConfig::half_config:   return dac_typed<mpdsp::half_>(quantized);
 	case mpdsp::ArithConfig::ml_hw:         return dac_typed<mpdsp::half_>(quantized);
 	case mpdsp::ArithConfig::posit_full:    return dac_typed<mpdsp::p16>(quantized);
-	case mpdsp::ArithConfig::tiny_posit:    return dac_typed<sw::universal::posit<8,2>>(quantized);
 	case mpdsp::ArithConfig::sensor_8bit:   return dac_typed<mpdsp::int8_sample_t>(quantized);
 	case mpdsp::ArithConfig::sensor_6bit:   return dac_typed<mpdsp::int6_sample_t>(quantized);
 	case mpdsp::ArithConfig::fpga_fixed:    return dac_typed<mpdsp::fx1612_t>(quantized);
+	// Posit taxonomy grid (#81).
+	case mpdsp::ArithConfig::posit_8_0:     return dac_typed<mpdsp::p8_0>(quantized);
+	case mpdsp::ArithConfig::posit_8_1:     return dac_typed<mpdsp::p8_1>(quantized);
+	case mpdsp::ArithConfig::posit_8_2:     return dac_typed<mpdsp::p8_2>(quantized);
+	case mpdsp::ArithConfig::posit_16_0:    return dac_typed<mpdsp::p16_0>(quantized);
+	case mpdsp::ArithConfig::posit_16_1:    return dac_typed<mpdsp::p16_1>(quantized);
+	case mpdsp::ArithConfig::posit_16_2:    return dac_typed<mpdsp::p16_2>(quantized);
+	case mpdsp::ArithConfig::posit_32_0:    return dac_typed<mpdsp::p32_0>(quantized);
+	case mpdsp::ArithConfig::posit_32_1:    return dac_typed<mpdsp::p32_1>(quantized);
+	case mpdsp::ArithConfig::posit_32_2:    return dac_typed<mpdsp::p32_2>(quantized);
 	}
 	// Unreachable: switch is exhaustive over mpdsp::ArithConfig.
 	return quantized;

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -2,7 +2,7 @@
 // types.hpp: arithmetic configuration dispatch for Python bindings
 //
 // Maps runtime string keys to compile-time template instantiations.
-// This avoids combinatorial explosion: 8 configs, not 216.
+// This avoids combinatorial explosion: N configs, not NNN.
 
 #include <stdexcept>
 #include <string>
@@ -20,11 +20,32 @@
 
 namespace mpdsp {
 
-// Arithmetic type aliases used across bindings
+// Non-posit type aliases used across bindings
 using cf24  = sw::universal::cfloat<24, 5, uint32_t, true, false, false>;
 using half_ = sw::universal::cfloat<16, 5, uint16_t, true, false, false>;
-using p32   = sw::universal::posit<32, 2>;
-using p16   = sw::universal::posit<16, 1>;
+
+// Posit taxonomy grid (issue #81) — posit<N, es> for every combination
+// of N ∈ {8, 16, 32} and es ∈ {0, 1, 2}. Single-type configs: coefficient,
+// state, and sample all use the same posit type. The mixed `posit_full`
+// bundle (posit<32,2> state + posit<16,1> sample) is orthogonal and
+// unchanged — it represents a specific production pipeline, not a grid
+// cell.
+using p8_0  = sw::universal::posit<8, 0>;
+using p8_1  = sw::universal::posit<8, 1>;
+using p8_2  = sw::universal::posit<8, 2>;
+using p16_0 = sw::universal::posit<16, 0>;
+using p16_1 = sw::universal::posit<16, 1>;
+using p16_2 = sw::universal::posit<16, 2>;
+using p32_0 = sw::universal::posit<32, 0>;
+using p32_1 = sw::universal::posit<32, 1>;
+using p32_2 = sw::universal::posit<32, 2>;
+
+// Legacy aliases from before the taxonomy grid landed. `p32` and `p16`
+// were named for their roles in the posit_full bundle (32-bit state +
+// 16-bit sample); they live on as aliases for the corresponding grid
+// cells so existing dispatcher code paths keep compiling.
+using p32 = p32_2;
+using p16 = p16_1;
 
 // Sensor / FPGA sample-path scalars (issue #55). integer<N> is the ADC
 // quantization target for sensor_* configs; fixpnt is the state/sample
@@ -41,12 +62,27 @@ enum class ArithConfig {
 	gpu_baseline,   // double / float / float
 	ml_hw,          // double / float / half
 	posit_full,     // double / posit<32,2> / posit<16,1>
-	tiny_posit,     // double / posit<8,2> / posit<8,2>
 	cf24_config,    // double / cf24 / cf24
 	half_config,    // double / half / half
 	sensor_8bit,    // double / double / integer<8>
 	sensor_6bit,    // double / double / integer<6>
 	fpga_fixed,     // double / fixpnt<32,24> / fixpnt<16,12>
+	// Posit taxonomy grid (#81) — 9 cells (N × es).
+	posit_8_0,      // posit<8,0>  throughout
+	posit_8_1,      // posit<8,1>  throughout
+	posit_8_2,      // posit<8,2>  throughout
+	posit_16_0,     // posit<16,0> throughout
+	posit_16_1,     // posit<16,1> throughout
+	posit_16_2,     // posit<16,2> throughout
+	posit_32_0,     // posit<32,0> throughout
+	posit_32_1,     // posit<32,1> throughout
+	posit_32_2,     // posit<32,2> throughout
+	// Legacy alias for the pre-#81 "tiny_posit" name. Same underlying
+	// enum value as posit_8_2, so switches only need the posit_8_2 case
+	// (adding a tiny_posit case would be a duplicate-case compile error).
+	// parse_config accepts "tiny_posit" as input; available_configs()
+	// does not list it — the taxonomic name is canonical.
+	tiny_posit = posit_8_2,
 };
 
 inline ArithConfig parse_config(const std::string& name) {
@@ -54,27 +90,48 @@ inline ArithConfig parse_config(const std::string& name) {
 	if (name == "gpu_baseline" || name == "float") return ArithConfig::gpu_baseline;
 	if (name == "ml_hw" || name == "bfloat16") return ArithConfig::ml_hw;
 	if (name == "posit_full") return ArithConfig::posit_full;
-	if (name == "tiny_posit") return ArithConfig::tiny_posit;
 	if (name == "cf24") return ArithConfig::cf24_config;
 	if (name == "half") return ArithConfig::half_config;
 	if (name == "sensor_8bit") return ArithConfig::sensor_8bit;
 	if (name == "sensor_6bit") return ArithConfig::sensor_6bit;
 	if (name == "fpga_fixed") return ArithConfig::fpga_fixed;
+	// Posit taxonomy grid (#81).
+	if (name == "posit_8_0")  return ArithConfig::posit_8_0;
+	if (name == "posit_8_1")  return ArithConfig::posit_8_1;
+	if (name == "posit_8_2")  return ArithConfig::posit_8_2;
+	if (name == "posit_16_0") return ArithConfig::posit_16_0;
+	if (name == "posit_16_1") return ArithConfig::posit_16_1;
+	if (name == "posit_16_2") return ArithConfig::posit_16_2;
+	if (name == "posit_32_0") return ArithConfig::posit_32_0;
+	if (name == "posit_32_1") return ArithConfig::posit_32_1;
+	if (name == "posit_32_2") return ArithConfig::posit_32_2;
+	// Legacy alias — maps to the same enum value as posit_8_2. Kept so
+	// any caller still passing "tiny_posit" continues to work. Remove
+	// if a major-version cleanup ever drops it; not listed in
+	// available_configs() already.
+	if (name == "tiny_posit") return ArithConfig::posit_8_2;
 	throw std::invalid_argument("Unknown arithmetic config: " + name);
 }
 
-// List of available config names (for Python introspection)
+// List of available config names (for Python introspection). The
+// "tiny_posit" alias is intentionally absent — parse_config still
+// accepts it, but the canonical name for that config is "posit_8_2".
 inline std::vector<std::string> available_configs() {
 	return { "reference", "gpu_baseline", "ml_hw", "posit_full",
-	         "tiny_posit", "cf24", "half",
-	         "sensor_8bit", "sensor_6bit", "fpga_fixed" };
+	         "cf24", "half",
+	         "sensor_8bit", "sensor_6bit", "fpga_fixed",
+	         "posit_8_0", "posit_8_1", "posit_8_2",
+	         "posit_16_0", "posit_16_1", "posit_16_2",
+	         "posit_32_0", "posit_32_1", "posit_32_2" };
 }
 
 // Sample-scalar bit width per config. Surfaces the table that was
 // previously hardcoded in scripts/plot_dashboard.py:plot_precision_cost_frontier
 // so the dashboard and any other consumer can query it rather than duplicate.
 // Returns the width of the narrowest (sample-path) scalar, which is what the
-// precision-vs-cost frontier is plotted against.
+// precision-vs-cost frontier is plotted against. For posit grid cells, the
+// ES dimension doesn't affect bit width — only exponent encoding — so every
+// posit_N_* config reports N.
 inline int bits_of(const std::string& name) {
 	auto cfg = parse_config(name);
 	switch (cfg) {
@@ -82,12 +139,20 @@ inline int bits_of(const std::string& name) {
 	case ArithConfig::gpu_baseline: return 32;
 	case ArithConfig::ml_hw:        return 16;  // half
 	case ArithConfig::posit_full:   return 16;  // posit<16,1> sample path
-	case ArithConfig::tiny_posit:   return 8;   // posit<8,2>
 	case ArithConfig::cf24_config:  return 24;
 	case ArithConfig::half_config:  return 16;
 	case ArithConfig::sensor_8bit:  return 8;
 	case ArithConfig::sensor_6bit:  return 6;
 	case ArithConfig::fpga_fixed:   return 16;  // fixpnt<16,12> sample path
+	case ArithConfig::posit_8_0:    return 8;
+	case ArithConfig::posit_8_1:    return 8;
+	case ArithConfig::posit_8_2:    return 8;   // also covers tiny_posit alias
+	case ArithConfig::posit_16_0:   return 16;
+	case ArithConfig::posit_16_1:   return 16;
+	case ArithConfig::posit_16_2:   return 16;
+	case ArithConfig::posit_32_0:   return 32;
+	case ArithConfig::posit_32_1:   return 32;
+	case ArithConfig::posit_32_2:   return 32;
 	}
 	throw std::invalid_argument("bits_of: unsupported ArithConfig");
 }

--- a/src/types_bindings.cpp
+++ b/src/types_bindings.cpp
@@ -258,7 +258,15 @@ project_dispatch(const mtl::vec::dense_vector<double>& src,
 	using mpdsp::int6_sample_t;
 	using mpdsp::int8_sample_t;
 	using mpdsp::p16;
-	using tiny_posit_t = sw::universal::posit<8, 2>;
+	using mpdsp::p8_0;
+	using mpdsp::p8_1;
+	using mpdsp::p8_2;
+	using mpdsp::p16_0;
+	using mpdsp::p16_1;
+	using mpdsp::p16_2;
+	using mpdsp::p32_0;
+	using mpdsp::p32_1;
+	using mpdsp::p32_2;
 
 	switch (config) {
 	case mpdsp::ArithConfig::reference:
@@ -269,8 +277,6 @@ project_dispatch(const mtl::vec::dense_vector<double>& src,
 		return project_typed<half_>(src);
 	case mpdsp::ArithConfig::posit_full:
 		return project_typed<p16>(src);
-	case mpdsp::ArithConfig::tiny_posit:
-		return project_typed<tiny_posit_t>(src);
 	case mpdsp::ArithConfig::cf24_config:
 		return project_typed<cf24>(src);
 	case mpdsp::ArithConfig::half_config:
@@ -281,6 +287,17 @@ project_dispatch(const mtl::vec::dense_vector<double>& src,
 		return project_typed<int6_sample_t>(src);
 	case mpdsp::ArithConfig::fpga_fixed:
 		return project_typed<fx1612_t>(src);
+	// Posit taxonomy grid (#81) — project through the posit<N,es> scalar.
+	// posit_8_2 also covers the tiny_posit alias (same enum value).
+	case mpdsp::ArithConfig::posit_8_0:  return project_typed<p8_0>(src);
+	case mpdsp::ArithConfig::posit_8_1:  return project_typed<p8_1>(src);
+	case mpdsp::ArithConfig::posit_8_2:  return project_typed<p8_2>(src);
+	case mpdsp::ArithConfig::posit_16_0: return project_typed<p16_0>(src);
+	case mpdsp::ArithConfig::posit_16_1: return project_typed<p16_1>(src);
+	case mpdsp::ArithConfig::posit_16_2: return project_typed<p16_2>(src);
+	case mpdsp::ArithConfig::posit_32_0: return project_typed<p32_0>(src);
+	case mpdsp::ArithConfig::posit_32_1: return project_typed<p32_1>(src);
+	case mpdsp::ArithConfig::posit_32_2: return project_typed<p32_2>(src);
 	}
 	// Unreachable: the switch above is exhaustive over mpdsp::ArithConfig.
 	return src;

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -106,7 +106,28 @@ class TestAvailableDtypes:
         assert "sensor_8bit" in dtypes
         assert "sensor_6bit" in dtypes
         assert "fpga_fixed" in dtypes
-        assert len(dtypes) == 10
+
+    def test_available_dtypes_includes_full_posit_grid(self):
+        # Issue #81 — the 3×3 posit<N,es> grid for N ∈ {8,16,32},
+        # es ∈ {0,1,2}. Guards against silent regression of the
+        # taxonomic expansion.
+        dtypes = mpdsp.available_dtypes()
+        for n in (8, 16, 32):
+            for es in (0, 1, 2):
+                assert f"posit_{n}_{es}" in dtypes
+
+    def test_tiny_posit_is_accepted_as_alias(self):
+        # Issue #81 — tiny_posit remains accepted as a legacy alias
+        # for posit_8_2 via parse_config, but is no longer listed in
+        # available_dtypes() (the canonical name is posit_8_2).
+        assert "tiny_posit" not in mpdsp.available_dtypes()
+        # But still a valid input to any dtype= parameter, mapping to
+        # the same precision as posit_8_2.
+        assert mpdsp.bits_of("tiny_posit") == mpdsp.bits_of("posit_8_2") == 8
+        sig = mpdsp.sine(128, frequency=100.0, sample_rate=44100.0)
+        via_alias = mpdsp.adc(sig, dtype="tiny_posit")
+        via_taxonomic = mpdsp.adc(sig, dtype="posit_8_2")
+        np.testing.assert_array_equal(via_alias, via_taxonomic)
 
     def test_invalid_dtype_raises(self):
         sig = mpdsp.sine(100, frequency=440.0, sample_rate=44100.0)
@@ -130,10 +151,14 @@ class TestBitsOf:
         ("half",         16),
         ("cf24",         24),
         ("posit_full",   16),
-        ("tiny_posit",    8),
+        ("tiny_posit",    8),   # legacy alias for posit_8_2
         ("sensor_8bit",   8),
         ("sensor_6bit",   6),
         ("fpga_fixed",   16),
+        # Posit taxonomy grid (#81) — ES doesn't affect bit width.
+        ("posit_8_0",     8), ("posit_8_1",   8), ("posit_8_2",   8),
+        ("posit_16_0",   16), ("posit_16_1", 16), ("posit_16_2", 16),
+        ("posit_32_0",   32), ("posit_32_1", 32), ("posit_32_2", 32),
     ])
     def test_bits_of_returns_expected_width(self, dtype, expected):
         assert mpdsp.bits_of(dtype) == expected
@@ -198,6 +223,58 @@ class TestSensorAndFpgaQuantization:
         assert projected.shape == sig.shape
         err = np.max(np.abs(sig - projected))
         assert err > 1e-3  # integer<8> can't represent 0.5 exactly
+
+
+class TestPositGridSQNR:
+    """3×3 SQNR sweep through posit<N,es> for N ∈ {8,16,32}, es ∈ {0,1,2}.
+
+    Issue #81. These aren't chasing specific dB values — they're pinning
+    the structural invariants of the grid:
+
+    1. **Wider is better:** at the same ES, 32-bit posits beat 16-bit,
+       which beat 8-bit. This guards against a dispatch mis-wiring
+       that accidentally routes posit_32_* through posit_8_* types.
+    2. **Grid cells are distinct:** no two cells produce identical
+       adc() output. Catches enum-value collisions (e.g. accidentally
+       making posit_16_1 an alias of posit_16_2 the way posit_8_2
+       intentionally aliases tiny_posit).
+    """
+
+    # A mid-amplitude, multi-tone signal stresses each cell's dynamic
+    # range differently than a pure sine would.
+    def _test_signal(self, n: int = 2048):
+        rng = np.random.default_rng(7)
+        t = np.arange(n) / 44100.0
+        return (0.3 * np.sin(2 * np.pi * 440.0 * t)
+                + 0.2 * np.sin(2 * np.pi * 1760.0 * t)
+                + 0.05 * rng.normal(size=n))
+
+    @pytest.mark.parametrize("es", [0, 1, 2])
+    def test_sqnr_increases_with_bit_width_at_fixed_es(self, es):
+        sig = self._test_signal()
+        sqnr_8  = mpdsp.measure_sqnr_db(sig, f"posit_8_{es}")
+        sqnr_16 = mpdsp.measure_sqnr_db(sig, f"posit_16_{es}")
+        sqnr_32 = mpdsp.measure_sqnr_db(sig, f"posit_32_{es}")
+        assert sqnr_8 < sqnr_16 < sqnr_32, (
+            f"expected SQNR to grow with width at es={es}; got "
+            f"8→{sqnr_8:.1f}, 16→{sqnr_16:.1f}, 32→{sqnr_32:.1f}")
+
+    def test_grid_cells_all_produce_distinct_outputs(self):
+        # 9 cells × adc() → 9 distinct arrays. Any two being identical
+        # would mean the enum or dispatcher collapsed them somewhere.
+        # posit_8_2 == tiny_posit by design, but that's the same enum
+        # value so it's not a 10th distinct cell.
+        sig = self._test_signal(n=512)
+        results = {}
+        for n in (8, 16, 32):
+            for es in (0, 1, 2):
+                key = f"posit_{n}_{es}"
+                results[key] = mpdsp.adc(sig, dtype=key)
+        keys = list(results)
+        for i, a in enumerate(keys):
+            for b in keys[i + 1:]:
+                assert not np.array_equal(results[a], results[b]), (
+                    f"{a} and {b} produced bit-identical adc() output")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves #81. Adds 9 new `ArithConfig` values implementing the 3×3 posit taxonomy grid — every `posit<N, es>` for N ∈ {8, 16, 32} and es ∈ {0, 1, 2} becomes a first-class single-type config, so fixed-N sweeps across ES produce 3 stacked points on the precision-cost frontier and ES's effect on dynamic-range-vs-precision tradeoff is directly readable.

## Naming

`posit_{nbits}_{es}` throughout — matches the well-established `posit<N, es>` shorthand from the Universal library and posit research literature:

|   | `es = 0` | `es = 1` | `es = 2` |
|---|----------|----------|----------|
| `N = 8`  | `posit_8_0`  | `posit_8_1`  | `posit_8_2`  |
| `N = 16` | `posit_16_0` | `posit_16_1` | `posit_16_2` |
| `N = 32` | `posit_32_0` | `posit_32_1` | `posit_32_2` |

## Relationship to existing configs

- **`posit_full`** — unchanged. It's a specific mixed-precision bundle (`posit<32,2>` state + `posit<16,1>` sample) that doesn't collapse to any single grid cell; it represents a production pipeline orthogonal to the taxonomic slice.
- **`tiny_posit`** — C++ enum alias of `posit_8_2` (same underlying value; `switch` cases for `tiny_posit` would be a duplicate-case compile error now). `parse_config` still accepts `"tiny_posit"` as input, so any caller passing that string continues to work. `available_configs()` no longer lists it — the taxonomic name `posit_8_2` is canonical.

## Changes (10 files, ~240 LOC)

| File | Change |
|------|--------|
| `src/types.hpp` | 9 type aliases + enum values + `parse_config` branches + `available_configs` list + `bits_of` cases. `tiny_posit = posit_8_2` alias preserved. |
| `src/_binding_helpers.hpp` | `dispatch_dtype_fn` + `make_impl_for_dtype` extended |
| `src/filter_bindings.cpp` | `process_dispatch`, `fir_process_dispatch`, `pole_displacement_dispatch` extended |
| `src/quantization_bindings.cpp` | `adc_dispatch`, `dac_dispatch` extended |
| `src/types_bindings.cpp` | `project_dispatch` extended |
| `src/estimation_bindings.cpp` | `make_adaptive_impl` extended. Grid cells work with single-T adaptive filters (unlike sensor_*/fpga_fixed rejected there); error message updated. |
| `README.md` + `docs/api_reference.md` + `scripts/build_api_ref.py` | Config table gains a dedicated posit-taxonomy subtable |
| `tests/test_quantization.py` | Drops hardcoded count assumption; adds grid-membership / alias / 3×3 SQNR tests |

No upstream (`mixed-precision-dsp` / `Universal`) work needed — `sw::universal::posit<N, es>` is fully template-parameterized and all 9 cells instantiate cleanly.

## New tests (16 cases)

- **`test_available_dtypes_includes_full_posit_grid`** — 9 cells must appear in `available_dtypes()`.
- **`test_tiny_posit_is_accepted_as_alias`** — legacy string routes through `parse_config` to the same enum value as `"posit_8_2"` and produces bit-identical `adc()` output.
- **`TestBitsOf` parametrize** — width per grid cell pinned; ES doesn't affect bit width.
- **`TestPositGridSQNR`**:
  - `test_sqnr_increases_with_bit_width_at_fixed_es` (parametrized over ES): guards dispatch mis-wiring that might route `posit_32_*` through `posit_8_*` types.
  - `test_grid_cells_all_produce_distinct_outputs`: no two of the 9 cells produce identical `adc()` output. Catches silent enum-value collisions.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| `_core` | OK | 737/737 | OK | 737/737 |

(Up from 674 pre-grid — 47 auto-enrolled cases from parametrized dtype sweeps across fft / periodogram / psd / spectrogram / canny / convolve2d / …, plus the 16 new explicit posit-grid tests.)

## Research motivation

Before this PR the precision-cost frontier plot had at most 2 posit points (posit_full and tiny_posit). After, each bit-width cluster gains the ES axis:

- At 8 bits: 3 cells (es=0, 1, 2) — answers "which ES at 8 bits?"
- At 16 bits: 3 cells — answers "does the 16-bit posit_full bundle's sample leg (es=1) actually win over es=0 or es=2 in single-type use?"
- At 32 bits: 3 cells — answers "is posit_32_2 materially different from float?"

These are primary research questions this library exists to answer, and the visual tool for answering them didn't exist before.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready 82`

Resolves #81

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Expanded posit arithmetic support with a full configuration grid: `posit_8`, `posit_16`, and `posit_32` with exponent sizes 0, 1, and 2 (9 configurations total).
  * Legacy `tiny_posit` remains supported as an alias to `posit_8_2`.

* **Documentation**
  * Updated configuration tables and API reference with the new posit taxonomy grid definitions and behavior clarifications.

* **Tests**
  * Added comprehensive test coverage for the full posit grid including SQNR validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->