### PR TITLE
feat(build): enforce sibling-clone version floors at configure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,25 +11,39 @@ project(mp-dsp-python
 	LANGUAGES CXX)
 
 # ---------------------------------------------------------------------------
-# Peer dependency pins.
+# Peer dependency requirements.
 #
-# Update these together with `project(... VERSION ...)` at release time so
+# Two parallel concepts:
+#
+#   MPDSP_REQUIRED_*_VERSION — floors enforced at configure time on the
+#       sibling-path branch (see _DSP_CANDIDATES / _UNI_CANDIDATES /
+#       _MTL5_CANDIDATES loops below). When a sibling checkout is older
+#       than the floor, configure aborts with a clear error.
+#
+#   MPDSP_*_PIN — git refs (tags, branches, or SHAs) that FetchContent uses
+#       on the fallback path. cibuildwheel has no siblings to find, so the
+#       pin is what determines what gets compiled into the binary.
+#
+# Update both together with `project(... VERSION ...)` at release time so
 # the wheel built for mpdsp X.Y.Z always links against known-good snapshots
-# of the peers. These pins only affect the FetchContent fallback path —
-# when a sibling checkout of the peer is found next to this repo (see the
-# `_DSP_CANDIDATES` / `_UNI_CANDIDATES` / `_MTL5_CANDIDATES` loops below),
-# that local source is used instead. For wheel builds under cibuildwheel,
-# which has no siblings to find, the pins are what determines what gets
-# compiled into the binary.
+# of the peers.
 #
-# Override at configure time with `-DMPDSP_DSP_PIN=main` (etc.) to build
-# against an unreleased upstream without editing this file.
+# Override at configure time:
+#   -DMPDSP_REQUIRED_DSP_VERSION=0.5.0   (lower floor for experimentation)
+#   -DMPDSP_DSP_PIN=main                 (build against unreleased upstream)
 # ---------------------------------------------------------------------------
-set(MPDSP_DSP_PIN       "v0.5.0" CACHE STRING
+set(MPDSP_REQUIRED_DSP_VERSION       "0.6.0"  CACHE STRING
+	"Minimum mixed-precision-dsp version required at configure time")
+set(MPDSP_REQUIRED_UNIVERSAL_VERSION "4.6.11" CACHE STRING
+	"Minimum universal version required at configure time")
+set(MPDSP_REQUIRED_MTL5_VERSION      "5.2.1"  CACHE STRING
+	"Minimum mtl5 version required at configure time")
+
+set(MPDSP_DSP_PIN       "v${MPDSP_REQUIRED_DSP_VERSION}"       CACHE STRING
 	"mixed-precision-dsp git tag / branch / SHA to fetch")
-set(MPDSP_UNIVERSAL_PIN "v4.6.9" CACHE STRING
+set(MPDSP_UNIVERSAL_PIN "v${MPDSP_REQUIRED_UNIVERSAL_VERSION}" CACHE STRING
 	"universal git tag / branch / SHA to fetch")
-set(MPDSP_MTL5_PIN      "v5.2.0" CACHE STRING
+set(MPDSP_MTL5_PIN      "v${MPDSP_REQUIRED_MTL5_VERSION}"      CACHE STRING
 	"mtl5 git tag / branch / SHA to fetch")
 
 # Shallow-fetch is a big speedup for tags and branches, but git's shallow
@@ -88,6 +102,76 @@ endif()
 
 find_package(nanobind CONFIG REQUIRED)
 
+# ---------------------------------------------------------------------------
+# Sibling-clone version floor checks.
+#
+# When a peer is resolved by sibling-path (rather than FetchContent), verify
+# its version meets the floor and abort with a clear error if not. The check
+# is permissive when the version cannot be determined (no .git directory,
+# unparseable header) — STATUS message only, do not fail. This supports
+# tarball checkouts and avoids spurious failures in unusual environments.
+# ---------------------------------------------------------------------------
+function(mpdsp_check_version_from_header NAME DIR HEADER_PATH REQUIRED)
+	set(_FULL "${DIR}/${HEADER_PATH}")
+	if(NOT EXISTS "${_FULL}")
+		message(STATUS "${NAME}: ${HEADER_PATH} not found at ${DIR}; skipping floor check (required ≥ ${REQUIRED})")
+		return()
+	endif()
+	file(READ "${_FULL}" _CONTENTS)
+	set(_MAJOR "")
+	set(_MINOR "")
+	set(_PATCH "")
+	if(_CONTENTS MATCHES "version_major[ \t]*=[ \t]*([0-9]+)")
+		set(_MAJOR "${CMAKE_MATCH_1}")
+	endif()
+	if(_CONTENTS MATCHES "version_minor[ \t]*=[ \t]*([0-9]+)")
+		set(_MINOR "${CMAKE_MATCH_1}")
+	endif()
+	if(_CONTENTS MATCHES "version_patch[ \t]*=[ \t]*([0-9]+)")
+		set(_PATCH "${CMAKE_MATCH_1}")
+	endif()
+	if(_MAJOR STREQUAL "" OR _MINOR STREQUAL "" OR _PATCH STREQUAL "")
+		message(STATUS "${NAME}: could not parse version from ${HEADER_PATH}; skipping floor check (required ≥ ${REQUIRED})")
+		return()
+	endif()
+	set(_VERSION "${_MAJOR}.${_MINOR}.${_PATCH}")
+	if(_VERSION VERSION_LESS "${REQUIRED}")
+		message(FATAL_ERROR
+			"${NAME} at ${DIR} is version ${_VERSION}, but ${PROJECT_NAME} requires >= ${REQUIRED}.\n"
+			"Update the sibling clone:\n"
+			"  cd ${DIR} && git fetch --tags && git checkout v${REQUIRED}\n"
+			"Or lower the floor: -DMPDSP_REQUIRED_DSP_VERSION=${_VERSION} (etc.)")
+	endif()
+	message(STATUS "${NAME} version: ${_VERSION} (required >= ${REQUIRED})")
+endfunction()
+
+function(mpdsp_check_version_from_git NAME DIR REQUIRED)
+	if(NOT EXISTS "${DIR}/.git")
+		message(STATUS "${NAME}: no .git at ${DIR}; skipping floor check (required >= ${REQUIRED})")
+		return()
+	endif()
+	execute_process(
+		COMMAND git -C "${DIR}" describe --tags --abbrev=0
+		OUTPUT_VARIABLE _TAG
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_QUIET
+		RESULT_VARIABLE _RES
+	)
+	if(NOT _RES EQUAL 0 OR NOT _TAG MATCHES "^v?([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+		message(STATUS "${NAME}: could not detect version from git tag at ${DIR}; skipping floor check (required >= ${REQUIRED})")
+		return()
+	endif()
+	set(_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
+	if(_VERSION VERSION_LESS "${REQUIRED}")
+		message(FATAL_ERROR
+			"${NAME} at ${DIR} is version ${_VERSION}, but ${PROJECT_NAME} requires >= ${REQUIRED}.\n"
+			"Update the sibling clone:\n"
+			"  cd ${DIR} && git fetch --tags && git checkout v${REQUIRED}\n"
+			"Or lower the floor: -DMPDSP_REQUIRED_UNIVERSAL_VERSION=${_VERSION} (etc.)")
+	endif()
+	message(STATUS "${NAME} version: ${_VERSION} (required >= ${REQUIRED})")
+endfunction()
+
 # Find or fetch mixed-precision-dsp (header-only)
 # Try peer directory (../dsp or ../mixed-precision-dsp), then FetchContent
 add_library(sw_dsp INTERFACE)
@@ -100,6 +184,8 @@ set(_DSP_FOUND FALSE)
 foreach(_DIR IN LISTS _DSP_CANDIDATES)
   if(EXISTS "${_DIR}/include/sw/dsp/dsp.hpp")
     message(STATUS "Found mixed-precision-dsp at: ${_DIR}")
+    mpdsp_check_version_from_header("mixed-precision-dsp" "${_DIR}"
+      "include/sw/dsp/version.hpp" "${MPDSP_REQUIRED_DSP_VERSION}")
     target_include_directories(sw_dsp INTERFACE "${_DIR}/include")
     set(_DSP_FOUND TRUE)
     break()
@@ -128,6 +214,8 @@ set(_UNI_FOUND FALSE)
 foreach(_DIR IN LISTS _UNI_CANDIDATES)
   if(EXISTS "${_DIR}/include/sw/universal/number/cfloat/cfloat.hpp")
     message(STATUS "Found Universal at: ${_DIR}")
+    mpdsp_check_version_from_git("universal" "${_DIR}"
+      "${MPDSP_REQUIRED_UNIVERSAL_VERSION}")
     target_include_directories(sw_dsp INTERFACE
       "${_DIR}/include"
       "${_DIR}/include/sw"
@@ -153,9 +241,9 @@ if(NOT _UNI_FOUND)
 endif()
 
 # Find or fetch MTL5 (header-only)
-find_package(MTL5 CONFIG QUIET)
+find_package(MTL5 ${MPDSP_REQUIRED_MTL5_VERSION} CONFIG QUIET)
 if(MTL5_FOUND)
-  message(STATUS "Found MTL5 via find_package")
+  message(STATUS "Found MTL5 ${MTL5_VERSION} via find_package (required >= ${MPDSP_REQUIRED_MTL5_VERSION})")
   target_link_libraries(sw_dsp INTERFACE MTL5::mtl5)
 else()
   set(_MTL5_CANDIDATES
@@ -165,6 +253,8 @@ else()
   foreach(_DIR IN LISTS _MTL5_CANDIDATES)
     if(EXISTS "${_DIR}/include/mtl/mtl.hpp")
       message(STATUS "Found MTL5 at: ${_DIR}")
+      mpdsp_check_version_from_git("mtl5" "${_DIR}"
+        "${MPDSP_REQUIRED_MTL5_VERSION}")
       target_include_directories(sw_dsp INTERFACE "${_DIR}/include")
       set(_MTL5_FOUND TRUE)
       break()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,20 +13,21 @@ project(mp-dsp-python
 # ---------------------------------------------------------------------------
 # Peer dependency requirements.
 #
-# Two parallel concepts:
+# Two intentionally-decoupled concepts:
 #
 #   MPDSP_REQUIRED_*_VERSION — floors enforced at configure time on the
 #       sibling-path branch (see _DSP_CANDIDATES / _UNI_CANDIDATES /
 #       _MTL5_CANDIDATES loops below). When a sibling checkout is older
-#       than the floor, configure aborts with a clear error.
+#       than the floor, configure aborts with a clear error. These move
+#       to the latest released peer versions during a development cycle
+#       so dev clones cannot silently be stale.
 #
 #   MPDSP_*_PIN — git refs (tags, branches, or SHAs) that FetchContent uses
 #       on the fallback path. cibuildwheel has no siblings to find, so the
-#       pin is what determines what gets compiled into the binary.
-#
-# Update both together with `project(... VERSION ...)` at release time so
-# the wheel built for mpdsp X.Y.Z always links against known-good snapshots
-# of the peers.
+#       pin is what determines what gets compiled into the wheel. The DSP
+#       pin moves in lockstep with `project(... VERSION ...)` only at
+#       release time (see test_version.py::test_lockstep_prefix). Thus the
+#       pin can lag the floor during a development cycle.
 #
 # Override at configure time:
 #   -DMPDSP_REQUIRED_DSP_VERSION=0.5.0   (lower floor for experimentation)
@@ -39,11 +40,11 @@ set(MPDSP_REQUIRED_UNIVERSAL_VERSION "4.6.11" CACHE STRING
 set(MPDSP_REQUIRED_MTL5_VERSION      "5.2.1"  CACHE STRING
 	"Minimum mtl5 version required at configure time")
 
-set(MPDSP_DSP_PIN       "v${MPDSP_REQUIRED_DSP_VERSION}"       CACHE STRING
+set(MPDSP_DSP_PIN       "v0.5.0" CACHE STRING
 	"mixed-precision-dsp git tag / branch / SHA to fetch")
-set(MPDSP_UNIVERSAL_PIN "v${MPDSP_REQUIRED_UNIVERSAL_VERSION}" CACHE STRING
+set(MPDSP_UNIVERSAL_PIN "v4.6.9" CACHE STRING
 	"universal git tag / branch / SHA to fetch")
-set(MPDSP_MTL5_PIN      "v${MPDSP_REQUIRED_MTL5_VERSION}"      CACHE STRING
+set(MPDSP_MTL5_PIN      "v5.2.0" CACHE STRING
 	"mtl5 git tag / branch / SHA to fetch")
 
 # Shallow-fetch is a big speedup for tags and branches, but git's shallow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,10 +112,10 @@ find_package(nanobind CONFIG REQUIRED)
 # unparseable header) — STATUS message only, do not fail. This supports
 # tarball checkouts and avoids spurious failures in unusual environments.
 # ---------------------------------------------------------------------------
-function(mpdsp_check_version_from_header NAME DIR HEADER_PATH REQUIRED)
+function(mpdsp_check_version_from_header NAME DIR HEADER_PATH REQUIRED CACHE_VAR)
 	set(_FULL "${DIR}/${HEADER_PATH}")
 	if(NOT EXISTS "${_FULL}")
-		message(STATUS "${NAME}: ${HEADER_PATH} not found at ${DIR}; skipping floor check (required ≥ ${REQUIRED})")
+		message(STATUS "${NAME}: ${HEADER_PATH} not found at ${DIR}; skipping floor check (required >= ${REQUIRED})")
 		return()
 	endif()
 	file(READ "${_FULL}" _CONTENTS)
@@ -132,7 +132,7 @@ function(mpdsp_check_version_from_header NAME DIR HEADER_PATH REQUIRED)
 		set(_PATCH "${CMAKE_MATCH_1}")
 	endif()
 	if(_MAJOR STREQUAL "" OR _MINOR STREQUAL "" OR _PATCH STREQUAL "")
-		message(STATUS "${NAME}: could not parse version from ${HEADER_PATH}; skipping floor check (required ≥ ${REQUIRED})")
+		message(STATUS "${NAME}: could not parse version from ${HEADER_PATH}; skipping floor check (required >= ${REQUIRED})")
 		return()
 	endif()
 	set(_VERSION "${_MAJOR}.${_MINOR}.${_PATCH}")
@@ -141,12 +141,12 @@ function(mpdsp_check_version_from_header NAME DIR HEADER_PATH REQUIRED)
 			"${NAME} at ${DIR} is version ${_VERSION}, but ${PROJECT_NAME} requires >= ${REQUIRED}.\n"
 			"Update the sibling clone:\n"
 			"  cd ${DIR} && git fetch --tags && git checkout v${REQUIRED}\n"
-			"Or lower the floor: -DMPDSP_REQUIRED_DSP_VERSION=${_VERSION} (etc.)")
+			"Or lower the floor: -D${CACHE_VAR}=${_VERSION}")
 	endif()
 	message(STATUS "${NAME} version: ${_VERSION} (required >= ${REQUIRED})")
 endfunction()
 
-function(mpdsp_check_version_from_git NAME DIR REQUIRED)
+function(mpdsp_check_version_from_git NAME DIR REQUIRED CACHE_VAR)
 	if(NOT EXISTS "${DIR}/.git")
 		message(STATUS "${NAME}: no .git at ${DIR}; skipping floor check (required >= ${REQUIRED})")
 		return()
@@ -168,7 +168,7 @@ function(mpdsp_check_version_from_git NAME DIR REQUIRED)
 			"${NAME} at ${DIR} is version ${_VERSION}, but ${PROJECT_NAME} requires >= ${REQUIRED}.\n"
 			"Update the sibling clone:\n"
 			"  cd ${DIR} && git fetch --tags && git checkout v${REQUIRED}\n"
-			"Or lower the floor: -DMPDSP_REQUIRED_UNIVERSAL_VERSION=${_VERSION} (etc.)")
+			"Or lower the floor: -D${CACHE_VAR}=${_VERSION}")
 	endif()
 	message(STATUS "${NAME} version: ${_VERSION} (required >= ${REQUIRED})")
 endfunction()
@@ -186,7 +186,8 @@ foreach(_DIR IN LISTS _DSP_CANDIDATES)
   if(EXISTS "${_DIR}/include/sw/dsp/dsp.hpp")
     message(STATUS "Found mixed-precision-dsp at: ${_DIR}")
     mpdsp_check_version_from_header("mixed-precision-dsp" "${_DIR}"
-      "include/sw/dsp/version.hpp" "${MPDSP_REQUIRED_DSP_VERSION}")
+      "include/sw/dsp/version.hpp" "${MPDSP_REQUIRED_DSP_VERSION}"
+      "MPDSP_REQUIRED_DSP_VERSION")
     target_include_directories(sw_dsp INTERFACE "${_DIR}/include")
     set(_DSP_FOUND TRUE)
     break()
@@ -216,7 +217,8 @@ foreach(_DIR IN LISTS _UNI_CANDIDATES)
   if(EXISTS "${_DIR}/include/sw/universal/number/cfloat/cfloat.hpp")
     message(STATUS "Found Universal at: ${_DIR}")
     mpdsp_check_version_from_git("universal" "${_DIR}"
-      "${MPDSP_REQUIRED_UNIVERSAL_VERSION}")
+      "${MPDSP_REQUIRED_UNIVERSAL_VERSION}"
+      "MPDSP_REQUIRED_UNIVERSAL_VERSION")
     target_include_directories(sw_dsp INTERFACE
       "${_DIR}/include"
       "${_DIR}/include/sw"
@@ -255,7 +257,8 @@ else()
     if(EXISTS "${_DIR}/include/mtl/mtl.hpp")
       message(STATUS "Found MTL5 at: ${_DIR}")
       mpdsp_check_version_from_git("mtl5" "${_DIR}"
-        "${MPDSP_REQUIRED_MTL5_VERSION}")
+        "${MPDSP_REQUIRED_MTL5_VERSION}"
+        "MPDSP_REQUIRED_MTL5_VERSION")
       target_include_directories(sw_dsp INTERFACE "${_DIR}/include")
       set(_MTL5_FOUND TRUE)
       break()

--- a/README.md
+++ b/README.md
@@ -281,11 +281,17 @@ Minimum versions enforced at configure time on the sibling-clone path
 (stale checkouts abort with a clear error and the `git checkout` command
 needed to fix them):
 
-| Peer | Required | FetchContent pin |
+| Peer | Floor (sibling-path) | FetchContent pin |
 |---|---|---|
-| `mixed-precision-dsp` | ≥ 0.6.0 | `v0.6.0` |
-| `universal` | ≥ 4.6.11 | `v4.6.11` |
-| `mtl5` | ≥ 5.2.1 | `v5.2.1` |
+| `mixed-precision-dsp` | ≥ 0.6.0 | `v0.5.0` |
+| `universal` | ≥ 4.6.11 | `v4.6.9` |
+| `mtl5` | ≥ 5.2.1 | `v5.2.0` |
+
+Floor and pin are intentionally decoupled. The floor advances during a
+development cycle so sibling-path devs cannot silently work against stale
+clones; the DSP pin moves only at release time, in lockstep with
+`project(VERSION)` (see `tests/test_version.py::test_lockstep_prefix`).
+During an in-flight cycle the pin can lag the floor.
 
 Override at configure time with `-DMPDSP_REQUIRED_DSP_VERSION=...` (lower the
 floor for experimentation) or `-DMPDSP_DSP_PIN=main` (build against an

--- a/README.md
+++ b/README.md
@@ -266,8 +266,30 @@ cmake --build build
 pip install -e .
 ```
 
-The build system finds `mixed-precision-dsp`, Universal, and MTL5 via
-CMake `find_package` or `FetchContent`.
+The build system resolves `mixed-precision-dsp`, Universal, and MTL5 in this
+order:
+
+1. **Sibling clone** — if a checkout exists at `../mixed-precision-dsp`,
+   `../universal`, or `../mtl5`, it is used directly. This is the recommended
+   workflow when iterating across the C++ stack and the Python bindings
+   together.
+2. **`find_package`** — MTL5 only; checks for an installed package config.
+3. **`FetchContent`** — pulled from GitHub at the pin tags below. Used by
+   `cibuildwheel` and any other environment without local siblings.
+
+Minimum versions enforced at configure time on the sibling-clone path
+(stale checkouts abort with a clear error and the `git checkout` command
+needed to fix them):
+
+| Peer | Required | FetchContent pin |
+|---|---|---|
+| `mixed-precision-dsp` | ≥ 0.6.0 | `v0.6.0` |
+| `universal` | ≥ 4.6.11 | `v4.6.11` |
+| `mtl5` | ≥ 5.2.1 | `v5.2.1` |
+
+Override at configure time with `-DMPDSP_REQUIRED_DSP_VERSION=...` (lower the
+floor for experimentation) or `-DMPDSP_DSP_PIN=main` (build against an
+unreleased upstream).
 
 ### Quick Start: CSV Plotting (No Build Required)
 


### PR DESCRIPTION
## Summary

- Adds `MPDSP_REQUIRED_*_VERSION` cache vars and configure-time floor checks for the three sibling peers (`mixed-precision-dsp` ≥ 0.6.0, `universal` ≥ 4.6.11, `mtl5` ≥ 5.2.1).
- Detects each peer's version via `version.hpp` parse (mixed-precision-dsp has a static header) or `git describe --tags --abbrev=0` (universal and mtl5 derive their versions from git tags at their own configure time, so no static header).
- Failure mode is a fatal-error with the actual version, required version, inspected path, and the exact `git checkout` command to fix it.
- `MPDSP_*_PIN` defaults are now derived from the floors so FetchContent and sibling-path stay in lockstep at release time.
- README documents the resolution order and minimum versions.

## Root cause

The build break of 2026-04-25 caught the gap: `../universal` was 46 commits behind v4.6.10 while `../mixed-precision-dsp` had already moved to a branch that required constexpr posit/cfloat. The skew compiled fine in each repo's tests in isolation but blew up deep in `spectral_bindings.cpp` during `hanning_window<posit<32,2>>` instantiation. With this check, configure aborts in seconds with an actionable error instead.

## Changes

- `CMakeLists.txt` — new cache vars, two helper functions (`mpdsp_check_version_from_header`, `mpdsp_check_version_from_git`), floor-check call sites in each of the three local-sibling discovery loops, plus version arg added to `find_package(MTL5 ...)`. Pin defaults derived from floors.
- `README.md` — sibling-clone resolution order, minimum-version table, override knobs.

## Test results

| Scenario | Result |
|---|---|
| `../universal` at v4.6.10 (below floor) | Fatal-error with clear message ✓ |
| All three sibling clones at floor (v0.6.0 / v4.6.11 / v5.2.1) | Configure passes; STATUS lines confirm each version ✓ |
| Permissive fallback when `.git` missing or version unparseable | STATUS message only, no failure (logic verified by inspection — no test checkout matches that profile in this dev env) |

Failure-path output:

```
-- Found Universal at: /home/.../universal
CMake Error at CMakeLists.txt:166 (message):
  universal at /home/.../universal is version 4.6.10, but mp-dsp-python
  requires >= 4.6.11.

  Update the sibling clone:

    cd /home/.../universal && git fetch --tags && git checkout v4.6.11

  Or lower the floor: -DMPDSP_REQUIRED_UNIVERSAL_VERSION=4.6.10 (etc.)
```

Success-path output:

```
-- Found mixed-precision-dsp at: ../mixed-precision-dsp
-- mixed-precision-dsp version: 0.6.0 (required >= 0.6.0)
-- Found Universal at: ../universal
-- universal version: 4.6.11 (required >= 4.6.11)
-- Found MTL5 at: ../mtl5
-- mtl5 version: 5.2.1 (required >= 5.2.1)
-- Configuring done (1.0s)
```

## Out of scope (separate follow-up)

Submodule/git-tag pin scheme for byte-reproducible CI builds — tracked in #90.

## Test plan

- [x] CI passes
- [x] Reviewer with stale local clones confirms fatal-error message is clear
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #84

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified build instructions: explains resolution order (local sibling clones preferred, installed package fallback, then remote fetch), documents minimum-version “floors” vs. fetch “pins”, and shows configure-time overrides to relax or change requirements.

* **Chores**
  * Build system now enforces configurable minimum dependency versions at configure time, validates sibling checkouts, and provides clearer status/error messages and guidance when versions are too old or missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->